### PR TITLE
Add Step 17 to Roadmap: TT Dev Kit Testing

### DIFF
--- a/MXFP8_ROADMAP.md
+++ b/MXFP8_ROADMAP.md
@@ -115,3 +115,9 @@ This roadmap outlines the incremental development of the OCP MXFP8 Streaming MAC
 - **Tasks**:
   - Develop a serial-to-parallel interface for high-throughput hardware testing.
   - Compare FPGA results bit-for-bit with the Python reference model.
+
+### Step 17: Test on the TT Dev Kit
+- **Goal**: Verify the design on the [Tiny Tapeout Development Kit](https://store.tinytapeout.com/products/FPGA-Development-Kit-p813805747).
+- **Tasks**:
+  - Deploy the bitstream to the TT Dev Kit FPGA.
+  - Validate the 41-cycle streaming protocol using real hardware I/O.


### PR DESCRIPTION
Updated the OCP MX Streaming MAC Unit roadmap to include a new step for hardware-in-the-loop validation using the Tiny Tapeout Development Kit. This step (Step 17) focuses on verifying the RTL behavior and the 41-cycle streaming protocol on physical hardware.

Fixes #88

---
*PR created automatically by Jules for task [9570587419763386304](https://jules.google.com/task/9570587419763386304) started by @chatelao*