### PR TITLE
Make diagram workflow more flexible

### DIFF
--- a/.github/workflows/diagram.yaml
+++ b/.github/workflows/diagram.yaml
@@ -19,13 +19,20 @@ jobs:
 
       - name: Generate Logic Diagrams
         run: |
+          # Use yq to extract project metadata from info.yaml
+          TOP_MODULE=$(yq -r '.project.top_module' info.yaml)
+          SOURCES=$(yq -r '.project.source_files[]' info.yaml | sed 's|^|src/|' | tr '\n' ' ')
+
+          echo "Top Module: $TOP_MODULE"
+          echo "Sources: $SOURCES"
+
           # 1. Standard Logic Diagram
-          yosys -p "read_verilog src/project.v; hierarchy -top tt_um_chatelao_fp8_multiplier; proc; opt; show -format dot -prefix logic_diagram tt_um_chatelao_fp8_multiplier"
+          yosys -p "read_verilog $SOURCES; hierarchy -top $TOP_MODULE; proc; opt; show -format dot -prefix logic_diagram $TOP_MODULE"
           dot -Tpng logic_diagram.dot -o logic_diagram.png
           dot -Tsvg logic_diagram.dot -o logic_diagram.svg
 
           # 2. Flattened RTL Logic Diagram (Resolution level +/- between top-level and flatten)
-          yosys -p "read_verilog src/project.v; hierarchy -top tt_um_chatelao_fp8_multiplier; proc; flatten; opt; show -format dot -prefix logic_diagram_rtl tt_um_chatelao_fp8_multiplier"
+          yosys -p "read_verilog $SOURCES; hierarchy -top $TOP_MODULE; proc; flatten; opt; show -format dot -prefix logic_diagram_rtl $TOP_MODULE"
           dot -Tpng logic_diagram_rtl.dot -o logic_diagram_rtl.png
           dot -Tsvg logic_diagram_rtl.dot -o logic_diagram_rtl.svg
 
@@ -35,7 +42,7 @@ jobs:
           # 3. Flattened Gate-Level Logic Diagram
           # Note: Technology mapping to IHP SG13G2 (synth_ihp) is currently unavailable in this CI environment.
           # Using generic 'synth' with 'flatten' as a substitute to show the flattened design structure.
-          yosys -p "read_verilog src/project.v; hierarchy -top tt_um_chatelao_fp8_multiplier; proc; flatten; synth -top tt_um_chatelao_fp8_multiplier; show -format dot -prefix logic_diagram_flattened tt_um_chatelao_fp8_multiplier"
+          yosys -p "read_verilog $SOURCES; hierarchy -top $TOP_MODULE; proc; flatten; synth -top $TOP_MODULE; show -format dot -prefix logic_diagram_flattened $TOP_MODULE"
           dot -Tpng logic_diagram_flattened.dot -o logic_diagram_flattened.png
           dot -Tsvg logic_diagram_flattened.dot -o logic_diagram_flattened.svg
 


### PR DESCRIPTION
This change makes the `.github/workflows/diagram.yaml` more flexible by using `yq` to extract project metadata (`top_module` and `source_files`) from `info.yaml`. 

Specifically:
- It replaces hardcoded `src/project.v` and `tt_um_chatelao_fp8_multiplier` with shell variables `$SOURCES` and `$TOP_MODULE`.
- It uses `yq -r` to ensure raw output (without quotes), which is compatible with both Python and Go versions of `yq` commonly found in CI environments.
- It correctly handles multiple source files by iterating over the `source_files` list and prepending the `src/` directory to each.

This improvement ensures that if the project structure or module name changes in `info.yaml`, the logic diagram generation will continue to work without requiring manual updates to the workflow file.

Fixes #31

---
*PR created automatically by Jules for task [590111318275388115](https://jules.google.com/task/590111318275388115) started by @chatelao*