### PR TITLE
Implement Step 4: Accumulator Unit

### DIFF
--- a/src/accumulator.v
+++ b/src/accumulator.v
@@ -1,0 +1,22 @@
+`default_nettype none
+
+module accumulator (
+    input  wire        clk,
+    input  wire        rst_n,
+    input  wire        clear,   // Synchronous clear (at LOAD_SCALE)
+    input  wire        en,      // Enable accumulation (during STREAM)
+    input  wire [31:0] data_in, // 32-bit signed aligned product
+    output reg  [31:0] data_out // 32-bit signed sum
+);
+
+    always @(posedge clk) begin
+        if (!rst_n) begin
+            data_out <= 32'd0;
+        end else if (clear) begin
+            data_out <= 32'd0;
+        end else if (en) begin
+            data_out <= $signed(data_out) + $signed(data_in);
+        end
+    end
+
+endmodule

--- a/test/Makefile_accumulator
+++ b/test/Makefile_accumulator
@@ -1,0 +1,9 @@
+# Makefile for accumulator test
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+SRC_DIR = $(PWD)/../src
+VERILOG_SOURCES = $(SRC_DIR)/accumulator.v $(PWD)/tb_accumulator.v
+TOPLEVEL = tb_accumulator
+MODULE = test_accumulator
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/test/tb_accumulator.v
+++ b/test/tb_accumulator.v
@@ -1,0 +1,27 @@
+`default_nettype none
+`timescale 1ns/1ps
+
+module tb_accumulator (
+    input  wire        clk,
+    input  wire        rst_n,
+    input  wire        clear,
+    input  wire        en,
+    input  wire [31:0] data_in,
+    output wire [31:0] data_out
+);
+
+    accumulator dut (
+        .clk(clk),
+        .rst_n(rst_n),
+        .clear(clear),
+        .en(en),
+        .data_in(data_in),
+        .data_out(data_out)
+    );
+
+    initial begin
+        $dumpfile("tb_accumulator.fst");
+        $dumpvars(0, tb_accumulator);
+    end
+
+endmodule

--- a/test/test_accumulator.py
+++ b/test/test_accumulator.py
@@ -1,0 +1,75 @@
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import ClockCycles, RisingEdge, Timer
+import random
+
+@cocotb.test()
+async def test_accumulator_basic(dut):
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    # Reset
+    dut.rst_n.value = 0
+    dut.clear.value = 0
+    dut.en.value = 0
+    dut.data_in.value = 0
+    await ClockCycles(dut.clk, 5)
+    dut.rst_n.value = 1
+    await RisingEdge(dut.clk)
+    await Timer(1, "ns")
+
+    # Accumulate some values
+    expected_sum = 0
+    for i in range(100):
+        val = random.randint(-10000, 10000)
+        dut.data_in.value = val
+        dut.en.value = 1
+        await RisingEdge(dut.clk)
+        await Timer(1, "ns")
+        expected_sum += val
+
+        actual_sum = int(dut.data_out.value)
+        # Handle 32-bit signed in Python
+        if actual_sum & 0x80000000:
+            actual_sum -= 0x100000000
+
+        assert actual_sum == expected_sum, f"Iteration {i}: Expected {expected_sum}, got {actual_sum}"
+
+    # Clear
+    dut.clear.value = 1
+    await RisingEdge(dut.clk)
+    await Timer(1, "ns")
+    assert int(dut.data_out.value) == 0
+    dut.clear.value = 0
+    await RisingEdge(dut.clk)
+
+@cocotb.test()
+async def test_accumulator_32_elements(dut):
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    # Reset
+    dut.rst_n.value = 1
+    dut.clear.value = 1
+    dut.en.value = 0
+    await ClockCycles(dut.clk, 2)
+    dut.clear.value = 0
+    await RisingEdge(dut.clk)
+    await Timer(1, "ns")
+
+    # Accumulate 32 elements (max range)
+    expected_sum = 0
+
+    for i in range(32):
+        val = random.randint(-1000000, 1000000)
+        dut.data_in.value = val
+        dut.en.value = 1
+        await RisingEdge(dut.clk)
+        await Timer(1, "ns")
+        expected_sum += val
+
+    actual_sum = int(dut.data_out.value)
+    if actual_sum & 0x80000000:
+        actual_sum -= 0x100000000
+
+    assert actual_sum == expected_sum, f"32-element sum: Expected {expected_sum}, got {actual_sum}"


### PR DESCRIPTION
Implemented the Accumulator Unit as per Step 4 of the MXFP8 roadmap. The module supports 32-bit signed accumulation with synchronous clear and enable signals, which are essential for the 38-cycle streaming protocol. Comprehensive unit tests using cocotb have been added to verify correctness.

Fixes #47

---
*PR created automatically by Jules for task [12773817439703119647](https://jules.google.com/task/12773817439703119647) started by @chatelao*