### PR TITLE
Update diagram workflow with tred and 180s timeouts

### DIFF
--- a/.github/workflows/diagram.yaml
+++ b/.github/workflows/diagram.yaml
@@ -36,30 +36,30 @@ jobs:
 
           # 1. Standard Logic Diagram
           yosys -p "read_verilog $SOURCES; hierarchy -top $TOP_MODULE; proc; opt; show -format dot -prefix logic_diagram $TOP_MODULE"
-          timeout 300 dot -Tpng logic_diagram.dot -o logic_diagram.png
-          timeout 300 dot -Tsvg logic_diagram.dot -o logic_diagram.svg
+          timeout 180 dot -Tpng logic_diagram.dot -o logic_diagram.png
+          timeout 180 dot -Tsvg logic_diagram.dot -o logic_diagram.svg
+          timeout 180 bash -c "tred logic_diagram.dot | dot -Tpng > logic_diagram_tred.png"
+          timeout 180 bash -c "tred logic_diagram.dot | dot -Tsvg > logic_diagram_tred.svg"
 
           # 2. Flattened RTL Logic Diagram (Resolution level +/- between top-level and flatten)
           yosys -p "read_verilog $SOURCES; hierarchy -top $TOP_MODULE; proc; flatten; opt; show -format dot -prefix logic_diagram_rtl $TOP_MODULE"
-          timeout 300 dot -Tpng logic_diagram_rtl.dot -o logic_diagram_rtl.png
-          timeout 300 dot -Tsvg logic_diagram_rtl.dot -o logic_diagram_rtl.svg
+          timeout 180 dot -Tpng logic_diagram_rtl.dot -o logic_diagram_rtl.png
+          timeout 180 dot -Tsvg logic_diagram_rtl.dot -o logic_diagram_rtl.svg
+          timeout 180 bash -c "tred logic_diagram_rtl.dot | dot -Tpng > logic_diagram_rtl_tred.png"
+          timeout 180 bash -c "tred logic_diagram_rtl.dot | dot -Tsvg > logic_diagram_rtl_tred.svg"
 
           # 3. Optional Full Render (Gate-level & Transitive Reduction)
           if [[ "${{ github.event.inputs.full_render }}" == "true" ]]; then
             echo "Executing full render steps..."
 
-            # Tred for RTL
-            timeout 600 tred logic_diagram_rtl.dot | dot -T png > logic_diagram_rtl_tred.png
-            timeout 600 tred logic_diagram_rtl.dot | dot -T svg > logic_diagram_rtl_tred.svg
-
             # Gate-Level Diagram
             yosys -p "read_verilog $SOURCES; hierarchy -top $TOP_MODULE; proc; flatten; synth -top $TOP_MODULE; show -format dot -prefix logic_diagram_flattened $TOP_MODULE"
-            timeout 600 dot -Tpng logic_diagram_flattened.dot -o logic_diagram_flattened.png
-            timeout 600 dot -Tsvg logic_diagram_flattened.dot -o logic_diagram_flattened.svg
+            timeout 180 dot -Tpng logic_diagram_flattened.dot -o logic_diagram_flattened.png
+            timeout 180 dot -Tsvg logic_diagram_flattened.dot -o logic_diagram_flattened.svg
 
             # Tred for Gate-Level
-            timeout 600 tred logic_diagram_flattened.dot | dot -T png > logic_diagram_flattened_tred.png
-            timeout 600 tred logic_diagram_flattened.dot | dot -T svg > logic_diagram_flattened_tred.svg
+            timeout 180 bash -c "tred logic_diagram_flattened.dot | dot -T png > logic_diagram_flattened_tred.png"
+            timeout 180 bash -c "tred logic_diagram_flattened.dot | dot -T svg > logic_diagram_flattened_tred.svg"
           fi
 
       - name: Upload Diagram Artifacts


### PR DESCRIPTION
Integrated `tred` (transitive reduction) into the standard logic and RTL diagram generation steps in `.github/workflows/diagram.yaml`. Updated all rendering timeouts to a strict 180 seconds (3 minutes) to prevent hung processes and optimized the "Full Render" section by removing redundant steps and using `bash -c` for piped commands to ensure timeouts are respected across the entire pipeline. Verified the changes by running functional tests and reviewing the workflow file.

Fixes #117

---
*PR created automatically by Jules for task [1292609889057179225](https://jules.google.com/task/1292609889057179225) started by @chatelao*