### PR TITLE
Add MXFP8 Implementation Concept and Roadmap

### DIFF
--- a/mxfp8_concept.md
+++ b/mxfp8_concept.md
@@ -1,0 +1,61 @@
+# Concept: Streaming MXFP8 MAC Unit for Tiny Tapeout
+
+## 1. Introduction
+The scaling of Deep Learning models necessitates efficient numerical representations to overcome the "Memory Wall". The **OCP Microscaling Formats (MX) Specification v1.0** introduces a block-based scaling approach that significantly reduces memory bandwidth and hardware complexity. This concept outlines the implementation of an MXFP8-compatible Multiply-Accumulate (MAC) unit within the strict constraints of a single **1x1 Tiny Tapeout tile** (Sky130).
+
+## 2. Numerical Representation: OCP MXFP8
+The implementation focuses on the **MXFP8** format (supporting both E4M3 and E5M2 variants) with a shared block scaling factor.
+
+- **Shared Scale**: UE8M0 (8-bit unsigned integer exponent, power-of-two scaling).
+- **Element Formats**:
+  - **E4M3**: 1-bit sign, 4-bit exponent, 3-bit mantissa.
+  - **E5M2**: 1-bit sign, 5-bit exponent, 2-bit mantissa.
+- **Block Size ($k$)**: 32 elements.
+- **Mathematical Formula**:
+  $$V_i = (-1)^{S_i} \times 2^{E_i - \text{Bias}} \times (1 + M_i) \times 2^X$$
+  Where $X$ is the shared UE8M0 scale.
+
+## 3. Architecture: Operand Streaming
+To fit within the ~320 D-Flip-Flop (DFF) budget of a 1x1 tile, the design avoids large on-chip buffers and instead employs **Temporal Multiplexing (Operand Streaming)**.
+
+### 3.1. I/O Protocol (38-Cycle Sequence)
+The unit communicates with a host (e.g., RP2040) using a strictly timed protocol:
+
+| Phase | Cycles | Input (`ui_in`) | Input (`uio_in`) | Output (`uo_out`) |
+|-------|--------|-----------------|------------------|-------------------|
+| **IDLE** | 0 | - | - | 0 |
+| **LOAD_SCALE** | 1-2 | Scale $X_A$ (C1) | Scale $X_B$ (C2) | 0 |
+| **STREAM** | 3-34 | Element $A_i$ | Element $B_i$ | 0 |
+| **OUTPUT** | 35-38 | - | - | Accumulator[byte] |
+
+### 3.2. Hardware/Software Co-Design
+The hardware computes the dot product of the scaled elements but factors out the shared scales to minimize gate count:
+$$C = \left( \sum_{i=1}^{32} \text{FP8}(A_i) \times \text{FP8}(B_i) \right) \times 2^{X_A + X_B}$$
+The ASIC performs the summation and the intermediate exponent arithmetic. The final scaling by $2^{X_A + X_B}$ is performed by the host software.
+
+## 4. Microarchitecture
+### 4.1. Datapath
+1.  **Sign Logic**: $S_{res} = S_A \oplus S_B$.
+2.  **Exponent Path**: Adds $E_A$ and $E_B$, subtracts bias.
+3.  **Mantissa Multiplier**: 4x4-bit (for E4M3) or 3x3-bit (for E5M2) integer multiplier.
+4.  **Alignment Shifter**: A small barrel shifter aligns the product to a fixed-point format based on the local exponent.
+5.  **Accumulator**: A 32-bit register stores the running sum.
+
+### 4.2. Control Logic
+A Finite State Machine (FSM) manages the cycle transitions and control signals for the registers and the output multiplexer.
+
+## 5. Resource Estimation (1x1 Tile)
+Estimated based on the "Streaming MXFP4" baseline, adjusted for 8-bit elements:
+
+- **D-Flip-Flops (DFFs)**:
+  - Scale Registers: 16 bits
+  - Accumulator: 32 bits
+  - FSM & Counters: 12 bits
+  - Input/Pipeline Registers: ~24 bits
+  - **Total**: ~84-100 DFFs (approx. 30% of 1x1 tile limit).
+- **Combinational Logic**:
+  - 4x4 Multiplier + Shifter + 32-bit Adder.
+  - Estimated **400-700 gates**, well within the routing limits for Sky130.
+
+## 6. Implementation Strategy
+The project will use the **OpenLane** flow and **Cocotb** for verification. Test vectors will be generated using the `AMD Quark` library or a custom Python model to ensure OCP MX compliance.

--- a/mxfp8_roadmap.md
+++ b/mxfp8_roadmap.md
@@ -1,0 +1,36 @@
+# Roadmap: MXFP8 Implementation on Tiny Tapeout
+
+This roadmap outlines the steps required to implement the OCP MXFP8 Streaming MAC Unit on a single 1x1 tile.
+
+## Phase 1: Specification & Design
+- [ ] **Protocol Finalization**: Define exact signal timing for `ui_in` and `uio_in` transitions.
+- [ ] **Arithmetic Precision**: Determine the internal bit-width of the fixed-point accumulator to prevent overflow during 32-element summation.
+- [ ] **Rounding Policy**: Implement rounding logic (e.g., Round-to-Nearest-Even) or justify truncation for area savings.
+
+## Phase 2: RTL Development
+- [ ] **FSM Implementation**: Create the state machine for the 38-cycle streaming protocol (IDLE, LOAD_SCALE, STREAM, OUTPUT).
+- [ ] **Multiplier Core**: Write the combinatorial logic for MXFP8 (E4M3/E5M2) multiplication (Sign XOR, Exp Add, Mantissa Mult).
+- [ ] **Alignment Logic**: Implement the barrel shifter to convert floating-point products to the fixed-point accumulator format.
+- [ ] **Accumulator Unit**: Integrate the 32-bit register and adder.
+- [ ] **Top-Level Wrapper**: Connect the core to `tt_um_` template and handle UIO configurations.
+
+## Phase 3: Verification (Cocotb)
+- [ ] **Python Model**: Develop a bit-accurate Python reference model for OCP MXFP8.
+- [ ] **Basic Testbench**: Verify that the FSM correctly transitions through all 38 states.
+- [ ] **Randomized Testing**: Run 10,000+ randomized vector tests against the Python model.
+- [ ] **Corner Cases**: Verify behavior with zeros, infinities (if supported), and maximum/minimum values.
+
+## Phase 4: Synthesis & Physical Design
+- [ ] **Initial Synthesis**: Run OpenLane and evaluate area utilization (target < 320 DFFs).
+- [ ] **Timing Closure**: Ensure the design meets setup/hold requirements at 50 MHz.
+- [ ] **Gate-Level Simulation (GLS)**: Run the Cocotb testbench against the synthesized netlist.
+- [ ] **LVS/DRC Check**: Verify that the layout passes all IHP SG13G2 / Sky130 design rules.
+
+## Phase 5: Documentation & Integration
+- [ ] **info.yaml**: Update project metadata, source file list, and pinout descriptions.
+- [ ] **Documentation**: Write detailed "How it works" and "How to test" sections in `docs/info.md`.
+- [ ] **Diagrams**: Generate a logic diagram for the streaming architecture.
+
+## Phase 6: Submission
+- [ ] **Pre-check**: Run the Tiny Tapeout pre-check actions locally or in CI.
+- [ ] **Final Submission**: Tag the repository and submit to the desired shuttle.


### PR DESCRIPTION
Added mxfp8_concept.md and mxfp8_roadmap.md based on the provided Gemini Analysis. The concept outlines a streaming MAC unit for MXFP8 that fits on a 1x1 Tiny Tapeout tile by leveraging temporal multiplexing and factoring out shared scale calculations to the host software. The roadmap provides a clear implementation path.

Fixes #33

---
*PR created automatically by Jules for task [15896078516078163469](https://jules.google.com/task/15896078516078163469) started by @chatelao*