### PR TITLE
Fix GH Action Workflow - Gate Analysis Synthesis Failure

### DIFF
--- a/src/accumulator.v
+++ b/src/accumulator.v
@@ -1,34 +1,36 @@
 `default_nettype none
 
-module accumulator (
+module accumulator #(
+    parameter WIDTH = 32
+)(
     input  wire        clk,
     input  wire        rst_n,
     input  wire        clear,   // Synchronous clear (at LOAD_SCALE)
     input  wire        en,      // Enable accumulation (during STREAM)
     input  wire        overflow_wrap, // Configurable overflow method
-    input  wire [31:0] data_in, // 32-bit signed aligned product
-    output reg  [31:0] data_out // 32-bit signed sum
+    input  wire [WIDTH-1:0] data_in, // signed aligned product
+    output reg  [WIDTH-1:0] data_out // signed sum
 );
 
-    // 33-bit sum to detect overflow
+    // full sum to detect overflow
     /* verilator lint_off UNUSEDSIGNAL */
-    wire signed [32:0] sum_full = $signed({data_out[31], data_out}) + $signed({data_in[31], data_in});
+    wire signed [WIDTH:0] sum_full = $signed({data_out[WIDTH-1], data_out}) + $signed({data_in[WIDTH-1], data_in});
     /* verilator lint_on UNUSEDSIGNAL */
-    wire [31:0] sum = sum_full[31:0];
+    wire [WIDTH-1:0] sum = sum_full[WIDTH-1:0];
 
-    // Check overflow: signs of inputs are same, but sign of 32-bit sum is different.
-    wire overflow = (data_out[31] == data_in[31]) && (sum[31] != data_out[31]);
+    // Check overflow: signs of inputs are same, but sign of sum is different.
+    wire overflow = (data_out[WIDTH-1] == data_in[WIDTH-1]) && (sum[WIDTH-1] != data_out[WIDTH-1]);
 
     always @(posedge clk) begin
         if (!rst_n) begin
-            data_out <= 32'd0;
+            data_out <= {WIDTH{1'b0}};
         end else if (clear) begin
-            data_out <= 32'd0;
+            data_out <= {WIDTH{1'b0}};
         end else if (en) begin
             if (overflow && !overflow_wrap) begin
-                data_out <= data_out[31] ? 32'h80000000 : 32'h7FFFFFFF;
+                data_out <= data_out[WIDTH-1] ? {1'b1, {(WIDTH-1){1'b0}}} : {1'b0, {(WIDTH-1){1'b1}}};
             end else begin
-                data_out <= sum[31:0];
+                data_out <= sum[WIDTH-1:0];
             end
         end
     end

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -3,7 +3,8 @@
 module fp8_mul #(
     parameter SUPPORT_E5M2  = 1,
     parameter SUPPORT_MXFP6 = 1,
-    parameter SUPPORT_MXFP4 = 1
+    parameter SUPPORT_MXFP4 = 1,
+    parameter SUPPORT_INT8  = 1
 )(
     input  wire [7:0] a,
     input  wire [7:0] b,
@@ -87,14 +88,14 @@ module fp8_mul #(
                 bias_a = 6'sd1;
                 zero_a = (ea == 5'd0);
             end
-            FMT_INT8: begin
+            FMT_INT8: if (SUPPORT_INT8) begin
                 sign_a = a[7];
                 ma = a[7] ? -a : a;
                 ea = 5'd0;
                 bias_a = 6'sd3;
                 zero_a = (a == 8'd0);
             end
-            FMT_INT8_SYM: begin
+            FMT_INT8_SYM: if (SUPPORT_INT8) begin
                 sign_a = a[7];
                 ma = (a == 8'h80) ? 8'd127 : (a[7] ? -a : a);
                 ea = 5'd0;
@@ -147,14 +148,14 @@ module fp8_mul #(
                 bias_b = 6'sd1;
                 zero_b = (eb == 5'd0);
             end
-            FMT_INT8: begin
+            FMT_INT8: if (SUPPORT_INT8) begin
                 sign_b = b[7];
                 mb = b[7] ? -b : b;
                 eb = 5'd0;
                 bias_b = 6'sd3;
                 zero_b = (b == 8'd0);
             end
-            FMT_INT8_SYM: begin
+            FMT_INT8_SYM: if (SUPPORT_INT8) begin
                 sign_b = b[7];
                 mb = (b == 8'h80) ? 8'd127 : (b[7] ? -b : b);
                 eb = 5'd0;
@@ -170,8 +171,11 @@ module fp8_mul #(
             end
         endcase
 
-        // 8x8 Multiplier
-        p_res = (zero_a || zero_b) ? 16'd0 : (ma * mb);
+        // 8x8 or 4x4 Multiplier
+        if (SUPPORT_INT8)
+            p_res = (zero_a || zero_b) ? 16'd0 : (ma * mb);
+        else
+            p_res = (zero_a || zero_b) ? 16'd0 : {8'd0, ma[3:0] * mb[3:0]};
         sign_res = sign_a ^ sign_b;
         exp_sum_res = $signed({2'b0, ea}) + $signed({2'b0, eb}) - ($signed(bias_a) + $signed(bias_b) - 7'sd7);
     end

--- a/src/project.v
+++ b/src/project.v
@@ -10,9 +10,12 @@
 
 module tt_um_chatelao_fp8_multiplier #(
     parameter ALIGNER_WIDTH = 40,
+    parameter ACCUMULATOR_WIDTH = 32,
     parameter SUPPORT_E5M2  = 1,
     parameter SUPPORT_MXFP6 = 1,
     parameter SUPPORT_MXFP4 = 1,
+    parameter SUPPORT_INT8  = 1,
+    parameter SUPPORT_PIPELINING = 1,
     parameter SUPPORT_ADV_ROUNDING = 1,
     parameter SUPPORT_MIXED_PRECISION = 1,
     parameter ENABLE_SHARED_SCALING = 1
@@ -111,7 +114,8 @@ module tt_um_chatelao_fp8_multiplier #(
     fp8_mul #(
         .SUPPORT_E5M2(SUPPORT_E5M2),
         .SUPPORT_MXFP6(SUPPORT_MXFP6),
-        .SUPPORT_MXFP4(SUPPORT_MXFP4)
+        .SUPPORT_MXFP4(SUPPORT_MXFP4),
+        .SUPPORT_INT8(SUPPORT_INT8)
     ) multiplier (
         .a(ui_in),
         .b(uio_in),
@@ -145,13 +149,16 @@ module tt_um_chatelao_fp8_multiplier #(
 
     // 3. Aligner Multiplexing
     // We reuse the fp8_aligner for both element alignment and final shared scaling.
-    wire [31:0] acc_out;
-    wire [31:0] acc_abs = acc_out[31] ? -acc_out : acc_out;
+    wire [ACCUMULATOR_WIDTH-1:0] acc_out;
+    wire [ACCUMULATOR_WIDTH-1:0] acc_abs = acc_out[ACCUMULATOR_WIDTH-1] ? -acc_out : acc_out;
 
-    // Shift aligner inputs by 1 cycle due to multiplier pipeline
-    wire [31:0] aligner_in_prod = (ENABLE_SHARED_SCALING && cycle_count >= 6'd36) ? acc_abs : {16'd0, mul_prod_reg};
-    wire signed [9:0] aligner_in_exp  = (ENABLE_SHARED_SCALING && cycle_count >= 6'd36) ? (shared_exp + 10'sd5) : {{3{mul_exp_sum_reg[6]}}, mul_exp_sum_reg};
-    wire aligner_in_sign = (ENABLE_SHARED_SCALING && cycle_count >= 6'd36) ? acc_out[31] : mul_sign_reg;
+    // Shift aligner inputs by 1 cycle due to multiplier pipeline (if enabled)
+    wire [31:0] aligner_in_prod = (ENABLE_SHARED_SCALING && cycle_count >= 6'd36) ?
+                                    (ACCUMULATOR_WIDTH > 32 ? acc_abs[31:0] : {{(32-ACCUMULATOR_WIDTH){1'b0}}, acc_abs}) :
+                                    {16'd0, SUPPORT_PIPELINING ? mul_prod_reg : mul_prod};
+    wire signed [9:0] aligner_in_exp  = (ENABLE_SHARED_SCALING && cycle_count >= 6'd36) ? (shared_exp + 10'sd5) :
+                                    (SUPPORT_PIPELINING ? {{3{mul_exp_sum_reg[6]}}, mul_exp_sum_reg} : {{3{mul_exp_sum[6]}}, mul_exp_sum});
+    wire aligner_in_sign = (ENABLE_SHARED_SCALING && cycle_count >= 6'd36) ? acc_out[ACCUMULATOR_WIDTH-1] : (SUPPORT_PIPELINING ? mul_sign_reg : mul_sign);
 
     wire [31:0] aligned_res;
     fp8_aligner #(
@@ -168,16 +175,21 @@ module tt_um_chatelao_fp8_multiplier #(
 
     // 4. Accumulator Control
     // With multiplier pipelining, aligned products are ready at cycles 4 to 35.
-    wire acc_en    = (cycle_count >= 6'd4 && cycle_count <= 6'd35) && (state == STATE_STREAM || state == STATE_OUTPUT);
+    // Without pipelining, they are ready at cycles 3 to 34.
+    wire acc_en    = SUPPORT_PIPELINING ?
+                     ((cycle_count >= 6'd4 && cycle_count <= 6'd35) && (state == STATE_STREAM || state == STATE_OUTPUT)) :
+                     ((cycle_count >= 6'd3 && cycle_count <= 6'd34) && (state == STATE_STREAM));
     wire acc_clear = (cycle_count <= 6'd2) && (state != STATE_STREAM);
 
-    accumulator acc_inst (
+    accumulator #(
+        .WIDTH(ACCUMULATOR_WIDTH)
+    ) acc_inst (
         .clk(clk),
         .rst_n(rst_n),
         .clear(acc_clear),
         .en(acc_en),
         .overflow_wrap(overflow_wrap),
-        .data_in(aligned_res),
+        .data_in(aligned_res[ACCUMULATOR_WIDTH-1:0]),
         .data_out(acc_out)
     );
 
@@ -188,7 +200,8 @@ module tt_um_chatelao_fp8_multiplier #(
         if (!rst_n) begin
             scaled_acc_reg <= 32'd0;
         end else if (ena && cycle_count == 6'd36) begin
-            scaled_acc_reg <= ENABLE_SHARED_SCALING ? aligned_res : acc_out;
+            scaled_acc_reg <= ENABLE_SHARED_SCALING ? aligned_res :
+                              (ACCUMULATOR_WIDTH > 32 ? acc_out[31:0] : {{(32-ACCUMULATOR_WIDTH){acc_out[ACCUMULATOR_WIDTH-1]}}, acc_out});
         end
     end
 

--- a/test/gate_analysis.py
+++ b/test/gate_analysis.py
@@ -26,6 +26,7 @@ def get_yosys_stats(params):
 
 def main():
     features = [
+        "SUPPORT_E5M2",
         "SUPPORT_MXFP6",
         "SUPPORT_MXFP4",
         "SUPPORT_INT8",

--- a/test/tb.v
+++ b/test/tb.v
@@ -24,9 +24,12 @@ module tb ();
   wire [7:0] uio_oe;
 
   parameter ALIGNER_WIDTH = 40;
+  parameter ACCUMULATOR_WIDTH = 32;
   parameter SUPPORT_E5M2 = 1;
   parameter SUPPORT_MXFP6 = 1;
   parameter SUPPORT_MXFP4 = 1;
+  parameter SUPPORT_INT8 = 1;
+  parameter SUPPORT_PIPELINING = 1;
   parameter SUPPORT_ADV_ROUNDING = 1;
   parameter SUPPORT_MIXED_PRECISION = 1;
   parameter ENABLE_SHARED_SCALING = 1;
@@ -47,9 +50,12 @@ module tb ();
   // RTL simulation instantiation (with parameters)
   tt_um_chatelao_fp8_multiplier #(
       .ALIGNER_WIDTH(ALIGNER_WIDTH),
+      .ACCUMULATOR_WIDTH(ACCUMULATOR_WIDTH),
       .SUPPORT_E5M2(SUPPORT_E5M2),
       .SUPPORT_MXFP6(SUPPORT_MXFP6),
       .SUPPORT_MXFP4(SUPPORT_MXFP4),
+      .SUPPORT_INT8(SUPPORT_INT8),
+      .SUPPORT_PIPELINING(SUPPORT_PIPELINING),
       .SUPPORT_ADV_ROUNDING(SUPPORT_ADV_ROUNDING),
       .SUPPORT_MIXED_PRECISION(SUPPORT_MIXED_PRECISION),
       .ENABLE_SHARED_SCALING(ENABLE_SHARED_SCALING)

--- a/test/test.py
+++ b/test/test.py
@@ -133,7 +133,7 @@ def get_param(handle, default=1):
         return default
 
 def align_product_model(a_bits, b_bits, format_a, format_b, round_mode=0, overflow_wrap=0,
-                        support_e5m2=1, support_mxfp6=1, support_mxfp4=1):
+                        support_e5m2=1, support_mxfp6=1, support_mxfp4=1, support_int8=1):
     # Fallback for unsupported formats in hardware
     if not support_e5m2 and format_a == 1: return 0
     if not support_e5m2 and format_b == 1: return 0
@@ -141,6 +141,8 @@ def align_product_model(a_bits, b_bits, format_a, format_b, round_mode=0, overfl
     if not support_mxfp6 and format_b in [2, 3]: return 0
     if not support_mxfp4 and format_a == 4: return 0
     if not support_mxfp4 and format_b == 4: return 0
+    if not support_int8 and format_a in [5, 6]: return 0
+    if not support_int8 and format_b in [5, 6]: return 0
 
     sa, ea, ma, ba, inta = decode_format(a_bits, format_a)
     sb, eb, mb, bb, intb = decode_format(b_bits, format_b)
@@ -154,6 +156,10 @@ def align_product_model(a_bits, b_bits, format_a, format_b, round_mode=0, overfl
 
     real_ma = (8 + ma) if not inta else ma
     real_mb = (8 + mb) if not intb else mb
+
+    if not support_int8:
+        real_ma = real_ma & 0xF
+        real_mb = real_mb & 0xF
 
     prod = real_ma * real_mb
     exp_sum = ea + eb - (ba + bb - 7)
@@ -183,6 +189,8 @@ async def run_mac_test(dut, format_a, format_b, a_elements, b_elements, scale_a=
     support_e5m2 = get_param(getattr(dut.user_project, "SUPPORT_E5M2", None), 1)
     support_mxfp6 = get_param(getattr(dut.user_project, "SUPPORT_MXFP6", None), 1)
     support_mxfp4 = get_param(getattr(dut.user_project, "SUPPORT_MXFP4", None), 1)
+    support_int8 = get_param(getattr(dut.user_project, "SUPPORT_INT8", None), 1)
+    acc_width = get_param(getattr(dut.user_project, "ACCUMULATOR_WIDTH", None), 32)
 
     await reset_dut(dut)
 
@@ -200,24 +208,25 @@ async def run_mac_test(dut, format_a, format_b, a_elements, b_elements, scale_a=
     # Process elements in groups of 32
     for a, b in zip(a_elements, b_elements):
         prod = align_product_model(a, b, format_a, format_b, round_mode, overflow_wrap,
-                                   support_e5m2, support_mxfp6, support_mxfp4)
+                                   support_e5m2, support_mxfp6, support_mxfp4, support_int8)
 
-        acc_32 = expected_acc & 0xFFFFFFFF
-        prod_32 = prod & 0xFFFFFFFF
-        sum_32 = (acc_32 + prod_32) & 0xFFFFFFFF
+        mask = (1 << acc_width) - 1
+        acc_masked = expected_acc & mask
+        prod_masked = prod & mask
+        sum_masked = (acc_masked + prod_masked) & mask
 
         # Signed overflow check
-        s_acc = (acc_32 >> 31) & 1
-        s_prod = (prod_32 >> 31) & 1
-        s_res = (sum_32 >> 31) & 1
+        s_acc = (acc_masked >> (acc_width - 1)) & 1
+        s_prod = (prod_masked >> (acc_width - 1)) & 1
+        s_res = (sum_masked >> (acc_width - 1)) & 1
 
         if not overflow_wrap and (s_acc == s_prod) and (s_acc != s_res):
-            expected_acc_raw = 0x80000000 if s_acc == 1 else 0x7FFFFFFF
+            expected_acc_raw = (1 << (acc_width - 1)) if s_acc == 1 else (1 << (acc_width - 1)) - 1
         else:
-            expected_acc_raw = sum_32
+            expected_acc_raw = sum_masked
 
-        if expected_acc_raw & 0x80000000:
-            expected_acc = expected_acc_raw - 0x100000000
+        if expected_acc_raw & (1 << (acc_width - 1)):
+            expected_acc = expected_acc_raw - (1 << acc_width)
         else:
             expected_acc = expected_acc_raw
 
@@ -242,7 +251,11 @@ async def run_mac_test(dut, format_a, format_b, a_elements, b_elements, scale_a=
         acc_sign = 1 if expected_acc < 0 else 0
         expected_final = align_model(acc_abs, shared_exp + 5, acc_sign, round_mode, overflow_wrap)
     else:
-        expected_final = expected_acc
+        # If no shared scaling, the result is sign-extended to 32-bit in hardware
+        if expected_acc < 0:
+            expected_final = (expected_acc & 0xFFFFFFFF) - 0x100000000
+        else:
+            expected_final = expected_acc
 
     # Cycle 37-40: Output Serialized Result
     actual_acc = 0
@@ -435,6 +448,7 @@ async def test_fast_start_scale_compression(dut):
     # Manual protocol for fast start:
 
     support_shared = get_param(getattr(dut.user_project, "ENABLE_SHARED_SCALING", None), 1)
+    support_int8 = get_param(getattr(dut.user_project, "SUPPORT_INT8", None), 1)
 
     # Cycle 0: IDLE. Set Fast Start bit ui_in[7]
     dut.ui_in.value = 0x80
@@ -448,7 +462,7 @@ async def test_fast_start_scale_compression(dut):
     support_e5m2 = get_param(getattr(dut.user_project, "SUPPORT_E5M2", None), 1)
     for a, b in zip(a_elements, b_elements):
         prod = align_product_model(a, b, format_a, format_b,
-                                   support_e5m2=support_e5m2, support_mxfp6=support_mxfp6, support_mxfp4=support_mxfp4)
+                                   support_e5m2=support_e5m2, support_mxfp6=support_mxfp6, support_mxfp4=support_mxfp4, support_int8=support_int8)
         expected_acc += prod
 
     if support_shared:


### PR DESCRIPTION
Fixed the GitHub Action workflow failure in the gate impact analysis step. The issue was caused by a mismatch between the parameters being set by the analysis script and those actually defined in the Verilog modules. Introduced `ACCUMULATOR_WIDTH`, `SUPPORT_INT8`, and `SUPPORT_PIPELINING` parameters across the RTL and updated the Python verification model to maintain bit-accurate simulation across all parameterized configurations. Verified the fix by running the full test suite and the gate analysis script, confirming that the 'Ultra-Tiny' variant now meets the 1x1 Tiny Tapeout tile budget.

Fixes #155

---
*PR created automatically by Jules for task [6212534495517218976](https://jules.google.com/task/6212534495517218976) started by @chatelao*