### PR TITLE
Implement MXFP6 and MXFP4 Support (Roadmap Step 7)

### DIFF
--- a/MXFP8_CONCEPT.md
+++ b/MXFP8_CONCEPT.md
@@ -75,10 +75,19 @@ The unit communicates with a host using a strictly timed protocol:
 | Phase | Cycles | Bits [7:0] | Function | Description |
 |-------|--------|------------|----------|-------------|
 | **IDLE** | 0 | `00000000` | N/A | |
-| **LOAD_SCALE** | 1 | `XXXXXXXF` | **Format** | Bit 0: `is_e5m2` (1=E5M2, 0=E4M3). |
+| **LOAD_SCALE** | 1 | `XXXXXFFF` | **Format** | Bits [2:0]: Format Select (see Table 4). |
 | **LOAD_SCALE** | 2 | `X_B[7:0]` | **Scale B** | Shared UE8M0 scale for Tensor B. |
-| **STREAM** | 3-34 | `B_i[7:0]` | **Element B** | MXFP8 element (E4M3/E5M2). |
+| **STREAM** | 3-34 | `B_i[7:0]` | **Element B** | MX element (aligned to lower bits). |
 | **OUTPUT** | 35-38 | `XXXXXXXX` | Isolated | |
+
+#### Table 4: Supported Formats
+| Format ID (`FFF`) | Name | Type | Bits | Sign | Exponent | Mantissa | Bias |
+|---|---|---|---|---|---|---|---|
+| `000` | E4M3 | MXFP8 | 8 | [7] | [6:3] | [2:0] | 7 |
+| `001` | E5M2 | MXFP8 | 8 | [7] | [6:2] | [1:0] | 15 |
+| `010` | E3M2 | MXFP6 | 6 | [5] | [4:2] | [1:0] | 3 |
+| `011` | E2M3 | MXFP6 | 6 | [5] | [4:3] | [2:0] | 1 |
+| `100` | E2M1 | MXFP4 | 4 | [3] | [2:1] | [0] | 1 |
 
 **Table 3: Output `uo_out` (Accumulator Serialization)**
 | Phase | Cycle | Bits [7:0] | Content |

--- a/MXFP8_ROADMAP.md
+++ b/MXFP8_ROADMAP.md
@@ -40,11 +40,12 @@ This roadmap outlines the incremental development of the OCP MXFP8 Streaming MAC
 
 ## Phase 2: Advanced OCP MX Features
 
-### Step 7: Extended Floating Point Support (MXFP6 & MXFP4)
+### Step 7: Extended Floating Point Support (MXFP6 & MXFP4) (Status: **COMPLETED**)
 - **Goal**: Support 6-bit and 4-bit floating point formats.
-- **Tasks**:
-  - Implement decoding for MXFP6 (E3M2, E2M3) and MXFP4 (E2M1).
-  - Update bias handling and zero-padding logic.
+- **Details**:
+  - Implemented decoding for E3M2 (Bias 3), E2M3 (Bias 1), and E2M1 (Bias 1).
+  - Updated 38-cycle protocol to support 3-bit format selection during Cycle 1.
+  - Unified datapath to handle variable exponent ranges and mantissa padding.
 
 ### Step 8: Integer Support (MXINT8) & Symmetric Range
 - **Goal**: Support 8-bit integer elements (MXINT8).

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -3,29 +3,89 @@
 module fp8_mul (
     input  wire [7:0] a,
     input  wire [7:0] b,
-    input  wire       is_e5m2,
+    input  wire [2:0] format,
     output wire [7:0] prod,     // Mantissa product, shifted to common weight
     output wire signed [6:0] exp_sum, // Combined exponent (biased)
     output wire       sign
 );
-    // Fields extraction
-    // E4M3: S[7], E[6:3], M[2:0], Bias 7
-    // E5M2: S[7], E[6:2], M[1:0], Bias 15
+    // Format Selection
+    localparam FMT_E4M3 = 3'b000;
+    localparam FMT_E5M2 = 3'b001;
+    localparam FMT_E3M2 = 3'b010;
+    localparam FMT_E2M3 = 3'b011;
+    localparam FMT_E2M1 = 3'b100;
 
-    wire [4:0] ea = is_e5m2 ? {1'b0, a[6:2]} : {1'b0, a[6:3]};
-    wire [4:0] eb = is_e5m2 ? {1'b0, b[6:2]} : {1'b0, b[6:3]};
+    reg [4:0] ea, eb;
+    reg [2:0] ma, mb;
+    reg signed [6:0] exp_bias_sum;
+    reg sign_a, sign_b;
 
-    // Align mantissas to 3 fractional bits (padding E5M2 with a 0)
-    wire [2:0] ma = is_e5m2 ? {a[1:0], 1'b0} : a[2:0];
-    wire [2:0] mb = is_e5m2 ? {b[1:0], 1'b0} : b[2:0];
+    always @(*) begin
+        case (format)
+            FMT_E4M3: begin
+                sign_a = a[7];
+                ea = {1'b0, a[6:3]};
+                ma = a[2:0];
+                sign_b = b[7];
+                eb = {1'b0, b[6:3]};
+                mb = b[2:0];
+                exp_bias_sum = 7'sd7; // 2*7 - 7
+            end
+            FMT_E5M2: begin
+                sign_a = a[7];
+                ea = a[6:2];
+                ma = {a[1:0], 1'b0};
+                sign_b = b[7];
+                eb = b[6:2];
+                mb = {b[1:0], 1'b0};
+                exp_bias_sum = 7'sd23; // 2*15 - 7
+            end
+            FMT_E3M2: begin
+                sign_a = a[5];
+                ea = {2'b0, a[4:2]};
+                ma = {a[1:0], 1'b0};
+                sign_b = b[5];
+                eb = {2'b0, b[4:2]};
+                mb = {b[1:0], 1'b0};
+                exp_bias_sum = -7'sd1; // 2*3 - 7
+            end
+            FMT_E2M3: begin
+                sign_a = a[5];
+                ea = {3'b0, a[4:3]};
+                ma = a[2:0];
+                sign_b = b[5];
+                eb = {3'b0, b[4:3]};
+                mb = b[2:0];
+                exp_bias_sum = -7'sd5; // 2*1 - 7
+            end
+            FMT_E2M1: begin
+                sign_a = a[3];
+                ea = {3'b0, a[2:1]};
+                ma = {a[0], 2'b0};
+                sign_b = b[3];
+                eb = {3'b0, b[2:1]};
+                mb = {b[0], 2'b0};
+                exp_bias_sum = -7'sd5; // 2*1 - 7
+            end
+            default: begin // Default to E4M3
+                sign_a = a[7];
+                ea = {1'b0, a[6:3]};
+                ma = a[2:0];
+                sign_b = b[7];
+                eb = {1'b0, b[6:3]};
+                mb = b[2:0];
+                exp_bias_sum = 7'sd7;
+            end
+        endcase
+    end
 
-    assign sign = a[7] ^ b[7];
+    assign sign = sign_a ^ sign_b;
 
     // OCP MX: Flush subnormals to zero (E=0 means value is 0)
     wire zero_a = (ea == 5'd0);
     wire zero_b = (eb == 5'd0);
 
-    // Integer mantissas: {1, M}
+    // Integer mantissas: {1, M} (each has 3 fractional bits)
     wire [3:0] mant_a = {1'b1, ma};
     wire [3:0] mant_b = {1'b1, mb};
 
@@ -33,18 +93,11 @@ module fp8_mul (
     wire [7:0] p = (zero_a || zero_b) ? 8'd0 : (mant_a * mant_b);
 
     // Exponent sum calculation
-    // Goal: exp_sum such that Aligner (prod * 2^(exp_sum - 5)) gives correct result.
-
-    // For E4M3: Value = (p/64) * 2^(ea+eb-14).
-    // Aligned = Value * 2^8 = (p/64) * 2^(ea+eb-6) = p * 2^(ea+eb-12).
-    // Matches exp_sum = ea+eb-7.
-
-    // For E5M2: Value = (p/64) * 2^(ea+eb-30). (p includes extra shift of 4 from ma/mb alignment)
-    // Aligned = Value * 2^8 = (p/64) * 2^(ea+eb-22) = p * 2^(ea+eb-28).
-    // Matches exp_sum = ea+eb-23.
-
-    assign exp_sum = is_e5m2 ? ($signed({2'b0, ea}) + $signed({2'b0, eb}) - 7'sd23)
-                             : ($signed({2'b0, ea}) + $signed({2'b0, eb}) - 7'sd7);
+    // Aligned = (p/64) * 2^(ea+eb - 2*Bias) * 2^8
+    // Aligned = p * 2^(ea+eb - 2*Bias + 2)
+    // In Aligner: shifted = p << (exp_sum - 5)
+    // So exp_sum = ea + eb - 2*Bias + 7 = ea + eb - (2*Bias - 7)
+    assign exp_sum = $signed({2'b0, ea}) + $signed({2'b0, eb}) - exp_bias_sum;
 
     assign prod = p;
 

--- a/src/project.v
+++ b/src/project.v
@@ -28,17 +28,17 @@ module tt_um_chatelao_fp8_multiplier (
     reg [1:0] state;
     reg [5:0] cycle_count;
 
-    // MXFP8 Registers
+    // MXFP Registers
     reg [7:0] scale_a;
     reg [7:0] scale_b;
-    reg       is_e5m2;
+    reg [2:0] format;
 
     initial begin
         state = STATE_IDLE;
         cycle_count = 6'd0;
         scale_a = 8'd0;
         scale_b = 8'd0;
-        is_e5m2 = 1'b0;
+        format = 3'd0;
     end
 
     // 1. Configure UIO as inputs
@@ -52,7 +52,7 @@ module tt_um_chatelao_fp8_multiplier (
             state <= STATE_IDLE;
             scale_a <= 8'd0;
             scale_b <= 8'd0;
-            is_e5m2 <= 1'b0;
+            format  <= 3'd0;
         end else if (ena) begin
             cycle_count <= (cycle_count == 6'd38) ? 6'd0 : cycle_count + 6'd1;
 
@@ -60,7 +60,7 @@ module tt_um_chatelao_fp8_multiplier (
                 6'd0:  state <= STATE_LOAD_SCALE;
                 6'd1:  begin
                          scale_a <= ui_in;
-                         is_e5m2 <= uio_in[0];
+                         format  <= uio_in[2:0];
                        end
                 6'd2:  begin
                          state   <= STATE_STREAM;
@@ -85,7 +85,7 @@ module tt_um_chatelao_fp8_multiplier (
     fp8_mul multiplier (
         .a(ui_in),
         .b(uio_in),
-        .is_e5m2(is_e5m2),
+        .format(format),
         .prod(mul_prod),
         .exp_sum(mul_exp_sum),
         .sign(mul_sign)

--- a/test/test.py
+++ b/test/test.py
@@ -5,35 +5,67 @@ import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import ClockCycles, Timer
 
-def align_product_model(a_bits, b_bits, is_e5m2):
-    if is_e5m2:
-        # E5M2 Extraction
-        ea = (a_bits >> 2) & 0x1F
-        eb = (b_bits >> 2) & 0x1F
-        ma = (a_bits & 0x3) << 1
-        mb = (b_bits & 0x3) << 1
-        exp_bias = 23
-    else:
-        # E4M3 Extraction
+def align_product_model(a_bits, b_bits, format_val):
+    if format_val == 0: # E4M3
         ea = (a_bits >> 3) & 0xF
-        eb = (b_bits >> 3) & 0xF
         ma = (a_bits & 0x7)
+        eb = (b_bits >> 3) & 0xF
         mb = (b_bits & 0x7)
-        exp_bias = 7
+        bias = 7
+        sign_a = (a_bits >> 7) & 1
+        sign_b = (b_bits >> 7) & 1
+    elif format_val == 1: # E5M2
+        ea = (a_bits >> 2) & 0x1F
+        ma = (a_bits & 0x3) << 1
+        eb = (b_bits >> 2) & 0x1F
+        mb = (b_bits & 0x3) << 1
+        bias = 15
+        sign_a = (a_bits >> 7) & 1
+        sign_b = (b_bits >> 7) & 1
+    elif format_val == 2: # E3M2
+        ea = (a_bits >> 2) & 0x7
+        ma = (a_bits & 0x3) << 1
+        eb = (b_bits >> 2) & 0x7
+        mb = (b_bits & 0x3) << 1
+        bias = 3
+        sign_a = (a_bits >> 5) & 1
+        sign_b = (b_bits >> 5) & 1
+    elif format_val == 3: # E2M3
+        ea = (a_bits >> 3) & 0x3
+        ma = (a_bits & 0x7)
+        eb = (b_bits >> 3) & 0x3
+        mb = (b_bits & 0x7)
+        bias = 1
+        sign_a = (a_bits >> 5) & 1
+        sign_b = (b_bits >> 5) & 1
+    elif format_val == 4: # E2M1
+        ea = (a_bits >> 1) & 0x3
+        ma = (a_bits & 0x1) << 2
+        eb = (b_bits >> 1) & 0x3
+        mb = (b_bits & 0x1) << 2
+        bias = 1
+        sign_a = (a_bits >> 3) & 1
+        sign_b = (b_bits >> 3) & 1
+    else: # Default to E4M3
+        return align_product_model(a_bits, b_bits, 0)
 
-    sign = ((a_bits >> 7) & 1) ^ ((b_bits >> 7) & 1)
+    sign = sign_a ^ sign_b
 
     if ea == 0 or eb == 0:
         return 0
 
     prod = (8 + ma) * (8 + mb)
-    exp_sum = ea + eb - exp_bias
+    exp_sum = ea + eb - 2*bias + 7
     shift_amt = exp_sum - 5
 
     if shift_amt >= 0:
         aligned = prod << shift_amt
     else:
-        aligned = prod >> (-shift_amt)
+        # Avoid negative shifts
+        if (-shift_amt) >= 64:
+            aligned = 0
+        else:
+            aligned = prod >> (-shift_amt)
 
     if sign:
         if aligned > 0x80000000:
@@ -64,33 +96,22 @@ async def reset_dut(dut):
     dut.rst_n.value = 1
     await ClockCycles(dut.clk, 1)
 
-@cocotb.test()
-async def test_mxfp8_mac_e4m3(dut):
-    dut._log.info("Start MXFP8 MAC Test (E4M3)")
-    clock = Clock(dut.clk, 10, unit="ns")
-    cocotb.start_soon(clock.start())
-
+async def run_mac_test(dut, format_val, a_elements, b_elements):
     await reset_dut(dut)
 
-    # State should now be LOAD_SCALE, cycle_count=1
-    # Capture scale_a and is_e5m2 at edge 1->2
-    dut.ui_in.value = 0x00
-    dut.uio_in.value = 0x00
-    await ClockCycles(dut.clk, 1) # EDGE 1 -> 2. state=LOAD_SCALE, cycle_count=2
+    # Cycle 1: Load Scale A and Format Select
+    dut.ui_in.value = 0x00 # Scale A
+    dut.uio_in.value = format_val
+    await ClockCycles(dut.clk, 1)
 
-    # Capture scale_b at edge 2->3
+    # Cycle 2: Load Scale B
     dut.ui_in.value = 0x00
-    dut.uio_in.value = 0x00
-    await ClockCycles(dut.clk, 1) # EDGE 2 -> 3. state=STREAM, cycle_count=3
-
-    # Stream elements (Cycle 3 to 34)
-    a_elements = [0x38] * 32 # 1.0
-    b_elements = [0x38] * 32
-    is_e5m2 = False
+    dut.uio_in.value = 0x00 # Scale B
+    await ClockCycles(dut.clk, 1)
 
     expected_acc = 0
     for a, b in zip(a_elements, b_elements):
-        expected_acc = (expected_acc + align_product_model(a, b, is_e5m2)) & 0xFFFFFFFF
+        expected_acc = (expected_acc + align_product_model(a, b, format_val)) & 0xFFFFFFFF
         if expected_acc & 0x80000000:
             expected_acc -= 0x100000000
 
@@ -99,7 +120,7 @@ async def test_mxfp8_mac_e4m3(dut):
         dut.uio_in.value = b_elements[i]
         await ClockCycles(dut.clk, 1)
 
-    # Cycle 35 is now active. State=OUTPUT
+    # Cycle 35-38: Output Serialized Result
     actual_acc = 0
     for i in range(4):
         await Timer(1, unit="ns")
@@ -109,99 +130,65 @@ async def test_mxfp8_mac_e4m3(dut):
     if actual_acc & 0x80000000:
         actual_acc -= 0x100000000
 
-    dut._log.info(f"Expected: {expected_acc}, Actual: {actual_acc}")
+    format_names = ["E4M3", "E5M2", "E3M2", "E2M3", "E2M1"]
+    name = format_names[format_val] if format_val < len(format_names) else "Unknown"
+    dut._log.info(f"Format: {name}, Expected: {expected_acc}, Actual: {actual_acc}")
     assert actual_acc == expected_acc
 
 @cocotb.test()
-async def test_mxfp8_mac_randomized(dut):
-    import random
-    dut._log.info("Start Randomized MXFP8 MAC Test")
+async def test_mxfp8_mac_e4m3(dut):
+    dut._log.info("Start MXFP8 MAC Test (E4M3)")
     clock = Clock(dut.clk, 10, unit="ns")
     cocotb.start_soon(clock.start())
-
-    for i in range(5):
-        await reset_dut(dut)
-        is_e5m2 = random.choice([True, False])
-
-        # Cycle 1
-        dut.ui_in.value = random.randint(0, 255)
-        dut.uio_in.value = 1 if is_e5m2 else 0
-        await ClockCycles(dut.clk, 1)
-
-        # Cycle 2
-        dut.ui_in.value = random.randint(0, 255)
-        dut.uio_in.value = random.randint(0, 255)
-        await ClockCycles(dut.clk, 1)
-
-        a_elements = [random.randint(0, 255) for _ in range(32)]
-        b_elements = [random.randint(0, 255) for _ in range(32)]
-
-        expected_acc = 0
-        for a, b in zip(a_elements, b_elements):
-            expected_acc = (expected_acc + align_product_model(a, b, is_e5m2)) & 0xFFFFFFFF
-            if expected_acc & 0x80000000:
-                expected_acc -= 0x100000000
-
-        for j in range(32):
-            dut.ui_in.value = a_elements[j]
-            dut.uio_in.value = b_elements[j]
-            await ClockCycles(dut.clk, 1)
-
-        actual_acc = 0
-        for j in range(4):
-            await Timer(1, unit="ns")
-            actual_acc = (actual_acc << 8) | int(dut.uo_out.value)
-            await ClockCycles(dut.clk, 1)
-
-        if actual_acc & 0x80000000:
-            actual_acc -= 0x100000000
-
-        dut._log.info(f"Iteration {i} ({'E5M2' if is_e5m2 else 'E4M3'}): Expected: {expected_acc}, Actual: {actual_acc}")
-        assert actual_acc == expected_acc
+    a_elements = [0x38] * 32 # 1.0 in E4M3
+    b_elements = [0x38] * 32
+    await run_mac_test(dut, 0, a_elements, b_elements)
 
 @cocotb.test()
 async def test_mxfp8_mac_e5m2(dut):
     dut._log.info("Start MXFP8 MAC Test (E5M2)")
     clock = Clock(dut.clk, 10, unit="ns")
     cocotb.start_soon(clock.start())
-
-    await reset_dut(dut)
-
-    # Cycle 1
-    dut.ui_in.value = 0x00
-    dut.uio_in.value = 0x01 # is_e5m2 = 1
-    await ClockCycles(dut.clk, 1)
-
-    # Cycle 2
-    dut.ui_in.value = 0x00
-    dut.uio_in.value = 0x00
-    await ClockCycles(dut.clk, 1)
-
-    # Stream elements
     a_elements = [0x3C] * 32 # 1.0 in E5M2
     b_elements = [0x3C] * 32
-    is_e5m2 = True
+    await run_mac_test(dut, 1, a_elements, b_elements)
 
-    expected_acc = 0
-    for a, b in zip(a_elements, b_elements):
-        expected_acc = (expected_acc + align_product_model(a, b, is_e5m2)) & 0xFFFFFFFF
-        if expected_acc & 0x80000000:
-            expected_acc -= 0x100000000
+@cocotb.test()
+async def test_mxfp6_mac_e3m2(dut):
+    dut._log.info("Start MXFP6 MAC Test (E3M2)")
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+    a_elements = [0x0C] * 32 # 1.0 in E3M2 (S=0, E=3, M=0) -> bit 5=0, bit [4:2]=3, bit [1:0]=0 -> 001100 = 0x0C
+    b_elements = [0x0C] * 32
+    await run_mac_test(dut, 2, a_elements, b_elements)
 
-    for i in range(32):
-        dut.ui_in.value = a_elements[i]
-        dut.uio_in.value = b_elements[i]
-        await ClockCycles(dut.clk, 1)
+@cocotb.test()
+async def test_mxfp6_mac_e2m3(dut):
+    dut._log.info("Start MXFP6 MAC Test (E2M3)")
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+    a_elements = [0x08] * 32 # 1.0 in E2M3 (S=0, E=1, M=0) -> bit 5=0, bit [4:3]=1, bit [2:0]=0 -> 001000 = 0x08
+    b_elements = [0x08] * 32
+    await run_mac_test(dut, 3, a_elements, b_elements)
 
-    # Cycle 35-38
-    actual_acc = 0
-    for i in range(4):
-        await Timer(1, unit="ns")
-        actual_acc = (actual_acc << 8) | int(dut.uo_out.value)
-        await ClockCycles(dut.clk, 1)
+@cocotb.test()
+async def test_mxfp4_mac_e2m1(dut):
+    dut._log.info("Start MXFP4 MAC Test (E2M1)")
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+    a_elements = [0x02] * 32 # 1.0 in E2M1 (S=0, E=1, M=0) -> bit 3=0, bit [2:1]=1, bit 0=0 -> 0010 = 0x02
+    b_elements = [0x02] * 32
+    await run_mac_test(dut, 4, a_elements, b_elements)
 
-    if actual_acc & 0x80000000:
-        actual_acc -= 0x100000000
+@cocotb.test()
+async def test_mxfp_mac_randomized(dut):
+    import random
+    dut._log.info("Start Randomized MXFP MAC Test")
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
 
-    dut._log.info(f"Expected: {expected_acc}, Actual: {actual_acc}")
-    assert actual_acc == expected_acc
+    for i in range(20):
+        format_val = random.randint(0, 4)
+        a_elements = [random.randint(0, 255) for _ in range(32)]
+        b_elements = [random.randint(0, 255) for _ in range(32)]
+        await run_mac_test(dut, format_val, a_elements, b_elements)


### PR DESCRIPTION
Implemented Step 7 of the Phase 2 roadmap, adding support for MXFP6 (E3M2, E2M3) and MXFP4 (E2M1) formats. The 38-cycle protocol was updated to allow 3-bit format selection during the scale-loading phase. The multiplier datapath now includes a unified exponent logic that handles various biases and mantissa alignments. Verified the implementation against a bit-accurate Python model for all formats.

Fixes #59

---
*PR created automatically by Jules for task [14361528000455433852](https://jules.google.com/task/14361528000455433852) started by @chatelao*