### PR TITLE
Add Step 18 to Roadmap for ASIC Validation

### DIFF
--- a/MXFP8_ROADMAP.md
+++ b/MXFP8_ROADMAP.md
@@ -123,3 +123,10 @@ This roadmap outlines the incremental development of the OCP MXFP8 Streaming MAC
 - **Tasks**:
   - Deploy the bitstream to the TT Dev Kit FPGA.
   - Validate the 41-cycle streaming protocol using real hardware I/O.
+
+### Step 18: Final ASIC Silicon Validation
+- **Goal**: Verify the fabricated OCP MX MAC Unit on the [TT Demo Board](https://github.com/TinyTapeout/tt-demo-pcb) using the TT Dev Kit.
+- **Tasks**:
+  - **Functional HIL Verification**: Use a Raspberry Pi Pico as a master controller to drive the 41-cycle streaming protocol, verifying results bit-accurately against the Python reference model.
+  - **Oscilloscope Characterization**: Measure protocol latency (from LOAD_SCALE to serialization) and clock jitter on the hardware.
+  - **Power Signature Analysis**: Analyze power consumption signatures during the STREAM phase using an oscilloscope to characterize the final silicon.


### PR DESCRIPTION
This change adds Step 18 to the `MXFP8_ROADMAP.md` file, outlining the final validation phase for the OCP MX MAC Unit on the fabricated ASIC. The step includes an in-depth verification plan using the Tiny Tapeout Demo Board and a Raspberry Pi Pico as a controller, along with oscilloscope-based characterization of latency, jitter, and power consumption.

Fixes #90

---
*PR created automatically by Jules for task [367740936754323198](https://jules.google.com/task/367740936754323198) started by @chatelao*