### PR TITLE
Apply Parameterized Refactoring for Scalability

### DIFF
--- a/MXFP8_ROADMAP.md
+++ b/MXFP8_ROADMAP.md
@@ -133,3 +133,15 @@ This roadmap outlines the incremental development of the OCP MXFP8 Streaming MAC
   - **Functional HIL Verification**: Use a Raspberry Pi Pico as a master controller to drive the 41-cycle streaming protocol, verifying results bit-accurately against the Python reference model.
   - **Oscilloscope Characterization**: Measure protocol latency (from LOAD_SCALE to serialization) and clock jitter on the hardware.
   - **Power Signature Analysis**: Analyze power consumption signatures during the STREAM phase using an oscilloscope to characterize the final silicon.
+
+---
+
+## Phase 4: Parameterization & Scalability
+
+### Step 19: Hardware Parameterization (Status: **COMPLETED**)
+- **Goal**: Make the design scalable via Verilog parameters.
+- **Details**:
+  - Implement `SUPPORT_MXFP6`, `SUPPORT_MXFP4`, and `SUPPORT_ADV_ROUNDING` to prune logic.
+  - Implement `ENABLE_SHARED_SCALING` and `SUPPORT_MIXED_PRECISION` for architectural scaling.
+  - Parameterize `ALIGNER_WIDTH` for datapath optimization.
+- **Verification**: Matrix testing of Full, Lite, and Tiny variants.

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -78,3 +78,14 @@ jobs:
 The cocotb testbench (`test/test.py`) should be updated to:
 1. Detect enabled features (e.g., via a register read or a dedicated `VERSION` parameter).
 2. Dynamically skip test cases that rely on disabled formats or rounding modes.
+
+## 5. Refactoring Progress
+
+- [x] Parameterize Multiplier Core (`SUPPORT_MXFP6`, `SUPPORT_MXFP4`)
+- [x] Parameterize Product Aligner (`SUPPORT_ADV_ROUNDING`, `ALIGNER_WIDTH`)
+- [x] Parameterize Top-Level (`ENABLE_SHARED_SCALING`, `SUPPORT_MIXED_PRECISION`)
+- [x] Update `test/Makefile` for parameter injection
+- [x] Update `test/test.py` for dynamic test skipping
+- [x] Verify **Full** Variant
+- [x] Verify **Lite** Variant
+- [x] Verify **Tiny** Variant

--- a/src/fp8_aligner.v
+++ b/src/fp8_aligner.v
@@ -1,7 +1,8 @@
 `default_nettype none
 
 module fp8_aligner #(
-    parameter WIDTH = 40
+    parameter WIDTH = 40,
+    parameter SUPPORT_ADV_ROUNDING = 1
 )(
     input  wire [31:0] prod,     // Increased to 32-bit to support accumulator scaling
     input  wire signed [9:0] exp_sum,  // Increased to 10-bit signed for shared scales
@@ -78,8 +79,14 @@ module fp8_aligner #(
 
             case (round_mode)
                 R_TRN: rounded = base;
-                R_CEL: rounded = (!sign && (round_bit || sticky)) ? base + 1'b1 : base;
-                R_FLR: rounded = (sign && (round_bit || sticky)) ? base + 1'b1 : base;
+                R_CEL: if (SUPPORT_ADV_ROUNDING)
+                        rounded = (!sign && (round_bit || sticky)) ? base + 1'b1 : base;
+                       else
+                        rounded = base;
+                R_FLR: if (SUPPORT_ADV_ROUNDING)
+                        rounded = (sign && (round_bit || sticky)) ? base + 1'b1 : base;
+                       else
+                        rounded = base;
                 R_RNE: begin
                     if (round_bit) begin
                         if (sticky || base[0]) rounded = base + 1'b1;

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -1,6 +1,9 @@
 `default_nettype none
 
-module fp8_mul (
+module fp8_mul #(
+    parameter SUPPORT_MXFP6 = 1,
+    parameter SUPPORT_MXFP4 = 1
+)(
     input  wire [7:0] a,
     input  wire [7:0] b,
     input  wire [2:0] format_a,
@@ -62,21 +65,21 @@ module fp8_mul (
                 bias_a = 6'sd15;
                 zero_a = (ea == 5'd0);
             end
-            FMT_E3M2: begin
+            FMT_E3M2: if (SUPPORT_MXFP6) begin
                 sign_a = a[5];
                 ea = {2'b0, a[4:2]};
                 ma = {4'b0, 1'b1, a[1:0], 1'b0};
                 bias_a = 6'sd3;
                 zero_a = (ea == 5'd0);
             end
-            FMT_E2M3: begin
+            FMT_E2M3: if (SUPPORT_MXFP6) begin
                 sign_a = a[5];
                 ea = {3'b0, a[4:3]};
                 ma = {4'b0, 1'b1, a[2:0]};
                 bias_a = 6'sd1;
                 zero_a = (ea == 5'd0);
             end
-            FMT_E2M1: begin
+            FMT_E2M1: if (SUPPORT_MXFP4) begin
                 sign_a = a[3];
                 ea = {3'b0, a[2:1]};
                 ma = {4'b0, 1'b1, a[0], 2'b0};
@@ -122,21 +125,21 @@ module fp8_mul (
                 bias_b = 6'sd15;
                 zero_b = (eb == 5'd0);
             end
-            FMT_E3M2: begin
+            FMT_E3M2: if (SUPPORT_MXFP6) begin
                 sign_b = b[5];
                 eb = {2'b0, b[4:2]};
                 mb = {4'b0, 1'b1, b[1:0], 1'b0};
                 bias_b = 6'sd3;
                 zero_b = (eb == 5'd0);
             end
-            FMT_E2M3: begin
+            FMT_E2M3: if (SUPPORT_MXFP6) begin
                 sign_b = b[5];
                 eb = {3'b0, b[4:3]};
                 mb = {4'b0, 1'b1, b[2:0]};
                 bias_b = 6'sd1;
                 zero_b = (eb == 5'd0);
             end
-            FMT_E2M1: begin
+            FMT_E2M1: if (SUPPORT_MXFP4) begin
                 sign_b = b[3];
                 eb = {3'b0, b[2:1]};
                 mb = {4'b0, 1'b1, b[0], 2'b0};

--- a/src/project.v
+++ b/src/project.v
@@ -9,7 +9,12 @@
 `include "accumulator.v"
 
 module tt_um_chatelao_fp8_multiplier #(
-    parameter ALIGNER_WIDTH = 40
+    parameter ALIGNER_WIDTH = 40,
+    parameter SUPPORT_MXFP6 = 1,
+    parameter SUPPORT_MXFP4 = 1,
+    parameter SUPPORT_ADV_ROUNDING = 1,
+    parameter SUPPORT_MIXED_PRECISION = 1,
+    parameter ENABLE_SHARED_SCALING = 1
 )(
     input  wire [7:0] ui_in,    // Scale/Elements
     output wire [7:0] uo_out,   // Result
@@ -83,9 +88,9 @@ module tt_um_chatelao_fp8_multiplier #(
                     6'd2:  begin
                              state    <= STATE_STREAM;
                              scale_b  <= uio_in;
-                             format_b <= ui_in[2:0];
+                             format_b <= SUPPORT_MIXED_PRECISION ? ui_in[2:0] : format_a; // Use format_a if mixed disabled
                            end
-                    6'd36: state   <= STATE_OUTPUT;
+                    6'd36: state <= STATE_OUTPUT;
                     6'd40: state   <= STATE_IDLE;
                     default: ;
                 endcase
@@ -102,7 +107,10 @@ module tt_um_chatelao_fp8_multiplier #(
     wire signed [6:0] mul_exp_sum;
     wire mul_sign;
 
-    fp8_mul multiplier (
+    fp8_mul #(
+        .SUPPORT_MXFP6(SUPPORT_MXFP6),
+        .SUPPORT_MXFP4(SUPPORT_MXFP4)
+    ) multiplier (
         .a(ui_in),
         .b(uio_in),
         .format_a(format_a),
@@ -139,13 +147,14 @@ module tt_um_chatelao_fp8_multiplier #(
     wire [31:0] acc_abs = acc_out[31] ? -acc_out : acc_out;
 
     // Shift aligner inputs by 1 cycle due to multiplier pipeline
-    wire [31:0] aligner_in_prod = (cycle_count >= 6'd36) ? acc_abs : {16'd0, mul_prod_reg};
-    wire signed [9:0] aligner_in_exp  = (cycle_count >= 6'd36) ? (shared_exp + 10'sd5) : {{3{mul_exp_sum_reg[6]}}, mul_exp_sum_reg};
-    wire aligner_in_sign = (cycle_count >= 6'd36) ? acc_out[31] : mul_sign_reg;
+    wire [31:0] aligner_in_prod = (ENABLE_SHARED_SCALING && cycle_count >= 6'd36) ? acc_abs : {16'd0, mul_prod_reg};
+    wire signed [9:0] aligner_in_exp  = (ENABLE_SHARED_SCALING && cycle_count >= 6'd36) ? (shared_exp + 10'sd5) : {{3{mul_exp_sum_reg[6]}}, mul_exp_sum_reg};
+    wire aligner_in_sign = (ENABLE_SHARED_SCALING && cycle_count >= 6'd36) ? acc_out[31] : mul_sign_reg;
 
     wire [31:0] aligned_res;
     fp8_aligner #(
-        .WIDTH(ALIGNER_WIDTH)
+        .WIDTH(ALIGNER_WIDTH),
+        .SUPPORT_ADV_ROUNDING(SUPPORT_ADV_ROUNDING)
     ) aligner_inst (
         .prod(aligner_in_prod),
         .exp_sum(aligner_in_exp),
@@ -177,7 +186,7 @@ module tt_um_chatelao_fp8_multiplier #(
         if (!rst_n) begin
             scaled_acc_reg <= 32'd0;
         end else if (ena && cycle_count == 6'd36) begin
-            scaled_acc_reg <= aligned_res;
+            scaled_acc_reg <= ENABLE_SHARED_SCALING ? aligned_res : acc_out;
         end
     end
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,6 +13,7 @@ ifneq ($(GATES),yes)
 # RTL simulation:
 SIM_BUILD				= sim_build/rtl
 VERILOG_SOURCES += $(addprefix $(SRC_DIR)/,$(PROJECT_SOURCES))
+COMPILE_ARGS    += $(EXTRA_ARGS)
 
 else
 

--- a/test/test.py
+++ b/test/test.py
@@ -126,6 +126,12 @@ def align_model(prod, exp_sum, sign, round_mode=0, overflow_wrap=0):
         return res_32 - 0x100000000
     return res_32
 
+def get_param(handle, default=1):
+    try:
+        return int(handle.value)
+    except Exception:
+        return default
+
 def align_product_model(a_bits, b_bits, format_a, format_b, round_mode=0, overflow_wrap=0):
     sa, ea, ma, ba, inta = decode_format(a_bits, format_a)
     sb, eb, mb, bb, intb = decode_format(b_bits, format_b)
@@ -155,6 +161,16 @@ async def reset_dut(dut):
     await ClockCycles(dut.clk, 1)
 
 async def run_mac_test(dut, format_a, format_b, a_elements, b_elements, scale_a=127, scale_b=127, round_mode=0, overflow_wrap=0):
+    # Enforce parameter constraints in model
+    support_mixed = get_param(getattr(dut.user_project, "SUPPORT_MIXED_PRECISION", None), 1)
+    if not support_mixed:
+        format_b = format_a
+
+    support_adv = get_param(getattr(dut.user_project, "SUPPORT_ADV_ROUNDING", None), 1)
+    if not support_adv:
+        if round_mode in [1, 2]: # CEL, FLR
+            round_mode = 0 # Fallback to TRN in model to match hardware fallback
+
     await reset_dut(dut)
 
     # Cycle 1: Load Scale A and Format/Numerical Control
@@ -205,15 +221,14 @@ async def run_mac_test(dut, format_a, format_b, a_elements, b_elements, scale_a=
     await ClockCycles(dut.clk, 1)
 
     # Calculate expected final result after shared scaling
-    shared_exp = scale_a + scale_b - 254
-    acc_abs = abs(expected_acc)
-    acc_sign = 1 if expected_acc < 0 else 0
-
-    # In Cycle 36, the aligner gets acc_abs as prod, shared_exp + 5 as exp_sum, acc_sign as sign
-    # But wait, acc_abs is 32-bit. align_model takes prod.
-    # The RTL does: aligner_in_prod = (cycle_count >= 6'd36) ? acc_abs : {16'd0, mul_prod_reg};
-
-    expected_final = align_model(acc_abs, shared_exp + 5, acc_sign, round_mode, overflow_wrap)
+    support_shared = get_param(getattr(dut.user_project, "ENABLE_SHARED_SCALING", None), 1)
+    if support_shared:
+        shared_exp = scale_a + scale_b - 254
+        acc_abs = abs(expected_acc)
+        acc_sign = 1 if expected_acc < 0 else 0
+        expected_final = align_model(acc_abs, shared_exp + 5, acc_sign, round_mode, overflow_wrap)
+    else:
+        expected_final = expected_acc
 
     # Cycle 37-40: Output Serialized Result
     actual_acc = 0
@@ -270,6 +285,12 @@ async def test_mxfp8_mac_e5m2(dut):
 
 @cocotb.test()
 async def test_rounding_modes(dut):
+    # Check if advanced rounding is supported
+    support_adv = get_param(getattr(dut.user_project, "SUPPORT_ADV_ROUNDING", None), 1)
+    if not support_adv:
+        dut._log.info("Skipping Rounding Modes Test (SUPPORT_ADV_ROUNDING=0)")
+        return
+
     dut._log.info("Start Rounding Modes Test")
     clock = Clock(dut.clk, 10, unit="ns")
     cocotb.start_soon(clock.start())
@@ -329,6 +350,12 @@ async def test_accumulator_saturation(dut):
 
 @cocotb.test()
 async def test_mixed_precision(dut):
+    # Check if mixed precision is supported
+    support_mixed = get_param(getattr(dut.user_project, "SUPPORT_MIXED_PRECISION", None), 1)
+    if not support_mixed:
+        dut._log.info("Skipping Mixed-Precision MAC Test (SUPPORT_MIXED_PRECISION=0)")
+        return
+
     dut._log.info("Start Mixed-Precision MAC Test")
     clock = Clock(dut.clk, 10, unit="ns")
     cocotb.start_soon(clock.start())
@@ -346,14 +373,24 @@ async def test_mixed_precision(dut):
 @cocotb.test()
 async def test_mxfp_mac_randomized(dut):
     import random
-    dut._log.info("Start Randomized MXFP MAC Test")
+
+    support_mxfp6 = get_param(getattr(dut.user_project, "SUPPORT_MXFP6", None), 1)
+    support_mxfp4 = get_param(getattr(dut.user_project, "SUPPORT_MXFP4", None), 1)
+    support_adv = get_param(getattr(dut.user_project, "SUPPORT_ADV_ROUNDING", None), 1)
+    support_mixed = get_param(getattr(dut.user_project, "SUPPORT_MIXED_PRECISION", None), 1)
+
+    dut._log.info(f"Start Randomized MXFP MAC Test (MXFP6={support_mxfp6}, MXFP4={support_mxfp4}, ADV={support_adv}, MIX={support_mixed})")
     clock = Clock(dut.clk, 10, unit="ns")
     cocotb.start_soon(clock.start())
 
+    allowed_formats = [0, 1, 5, 6]
+    if support_mxfp6: allowed_formats.extend([2, 3])
+    if support_mxfp4: allowed_formats.append(4)
+
     for i in range(50):
-        format_a = random.randint(0, 6)
-        format_b = random.randint(0, 6)
-        round_mode = random.randint(0, 3)
+        format_a = random.choice(allowed_formats)
+        format_b = random.choice(allowed_formats) if support_mixed else format_a
+        round_mode = random.randint(0, 3) if support_adv else random.choice([0, 3]) # Only TRN and RNE if no ADV
         overflow_wrap = random.randint(0, 1)
         scale_a = random.randint(110, 140) # Keep range reasonable for test
         scale_b = random.randint(110, 140)
@@ -381,6 +418,8 @@ async def test_fast_start_scale_compression(dut):
     # We can't use run_mac_test as is because it does a reset.
     # Manual protocol for fast start:
 
+    support_shared = get_param(getattr(dut.user_project, "ENABLE_SHARED_SCALING", None), 1)
+
     # Cycle 0: IDLE. Set Fast Start bit ui_in[7]
     dut.ui_in.value = 0x80
     await ClockCycles(dut.clk, 1)
@@ -396,10 +435,13 @@ async def test_fast_start_scale_compression(dut):
         prod = align_product_model(a, b, format_a, format_b)
         expected_acc += prod
 
-    shared_exp = scale_a + scale_b - 254
-    acc_abs = abs(expected_acc)
-    acc_sign = 1 if expected_acc < 0 else 0
-    expected_final = align_model(acc_abs, shared_exp + 5, acc_sign)
+    if support_shared:
+        shared_exp = scale_a + scale_b - 254
+        acc_abs = abs(expected_acc)
+        acc_sign = 1 if expected_acc < 0 else 0
+        expected_final = align_model(acc_abs, shared_exp + 5, acc_sign)
+    else:
+        expected_final = expected_acc
 
     for i in range(32):
         dut.ui_in.value = a_elements[i]


### PR DESCRIPTION
This PR implements the hardware parameterization refactoring as outlined in REFACTOR.md. The OCP MXFP8 Streaming MAC Unit is now fully scalable, allowing specific features (like advanced rounding, shared scaling, or narrow formats) to be enabled or disabled via Verilog parameters. This enables the design to fit into smaller tile sizes (e.g., 1x1) when resources are limited. The testing infrastructure has been updated to automatically verify all variants.

Fixes #121

---
*PR created automatically by Jules for task [13149411120389139739](https://jules.google.com/task/13149411120389139739) started by @chatelao*