### PR TITLE
Update documentation for 40-bit barrel shifter optimization

### DIFF
--- a/DIE_SIZE_ANALYSIS.md
+++ b/DIE_SIZE_ANALYSIS.md
@@ -16,12 +16,12 @@ The following diagram illustrates the high-level architecture and data flow betw
 
 | Rank | Sub-module | Component | Complexity | Estimated Gates |
 |---|---|---|---|---|
-| 1 | 🧩 `fp8_aligner` | 64-bit Barrel Shifter | Left/Right shift for elements + shared scales | ~800 |
+| 1 | 🧩 `fp8_aligner` | 40-bit Barrel Shifter | Left/Right shift for elements + shared scales | ~800 |
 | 2 | 🧩 `fp8_mul` | Operand Decoders (A/B) | 7-format support (E4M3, E5M2, FP6, FP4, INT8) | ~400 |
 | 3 | ✅ `fp8_mul` | 8x8 Combinatorial Multiplier | Mantissa product + signed integer mult | ~350 |
 | 4 | ✅ `tt_um_top` | Pipeline & Config Registers | ~100 DFFs for pipelining, scale/format storage | ~800 (eq) |
-| 5 | ✅ `fp8_aligner` | Sticky/Round-Bit Gen | 64-bit OR-reduction and muxing | ~250 |
-| 6 | 🧩 `fp8_aligner` | 64-bit Rounding Adder | `base + 1` logic for CEL, FLR, RNE | ~200 |
+| 5 | ✅ `fp8_aligner` | Sticky/Round-Bit Gen | 40-bit OR-reduction and muxing | ~250 |
+| 6 | 🧩 `fp8_aligner` | 40-bit Rounding Adder | `base + 1` logic for CEL, FLR, RNE | ~200 |
 | 7 | ✅ `accumulator` | 32-bit Signed Adder | Core dot-product accumulation | ~180 |
 | 8 | ✅ `tt_um_top` | Control FSM & Logic | 6-bit counter and 41-cycle state transitions | ~180 |
 | 9 | ✅ `fp8_mul` | Exponent Arithmetic | Biased addition/subtraction for 7 formats | ~150 |


### PR DESCRIPTION
Updated `DIE_SIZE_ANALYSIS.md` to correctly describe the `fp8_aligner` components as 40-bit instead of 64-bit. This correction brings the 'Current Die Size Analysis' section in line with the optimized 40-bit internal datapath implemented in RTL and previously marked as 'COMPLETED' in the optimization roadmap. Functional correctness was verified by running the full Cocotb test suite.

Fixes #133

---
*PR created automatically by Jules for task [2329251323575711893](https://jules.google.com/task/2329251323575711893) started by @chatelao*