### PR TITLE
Fix GitHub workflow tests and refine FP8 multiplier logic

### DIFF
--- a/src/project.v
+++ b/src/project.v
@@ -1,3 +1,5 @@
+`default_nettype none
+
 module tt_um_chatelao_fp8_multiplier (
     input  wire [7:0] ui_in,    // Operand 1
     output wire [7:0] uo_out,   // Result
@@ -9,11 +11,14 @@ module tt_um_chatelao_fp8_multiplier (
     input  wire       rst_n     
 );
 
+    // Avoid unused warnings
+    wire _unused = &{ena, clk, rst_n, 1'b0};
+
     // 1. Configure UIO as inputs
     assign uio_oe  = 8'b00000000; 
     assign uio_out = 8'b00000000;
 
-    // 2. Direct instantiation (No registers, no cycles)
+    // 2. Direct instantiation (Purely combinational)
     fp8mul mul1 (
         .sign1(ui_in[7]),
         .exp1(ui_in[6:3]),
@@ -31,55 +36,57 @@ module tt_um_chatelao_fp8_multiplier (
 endmodule
 
 module fp8mul (
-  input sign1,
-  input [3:0] exp1,
-  input [2:0] mant1,
+    input wire sign1,
+    input wire [3:0] exp1,
+    input wire [2:0] mant1,
 
-  input sign2,
-  input [3:0] exp2,
-  input [2:0] mant2,
+    input wire sign2,
+    input wire [3:0] exp2,
+    input wire [2:0] mant2,
 
-  output sign_out,
-  output [3:0] exp_out,
-  output [2:0] mant_out
+    output wire sign_out,
+    output wire [3:0] exp_out,
+    output wire [2:0] mant_out
 );
-    // Festlegung des Exponenten-Bias für ein (vermutlich) 8-Bit-Format (1 Sign, 4 Exp, 3 Mant)
+    // Exponent bias for 8-bit format (1 Sign, 4 Exp, 3 Mant)
     parameter EXP_BIAS = 7;
 
-    // FEHLERHAFTE LOGIK: Identifiziert fälschlicherweise "Negative Null" als NaN.
-    // In IEEE 754 ist NaN: Exponent max (alle 1er) und Mantisse != 0.
-    wire isnan = (sign1 == 1 && exp1 == 0 && mant1 == 0) || (sign2 == 1 && exp2 == 0 && mant2 == 0);
+    // NaN detection: Exponent all 1s and Mantissa != 0
+    wire isnan1 = (exp1 == 4'b1111 && mant1 != 3'b000);
+    wire isnan2 = (exp2 == 4'b1111 && mant2 != 3'b000);
+    wire isnan = isnan1 || isnan2;
 
-    // Multiplikation der Mantissen inklusive des impliziten Leading-Bit (1.xxx), falls Exp != 0
-    // Resultat ist 8 Bit breit (4 Bit * 4 Bit)
-    wire [7:0] full_mant = ({exp1 != 0, mant1} * {exp2 != 0, mant2});
+    // Mantissa multiplication including implicit leading bit (1.xxx), if Exp != 0
+    wire [7:0] full_mant = ({exp1 != 4'b0, mant1} * {exp2 != 4'b0, mant2});
 
-    // Prüfung auf Überlauf der Mantisse (Normalisierungsbedarf), falls MSB gesetzt
+    // Mantissa overflow check (normalization needed) if MSB is set
     wire overflow_mant = full_mant[7];
 
-    // Normalisierung: Schiebe Mantisse, falls Überlauf auftritt, sonst Ausrichtung für Rundung
+    // Normalization: Shift mantissa if overflow occurs, otherwise align for rounding
     wire [6:0] shifted_mant = overflow_mant ? full_mant[6:0] : {full_mant[5:0], 1'b0};
 
-    // Rundungslogik: Prüft auf Exponenten-Grenzfälle und Round-to-Nearest-Even Bedingungen
-    wire roundup = (exp1 + exp2 + overflow_mant < 1 + EXP_BIAS) && (shifted_mant[6:0] != 0)
+    // Exponent sum with enough bits to avoid overflow
+    wire [4:0] exp_sum = {1'b0, exp1} + {1'b0, exp2} + {4'b0, overflow_mant};
+
+    // Rounding logic: Check for exponent edge cases and Round-to-Nearest-Even conditions
+    wire roundup = (exp_sum < {1'b0, 4'd1 + EXP_BIAS[3:0]}) && (shifted_mant[6:0] != 7'b0)
                    || (shifted_mant[6:4] == 3'b111 && shifted_mant[3]);
 
-    // Unterlauf-Prüfung: Errechnet, ob das Ergebnis kleiner als die kleinste darstellbare Zahl ist
-    wire underflow = (exp1 + exp2 + overflow_mant) < 1 - roundup + EXP_BIAS;
+    // Underflow check: Result is smaller than the smallest representable number
+    wire underflow = exp_sum < ({1'b0, 4'd1 + EXP_BIAS[3:0]} - {4'b0, roundup});
 
-    // Zero-Flag: Resultat ist Null bei Eingabe-Null, erkanntem NaN (falsche Logik) oder Underflow
-    wire is_zero = exp1 == 0 || exp2 == 0 || isnan || underflow;
+    // Zero flag: Result is zero if any input is zero or underflow
+    wire is_zero = exp1 == 4'b0 || exp2 == 4'b0 || underflow;
 
-    // Temporäre Exponentenberechnung (Summe der Exponenten - Bias + Korrekturen)
-    // 5-Bit Breite verhindert sofortigen Wrap-around beim Vergleich
-    wire [4:0] exp_out_tmp = (exp1 + exp2 + overflow_mant + roundup) < EXP_BIAS ? 0 : (exp1 + exp2 + overflow_mant + roundup - EXP_BIAS);
+    // Temporary exponent calculation (Sum of exponents - Bias + corrections)
+    wire [4:0] exp_out_tmp = ((exp_sum + {4'b0, roundup}) < {1'b0, EXP_BIAS[3:0]}) ? 5'b0 : (exp_sum + {4'b0, roundup} - {1'b0, EXP_BIAS[3:0]});
 
-    // Finale Exponenten-Zuweisung: Sättigung bei 15 (Inf), Null-Steuerung oder 4-Bit Output
-    assign exp_out = exp_out_tmp > 15 ? 4'b1111 : (is_zero) ? 0 : exp_out_tmp[3:0];
+    // Final exponent assignment: Saturation at 15 (Inf/Max), zero control, or 4-bit output
+    assign exp_out = isnan ? 4'b1111 : (exp_out_tmp > 5'd15 ? 4'b1111 : (is_zero) ? 4'b0000 : exp_out_tmp[3:0]);
 
-    // Finale Mantissen-Zuweisung: Sättigung bei Inf, Rundung auf 3 Bit oder Inkrement bei Rundung
-    assign mant_out = exp_out_tmp > 15 ? 3'b111 : (is_zero || roundup) ? 0 : (shifted_mant[6:4] + (shifted_mant[3:0] > 8 || (shifted_mant[3:0] == 8 && shifted_mant[4])));
+    // Final mantissa assignment: Saturation at Inf/Max, rounding to 3 bits, or increment on rounding
+    assign mant_out = isnan ? 3'b111 : (exp_out_tmp > 5'd15 ? 3'b111 : (is_zero || roundup) ? 3'b000 : (shifted_mant[6:4] + {2'b0, (shifted_mant[3:0] > 4'd8 || (shifted_mant[3:0] == 4'd8 && shifted_mant[4]))}));
 
-    // Vorzeichen-Bestimmung: XOR der Vorzeichen, unterdrückt bei Null-Resultat (außer bei Fehl-NaN)
-    assign sign_out = ((sign1 ^ sign2) && !(is_zero)) || isnan;
+    // Sign determination: XOR of signs
+    assign sign_out = isnan ? (isnan1 ? sign1 : sign2) : (sign1 ^ sign2);
 endmodule

--- a/test/test.py
+++ b/test/test.py
@@ -5,7 +5,6 @@ import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import ClockCycles
 
-
 @cocotb.test()
 async def test_project(dut):
     dut._log.info("Start")
@@ -25,16 +24,21 @@ async def test_project(dut):
 
     dut._log.info("Test project behavior")
 
-    # Set the input values you want to test
-    dut.ui_in.value = 20
-    dut.uio_in.value = 30
+    # Test cases: (A, B, Expected)
+    test_cases = [
+        (0x40, 0x40, 0x48), # 2.0 * 2.0 = 4.0
+        (0x38, 0x38, 0x38), # 1.0 * 1.0 = 1.0
+        (0x40, 0x38, 0x40), # 2.0 * 1.0 = 2.0
+        (0x00, 0x40, 0x00), # 0.0 * 2.0 = 0.0
+        (0x80, 0x40, 0x80), # -0.0 * 2.0 = -0.0
+        (0x7F, 0x38, 0x7F), # NaN * 1.0 = NaN
+    ]
 
-    # Wait for one clock cycle to see the output values
-    await ClockCycles(dut.clk, 1)
+    for a, b, expected in test_cases:
+        dut.ui_in.value = a
+        dut.uio_in.value = b
+        await ClockCycles(dut.clk, 1)
+        dut._log.info(f"Input: A=0x{a:02x}, B=0x{b:02x} | Output: 0x{int(dut.uo_out.value):02x} | Expected: 0x{expected:02x}")
+        assert int(dut.uo_out.value) == expected
 
-    # The following assersion is just an example of how to check the output values.
-    # Change it to match the actual expected output of your module:
-    assert dut.uo_out.value == 50
-
-    # Keep testing the module by changing the input values, waiting for
-    # one or more clock cycles, and asserting the expected output values.
+    dut._log.info("All tests passed!")


### PR DESCRIPTION
This PR fixes a compilation/elaboration error in the GitHub Actions workflow for the Tiny Tapeout FP8 multiplier project. The error "Unknown module type" was likely due to syntax issues or non-ASCII characters in the source file. In addition to fixing the build, the multiplier logic has been refined for better correctness (rounding, NaN handling) and the test suite has been updated with real test cases.

Fixes #9

---
*PR created automatically by Jules for task [18295832185002827051](https://jules.google.com/task/18295832185002827051) started by @chatelao*