### PR TITLE
Mark sub-modules as mandatory/optional with emojis in DIE_SIZE_ANALYSIS.md

### DIFF
--- a/DIE_SIZE_ANALYSIS.md
+++ b/DIE_SIZE_ANALYSIS.md
@@ -11,18 +11,21 @@ The following diagram illustrates the high-level architecture and data flow betw
 
 ### Top 10 Area-Consuming Sub-modules/Components
 
+> ✅ Mandatory component for core MAC operation.
+> 🧩 Optional component (optimizable or removable via parameters).
+
 | Rank | Sub-module | Component | Complexity | Estimated Gates |
 |---|---|---|---|---|
-| 1 | `fp8_aligner` | 64-bit Barrel Shifter | Left/Right shift for elements + shared scales | ~800 |
-| 2 | `fp8_mul` | Operand Decoders (A/B) | 7-format support (E4M3, E5M2, FP6, FP4, INT8) | ~400 |
-| 3 | `fp8_mul` | 8x8 Combinatorial Multiplier | Mantissa product + signed integer mult | ~350 |
-| 4 | `tt_um_top` | Pipeline & Config Registers | ~100 DFFs for pipelining, scale/format storage | ~800 (eq) |
-| 5 | `fp8_aligner` | Sticky/Round-Bit Gen | 64-bit OR-reduction and muxing | ~250 |
-| 6 | `fp8_aligner` | 64-bit Rounding Adder | `base + 1` logic for CEL, FLR, RNE | ~200 |
-| 7 | `accumulator` | 32-bit Signed Adder | Core dot-product accumulation | ~180 |
-| 8 | `tt_um_top` | Control FSM & Logic | 6-bit counter and 41-cycle state transitions | ~180 |
-| 9 | `fp8_mul` | Exponent Arithmetic | Biased addition/subtraction for 7 formats | ~150 |
-| 10 | `fp8_aligner` | Saturation & Overflow | 32-bit signed clamping and wrapping muxes | ~120 |
+| 1 | 🧩 `fp8_aligner` | 64-bit Barrel Shifter | Left/Right shift for elements + shared scales | ~800 |
+| 2 | 🧩 `fp8_mul` | Operand Decoders (A/B) | 7-format support (E4M3, E5M2, FP6, FP4, INT8) | ~400 |
+| 3 | ✅ `fp8_mul` | 8x8 Combinatorial Multiplier | Mantissa product + signed integer mult | ~350 |
+| 4 | ✅ `tt_um_top` | Pipeline & Config Registers | ~100 DFFs for pipelining, scale/format storage | ~800 (eq) |
+| 5 | ✅ `fp8_aligner` | Sticky/Round-Bit Gen | 64-bit OR-reduction and muxing | ~250 |
+| 6 | 🧩 `fp8_aligner` | 64-bit Rounding Adder | `base + 1` logic for CEL, FLR, RNE | ~200 |
+| 7 | ✅ `accumulator` | 32-bit Signed Adder | Core dot-product accumulation | ~180 |
+| 8 | ✅ `tt_um_top` | Control FSM & Logic | 6-bit counter and 41-cycle state transitions | ~180 |
+| 9 | ✅ `fp8_mul` | Exponent Arithmetic | Biased addition/subtraction for 7 formats | ~150 |
+| 10 | ✅ `fp8_aligner` | Saturation & Overflow | 32-bit signed clamping and wrapping muxes | ~120 |
 | **Total** | | | | **~3430** |
 
 *Note: Gate counts are NAND2 equivalents based on RTL architectural complexity and bit-widths.*


### PR DESCRIPTION
This change updates the `DIE_SIZE_ANALYSIS.md` document to provide better visual context for hardware optimization. By marking sub-modules as mandatory (✅) or optional (🧩), it becomes clearer which components are essential for the core MAC operation and which ones can be pruned or optimized to fit smaller tile sizes (like the 1x1 Tiny Tapeout tile).

Key changes:
- Added a legend explaining the ✅ and 🧩 emojis.
- Updated all 10 rows in the area-consumption table with the appropriate status emoji.
- Verified that the changes are correctly formatted and that existing tests still pass.

Fixes #119

---
*PR created automatically by Jules for task [7584435752269198965](https://jules.google.com/task/7584435752269198965) started by @chatelao*