### PR TITLE
Implement Mixed-Precision Support (Step 10)

### DIFF
--- a/MXFP8_CONCEPT.md
+++ b/MXFP8_CONCEPT.md
@@ -165,6 +165,6 @@ The ASIC performs the summation and the intermediate exponent arithmetic. The fi
 - [x] **Step 7**: Extended Floating Point Support (MXFP6 & MXFP4).
 - [x] **Step 8**: Integer Support (MXINT8) & Symmetric Range.
 - [x] **Step 9**: Advanced Numerical Control (Rounding & Overflow modes).
-- [ ] **Step 10**: Mixed-Precision Operations (Independent A/B formats).
+- [x] **Step 10**: Mixed-Precision Operations (Independent A/B formats).
 - [ ] **Step 11**: Hardware-Accelerated Shared Scaling (Applying $2^{X_A+X_B}$ in hardware).
 - [ ] **Step 12**: Throughput Optimization & Scale Compression.

--- a/MXFP8_ROADMAP.md
+++ b/MXFP8_ROADMAP.md
@@ -63,11 +63,13 @@ This roadmap outlines the incremental development of the OCP MXFP8 Streaming MAC
   - Optimized aligner logic and pipelined the datapath to meet 27MHz timing for Gowin.
 - **Verification**: Targeted tests for rounding bit-accuracy and saturation/wrap behavior.
 
-### Step 10: Mixed-Precision Operations
+### Step 10: Mixed-Precision Operations (Status: **COMPLETED**)
 - **Goal**: Enable independent format selection for Operand A and Operand B.
-- **Tasks**:
-  - Decouple format selection logic.
-  - Update datapath to handle mixed exponent ranges.
+- **Details**:
+  - Decoupled format selection logic for A and B.
+  - Implemented unified exponent sum formula to handle mixed FP/INT precision.
+  - Updated 40-cycle protocol to sample `format_a` (Cycle 1) and `format_b` (Cycle 2).
+- **Verification**: New mixed-precision and randomized test cases in `test/test.py`.
 
 ### Step 11: Hardware-Accelerated Shared Scaling
 - **Goal**: Apply shared scales ($X_A, X_B$) in hardware.

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -3,8 +3,9 @@
 module fp8_mul (
     input  wire [7:0] a,
     input  wire [7:0] b,
-    input  wire [2:0] format,
-    output wire [15:0] prod,    // Mantissa product, shifted to common weight
+    input  wire [2:0] format_a,
+    input  wire [2:0] format_b,
+    output wire [15:0] prod,    // Mantissa product
     output wire signed [6:0] exp_sum, // Combined exponent (biased)
     output wire       sign
 );
@@ -17,137 +18,158 @@ module fp8_mul (
     localparam FMT_INT8 = 3'b101;
     localparam FMT_INT8_SYM = 3'b110;
 
-    reg [4:0] ea, eb;
-    reg [2:0] ma, mb;
-    reg signed [6:0] exp_bias_sum;
     reg sign_a, sign_b;
-
-    reg is_int;
-    reg signed [7:0] ia, ib;
+    reg [4:0] ea, eb;
+    reg [7:0] ma, mb;
+    reg signed [5:0] bias_a, bias_b;
+    reg zero_a, zero_b;
 
     reg [15:0] p_res;
     reg signed [6:0] exp_sum_res;
     reg sign_res;
 
-    // Temporal variables for calculation
-    reg zero_a, zero_b;
-    reg [3:0] mant_a, mant_b;
-    reg [7:0] p_fp;
-    reg signed [15:0] s_prod;
-
     always @(*) begin
         // Defaults to avoid latches
         sign_a = 1'b0;
         ea = 5'd0;
-        ma = 3'd0;
+        ma = 8'd0;
+        bias_a = 6'sd0;
+        zero_a = 1'b1;
+
         sign_b = 1'b0;
         eb = 5'd0;
-        mb = 3'd0;
-        exp_bias_sum = 7'sd0;
-        is_int = 1'b0;
-        ia = 8'sd0;
-        ib = 8'sd0;
+        mb = 8'd0;
+        bias_b = 6'sd0;
+        zero_b = 1'b1;
 
-        // Output and temporal variables initialization
         p_res = 16'd0;
         exp_sum_res = 7'sd0;
         sign_res = 1'b0;
 
-        zero_a = 1'b0;
-        zero_b = 1'b0;
-        mant_a = 4'd0;
-        mant_b = 4'd0;
-        p_fp = 8'd0;
-        s_prod = 16'sd0;
-
-        case (format)
+        // Operand A Decoding
+        case (format_a)
             FMT_E4M3: begin
                 sign_a = a[7];
                 ea = {1'b0, a[6:3]};
-                ma = a[2:0];
-                sign_b = b[7];
-                eb = {1'b0, b[6:3]};
-                mb = b[2:0];
-                exp_bias_sum = 7'sd7; // 2*7 - 7
+                ma = {4'b0, 1'b1, a[2:0]};
+                bias_a = 6'sd7;
+                zero_a = (ea == 5'd0);
             end
             FMT_E5M2: begin
                 sign_a = a[7];
                 ea = a[6:2];
-                ma = {a[1:0], 1'b0};
-                sign_b = b[7];
-                eb = b[6:2];
-                mb = {b[1:0], 1'b0};
-                exp_bias_sum = 7'sd23; // 2*15 - 7
+                ma = {4'b0, 1'b1, a[1:0], 1'b0};
+                bias_a = 6'sd15;
+                zero_a = (ea == 5'd0);
             end
             FMT_E3M2: begin
                 sign_a = a[5];
                 ea = {2'b0, a[4:2]};
-                ma = {a[1:0], 1'b0};
-                sign_b = b[5];
-                eb = {2'b0, b[4:2]};
-                mb = {b[1:0], 1'b0};
-                exp_bias_sum = -7'sd1; // 2*3 - 7
+                ma = {4'b0, 1'b1, a[1:0], 1'b0};
+                bias_a = 6'sd3;
+                zero_a = (ea == 5'd0);
             end
             FMT_E2M3: begin
                 sign_a = a[5];
                 ea = {3'b0, a[4:3]};
-                ma = a[2:0];
-                sign_b = b[5];
-                eb = {3'b0, b[4:3]};
-                mb = b[2:0];
-                exp_bias_sum = -7'sd5; // 2*1 - 7
+                ma = {4'b0, 1'b1, a[2:0]};
+                bias_a = 6'sd1;
+                zero_a = (ea == 5'd0);
             end
             FMT_E2M1: begin
                 sign_a = a[3];
                 ea = {3'b0, a[2:1]};
-                ma = {a[0], 2'b0};
-                sign_b = b[3];
-                eb = {3'b0, b[2:1]};
-                mb = {b[0], 2'b0};
-                exp_bias_sum = -7'sd5; // 2*1 - 7
+                ma = {4'b0, 1'b1, a[0], 2'b0};
+                bias_a = 6'sd1;
+                zero_a = (ea == 5'd0);
             end
             FMT_INT8: begin
-                is_int = 1'b1;
-                ia = $signed(a);
-                ib = $signed(b);
+                sign_a = a[7];
+                ma = a[7] ? -a : a;
+                ea = 5'd0;
+                bias_a = 6'sd3;
+                zero_a = (a == 8'd0);
             end
             FMT_INT8_SYM: begin
-                is_int = 1'b1;
-                ia = (a == 8'h80) ? -8'sd127 : $signed(a);
-                ib = (b == 8'h80) ? -8'sd127 : $signed(b);
+                sign_a = a[7];
+                ma = (a == 8'h80) ? 8'd127 : (a[7] ? -a : a);
+                ea = 5'd0;
+                bias_a = 6'sd3;
+                zero_a = (a == 8'd0);
             end
-            default: begin // Default to E4M3
+            default: begin
                 sign_a = a[7];
                 ea = {1'b0, a[6:3]};
-                ma = a[2:0];
-                sign_b = b[7];
-                eb = {1'b0, b[6:3]};
-                mb = b[2:0];
-                exp_bias_sum = 7'sd7;
+                ma = {4'b0, 1'b1, a[2:0]};
+                bias_a = 6'sd7;
+                zero_a = (ea == 5'd0);
             end
         endcase
 
-        if (is_int) begin
-            s_prod = ia * ib;
-            sign_res = s_prod[15];
-            p_res = sign_res ? -s_prod : s_prod;
-            exp_sum_res = 7'sd1;
-        end else begin
-            // OCP MX: Flush subnormals to zero (E=0 means value is 0)
-            zero_a = (ea == 5'd0);
-            zero_b = (eb == 5'd0);
+        // Operand B Decoding
+        case (format_b)
+            FMT_E4M3: begin
+                sign_b = b[7];
+                eb = {1'b0, b[6:3]};
+                mb = {4'b0, 1'b1, b[2:0]};
+                bias_b = 6'sd7;
+                zero_b = (eb == 5'd0);
+            end
+            FMT_E5M2: begin
+                sign_b = b[7];
+                eb = b[6:2];
+                mb = {4'b0, 1'b1, b[1:0], 1'b0};
+                bias_b = 6'sd15;
+                zero_b = (eb == 5'd0);
+            end
+            FMT_E3M2: begin
+                sign_b = b[5];
+                eb = {2'b0, b[4:2]};
+                mb = {4'b0, 1'b1, b[1:0], 1'b0};
+                bias_b = 6'sd3;
+                zero_b = (eb == 5'd0);
+            end
+            FMT_E2M3: begin
+                sign_b = b[5];
+                eb = {3'b0, b[4:3]};
+                mb = {4'b0, 1'b1, b[2:0]};
+                bias_b = 6'sd1;
+                zero_b = (eb == 5'd0);
+            end
+            FMT_E2M1: begin
+                sign_b = b[3];
+                eb = {3'b0, b[2:1]};
+                mb = {4'b0, 1'b1, b[0], 2'b0};
+                bias_b = 6'sd1;
+                zero_b = (eb == 5'd0);
+            end
+            FMT_INT8: begin
+                sign_b = b[7];
+                mb = b[7] ? -b : b;
+                eb = 5'd0;
+                bias_b = 6'sd3;
+                zero_b = (b == 8'd0);
+            end
+            FMT_INT8_SYM: begin
+                sign_b = b[7];
+                mb = (b == 8'h80) ? 8'd127 : (b[7] ? -b : b);
+                eb = 5'd0;
+                bias_b = 6'sd3;
+                zero_b = (b == 8'd0);
+            end
+            default: begin
+                sign_b = b[7];
+                eb = {1'b0, b[6:3]};
+                mb = {4'b0, 1'b1, b[2:0]};
+                bias_b = 6'sd7;
+                zero_b = (eb == 5'd0);
+            end
+        endcase
 
-            // Integer mantissas: {1, M} (each has 3 fractional bits)
-            mant_a = {1'b1, ma};
-            mant_b = {1'b1, mb};
-
-            // 4-bit * 4-bit = 8-bit product
-            p_fp = (zero_a || zero_b) ? 8'd0 : (mant_a * mant_b);
-
-            sign_res = sign_a ^ sign_b;
-            p_res = {8'd0, p_fp};
-            exp_sum_res = $signed({2'b0, ea}) + $signed({2'b0, eb}) - exp_bias_sum;
-        end
+        // 8x8 Multiplier
+        p_res = (zero_a || zero_b) ? 16'd0 : (ma * mb);
+        sign_res = sign_a ^ sign_b;
+        exp_sum_res = $signed({2'b0, ea}) + $signed({2'b0, eb}) - ($signed(bias_a) + $signed(bias_b) - 7'sd7);
     end
 
     assign sign = sign_res;

--- a/src/project.v
+++ b/src/project.v
@@ -31,7 +31,8 @@ module tt_um_chatelao_fp8_multiplier (
     // MXFP Registers
     reg [7:0] scale_a;
     reg [7:0] scale_b;
-    reg [2:0] format;
+    reg [2:0] format_a;
+    reg [2:0] format_b;
     reg [1:0] round_mode;
     reg       overflow_wrap;
 
@@ -40,7 +41,8 @@ module tt_um_chatelao_fp8_multiplier (
         cycle_count = 6'd0;
         scale_a = 8'd0;
         scale_b = 8'd0;
-        format = 3'd0;
+        format_a = 3'd0;
+        format_b = 3'd0;
         round_mode = 2'd0;
         overflow_wrap = 1'b0;
     end
@@ -62,7 +64,8 @@ module tt_um_chatelao_fp8_multiplier (
             state <= STATE_IDLE;
             scale_a <= 8'd0;
             scale_b <= 8'd0;
-            format  <= 3'd0;
+            format_a <= 3'd0;
+            format_b <= 3'd0;
             round_mode <= 2'd0;
             overflow_wrap <= 1'b0;
         end else if (ena) begin
@@ -72,13 +75,14 @@ module tt_um_chatelao_fp8_multiplier (
                 6'd0:  state <= STATE_LOAD_SCALE;
                 6'd1:  begin
                          scale_a       <= ui_in;
-                         format        <= uio_in[2:0];
+                         format_a      <= uio_in[2:0];
                          round_mode    <= uio_in[4:3];
                          overflow_wrap <= uio_in[5];
                        end
                 6'd2:  begin
-                         state   <= STATE_STREAM;
-                         scale_b <= uio_in;
+                         state    <= STATE_STREAM;
+                         scale_b  <= uio_in;
+                         format_b <= ui_in[2:0];
                        end
                 6'd35: state   <= STATE_OUTPUT;
                 6'd39: state   <= STATE_IDLE;
@@ -99,7 +103,8 @@ module tt_um_chatelao_fp8_multiplier (
     fp8_mul multiplier (
         .a(ui_in),
         .b(uio_in),
-        .format(format),
+        .format_a(format_a),
+        .format_b(format_b),
         .prod(mul_prod),
         .exp_sum(mul_exp_sum),
         .sign(mul_sign)

--- a/test/test.py
+++ b/test/test.py
@@ -5,80 +5,73 @@ import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import ClockCycles, Timer
 
-def align_product_model(a_bits, b_bits, format_val, round_mode=0, overflow_wrap=0):
+def decode_format(bits, format_val):
     if format_val == 0: # E4M3
-        ea = (a_bits >> 3) & 0xF
-        ma = (a_bits & 0x7)
-        eb = (b_bits >> 3) & 0xF
-        mb = (b_bits & 0x7)
+        sign = (bits >> 7) & 1
+        exp = (bits >> 3) & 0xF
+        mant = (bits & 0x7)
         bias = 7
-        sign_a = (a_bits >> 7) & 1
-        sign_b = (b_bits >> 7) & 1
         is_int = False
     elif format_val == 1: # E5M2
-        ea = (a_bits >> 2) & 0x1F
-        ma = (a_bits & 0x3) << 1
-        eb = (b_bits >> 2) & 0x1F
-        mb = (b_bits & 0x3) << 1
+        sign = (bits >> 7) & 1
+        exp = (bits >> 2) & 0x1F
+        mant = (bits & 0x3) << 1
         bias = 15
-        sign_a = (a_bits >> 7) & 1
-        sign_b = (b_bits >> 7) & 1
         is_int = False
     elif format_val == 2: # E3M2
-        ea = (a_bits >> 2) & 0x7
-        ma = (a_bits & 0x3) << 1
-        eb = (b_bits >> 2) & 0x7
-        mb = (b_bits & 0x3) << 1
+        sign = (bits >> 5) & 1
+        exp = (bits >> 2) & 0x7
+        mant = (bits & 0x3) << 1
         bias = 3
-        sign_a = (a_bits >> 5) & 1
-        sign_b = (b_bits >> 5) & 1
         is_int = False
     elif format_val == 3: # E2M3
-        ea = (a_bits >> 3) & 0x3
-        ma = (a_bits & 0x7)
-        eb = (b_bits >> 3) & 0x3
-        mb = (b_bits & 0x7)
+        sign = (bits >> 5) & 1
+        exp = (bits >> 3) & 0x3
+        mant = (bits & 0x7)
         bias = 1
-        sign_a = (a_bits >> 5) & 1
-        sign_b = (b_bits >> 5) & 1
         is_int = False
     elif format_val == 4: # E2M1
-        ea = (a_bits >> 1) & 0x3
-        ma = (a_bits & 0x1) << 2
-        eb = (b_bits >> 1) & 0x3
-        mb = (b_bits & 0x1) << 2
+        sign = (bits >> 3) & 1
+        exp = (bits >> 1) & 0x3
+        mant = (bits & 0x1) << 2
         bias = 1
-        sign_a = (a_bits >> 3) & 1
-        sign_b = (b_bits >> 3) & 1
         is_int = False
     elif format_val == 5: # INT8
-        ia = a_bits
-        if ia >= 128: ia -= 256
-        ib = b_bits
-        if ib >= 128: ib -= 256
+        sign = (bits >> 7) & 1
+        val = bits if bits < 128 else bits - 256
+        mant = abs(val)
+        exp = 0
+        bias = 3
         is_int = True
     elif format_val == 6: # INT8_SYM
-        ia = a_bits
-        if ia >= 128: ia -= 256
-        if ia == -128: ia = -127
-        ib = b_bits
-        if ib >= 128: ib -= 256
-        if ib == -128: ib = -127
+        sign = (bits >> 7) & 1
+        val = bits if bits < 128 else bits - 256
+        if val == -128: val = -127
+        mant = abs(val)
+        exp = 0
+        bias = 3
         is_int = True
-    else: # Default to E4M3
-        return align_product_model(a_bits, b_bits, 0, round_mode, overflow_wrap)
+    else: # Default E4M3
+        return decode_format(bits, 0)
 
-    if is_int:
-        prod_val = ia * ib
-        sign = 1 if prod_val < 0 else 0
-        prod = abs(prod_val)
-        exp_sum = 1
-    else:
-        sign = sign_a ^ sign_b
-        if ea == 0 or eb == 0:
-            return 0
-        prod = (8 + ma) * (8 + mb)
-        exp_sum = ea + eb - 2*bias + 7
+    return sign, exp, mant, bias, is_int
+
+def align_product_model(a_bits, b_bits, format_a, format_b, round_mode=0, overflow_wrap=0):
+    sa, ea, ma, ba, inta = decode_format(a_bits, format_a)
+    sb, eb, mb, bb, intb = decode_format(b_bits, format_b)
+
+    sign = sa ^ sb
+
+    if (not inta and ea == 0) or (not intb and eb == 0):
+        return 0
+    if (inta and a_bits == 0) or (intb and b_bits == 0):
+        return 0
+
+    real_ma = (8 + ma) if not inta else ma
+    real_mb = (8 + mb) if not intb else mb
+
+    prod = real_ma * real_mb
+    exp_sum = ea + eb - (ba + bb - 7)
 
     shift_amt = exp_sum - 5
 
@@ -144,22 +137,22 @@ async def reset_dut(dut):
     dut.rst_n.value = 1
     await ClockCycles(dut.clk, 1)
 
-async def run_mac_test(dut, format_val, a_elements, b_elements, round_mode=0, overflow_wrap=0):
+async def run_mac_test(dut, format_a, format_b, a_elements, b_elements, round_mode=0, overflow_wrap=0):
     await reset_dut(dut)
 
     # Cycle 1: Load Scale A and Format/Numerical Control
     dut.ui_in.value = 0x00 # Scale A
-    dut.uio_in.value = format_val | (round_mode << 3) | (overflow_wrap << 5)
+    dut.uio_in.value = format_a | (round_mode << 3) | (overflow_wrap << 5)
     await ClockCycles(dut.clk, 1)
 
-    # Cycle 2: Load Scale B
-    dut.ui_in.value = 0x00
+    # Cycle 2: Load Scale B and Format B
+    dut.ui_in.value = format_b
     dut.uio_in.value = 0x00 # Scale B
     await ClockCycles(dut.clk, 1)
 
     expected_acc = 0
     for a, b in zip(a_elements, b_elements):
-        prod = align_product_model(a, b, format_val, round_mode, overflow_wrap)
+        prod = align_product_model(a, b, format_a, format_b, round_mode, overflow_wrap)
 
         acc_32 = expected_acc & 0xFFFFFFFF
         prod_32 = prod & 0xFFFFFFFF
@@ -201,8 +194,9 @@ async def run_mac_test(dut, format_val, a_elements, b_elements, round_mode=0, ov
         actual_acc -= 0x100000000
 
     format_names = ["E4M3", "E5M2", "E3M2", "E2M3", "E2M1", "INT8", "INT8_SYM"]
-    name = format_names[format_val] if format_val < len(format_names) else "Unknown"
-    dut._log.info(f"Format: {name}, RM: {round_mode}, Wrap: {overflow_wrap}, Expected: {expected_acc}, Actual: {actual_acc}")
+    name_a = format_names[format_a] if format_a < len(format_names) else "Unknown"
+    name_b = format_names[format_b] if format_b < len(format_names) else "Unknown"
+    dut._log.info(f"Format: {name_a}x{name_b}, RM: {round_mode}, Wrap: {overflow_wrap}, Expected: {expected_acc}, Actual: {actual_acc}")
     assert actual_acc == expected_acc
 
 @cocotb.test()
@@ -212,7 +206,7 @@ async def test_mxfp8_mac_e4m3(dut):
     cocotb.start_soon(clock.start())
     a_elements = [0x38] * 32 # 1.0 in E4M3
     b_elements = [0x38] * 32
-    await run_mac_test(dut, 0, a_elements, b_elements)
+    await run_mac_test(dut, 0, 0, a_elements, b_elements)
 
 @cocotb.test()
 async def test_mxfp8_mac_e5m2(dut):
@@ -221,7 +215,7 @@ async def test_mxfp8_mac_e5m2(dut):
     cocotb.start_soon(clock.start())
     a_elements = [0x3C] * 32 # 1.0 in E5M2
     b_elements = [0x3C] * 32
-    await run_mac_test(dut, 1, a_elements, b_elements)
+    await run_mac_test(dut, 1, 1, a_elements, b_elements)
 
 @cocotb.test()
 async def test_rounding_modes(dut):
@@ -233,26 +227,26 @@ async def test_rounding_modes(dut):
     b_elements = [0x31] * 32
 
     # TRN: 40 * 32 = 1280
-    await run_mac_test(dut, 0, a_elements, b_elements, round_mode=0)
+    await run_mac_test(dut, 0, 0, a_elements, b_elements, round_mode=0)
     # CEL: (40+1) * 32 = 1312
-    await run_mac_test(dut, 0, a_elements, b_elements, round_mode=1)
+    await run_mac_test(dut, 0, 0, a_elements, b_elements, round_mode=1)
     # FLR: 40 * 32 = 1280 (positive)
-    await run_mac_test(dut, 0, a_elements, b_elements, round_mode=2)
+    await run_mac_test(dut, 0, 0, a_elements, b_elements, round_mode=2)
     # RNE: 81 >> 1 = 40.5. Ties to even. 40 is even. So 40.
-    await run_mac_test(dut, 0, a_elements, b_elements, round_mode=3)
+    await run_mac_test(dut, 0, 0, a_elements, b_elements, round_mode=3)
 
     # Negative test
     a_elements = [0xA9] * 32 # -0.28125
     b_elements = [0x31] * 32 # 0.5625
     # a*b = -0.158203125. Fixed point magnitude = 40.5.
     # TRN: -40 * 32 = -1280
-    await run_mac_test(dut, 0, a_elements, b_elements, round_mode=0)
+    await run_mac_test(dut, 0, 0, a_elements, b_elements, round_mode=0)
     # CEL: -40 * 32 = -1280 (negative, ceil towards 0)
-    await run_mac_test(dut, 0, a_elements, b_elements, round_mode=1)
+    await run_mac_test(dut, 0, 0, a_elements, b_elements, round_mode=1)
     # FLR: -(40+1) * 32 = -1312
-    await run_mac_test(dut, 0, a_elements, b_elements, round_mode=2)
+    await run_mac_test(dut, 0, 0, a_elements, b_elements, round_mode=2)
     # RNE: -40 * 32 = -1280
-    await run_mac_test(dut, 0, a_elements, b_elements, round_mode=3)
+    await run_mac_test(dut, 0, 0, a_elements, b_elements, round_mode=3)
 
 @cocotb.test()
 async def test_overflow_saturation(dut):
@@ -264,9 +258,9 @@ async def test_overflow_saturation(dut):
     b_elements = [0x7C] * 32
 
     # Saturation
-    await run_mac_test(dut, 1, a_elements, b_elements, overflow_wrap=0)
+    await run_mac_test(dut, 1, 1, a_elements, b_elements, overflow_wrap=0)
     # Wrap
-    await run_mac_test(dut, 1, a_elements, b_elements, overflow_wrap=1)
+    await run_mac_test(dut, 1, 1, a_elements, b_elements, overflow_wrap=1)
 
 @cocotb.test()
 async def test_accumulator_saturation(dut):
@@ -278,9 +272,25 @@ async def test_accumulator_saturation(dut):
     b_elements = [0x78] * 32
 
     # Accumulator Saturation
-    await run_mac_test(dut, 1, a_elements, b_elements, overflow_wrap=0)
+    await run_mac_test(dut, 1, 1, a_elements, b_elements, overflow_wrap=0)
     # Accumulator Wrap
-    await run_mac_test(dut, 1, a_elements, b_elements, overflow_wrap=1)
+    await run_mac_test(dut, 1, 1, a_elements, b_elements, overflow_wrap=1)
+
+@cocotb.test()
+async def test_mixed_precision(dut):
+    dut._log.info("Start Mixed-Precision MAC Test")
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    # E4M3 x E5M2
+    a_elements = [0x38] * 32 # 1.0 in E4M3
+    b_elements = [0x3C] * 32 # 1.0 in E5M2
+    await run_mac_test(dut, 0, 1, a_elements, b_elements)
+
+    # E3M2 x INT8
+    a_elements = [0x10] * 32 # 1.0 in E3M2
+    b_elements = [0x40] * 32 # 64 in INT8 (which is 1.0 with 2^-6 scale)
+    await run_mac_test(dut, 2, 5, a_elements, b_elements)
 
 @cocotb.test()
 async def test_mxfp_mac_randomized(dut):
@@ -290,9 +300,10 @@ async def test_mxfp_mac_randomized(dut):
     cocotb.start_soon(clock.start())
 
     for i in range(50):
-        format_val = random.randint(0, 6)
+        format_a = random.randint(0, 6)
+        format_b = random.randint(0, 6)
         round_mode = random.randint(0, 3)
         overflow_wrap = random.randint(0, 1)
         a_elements = [random.randint(0, 255) for _ in range(32)]
         b_elements = [random.randint(0, 255) for _ in range(32)]
-        await run_mac_test(dut, format_val, a_elements, b_elements, round_mode, overflow_wrap)
+        await run_mac_test(dut, format_a, format_b, a_elements, b_elements, round_mode, overflow_wrap)


### PR DESCRIPTION
This submission implements mixed-precision support for the OCP MX Streaming MAC Unit, as outlined in Step 10 of the roadmap. The core multiplier logic now accepts independent format selections for both operands, allowing operations such as E4M3 multiplied by E5M2 or FP multiplied by INT8. The top-level state machine was updated to sample the additional format selection from `ui_in` during Cycle 2. The implementation was verified with a comprehensive test suite in cocotb, including randomized mixed-precision combinations.

Fixes #69

---
*PR created automatically by Jules for task [6047599370595506212](https://jules.google.com/task/6047599370595506212) started by @chatelao*