### PR TITLE
Add VCD conversion and artifacts to test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Install Tools (iverilog, yosys)
         shell: bash
-        run: sudo apt-get update && sudo apt-get install -y iverilog yosys
+        run: sudo apt-get update && sudo apt-get install -y iverilog yosys gtkwave
 
       # Set Python up and install cocotb
       - name: Setup python
@@ -44,6 +44,11 @@ jobs:
           # make will return success even if the test fails, so check for failure in the results.xml
           ! grep failure results.xml
 
+      - name: Convert FST to VCD
+        if: always()
+        run: |
+          fst2vcd -f test/tb.fst -o test/tb.vcd
+
       - name: Test Summary
         uses: test-summary/action@v2.3
         with:
@@ -57,5 +62,6 @@ jobs:
           name: test-results-${{ matrix.config }}
           path: |
             test/tb.fst
+            test/tb.vcd
             test/results.xml
             test/output/*


### PR DESCRIPTION
This change updates the GitHub Actions test workflow to provide simulation waveforms in both FST and VCD formats. By installing the gtkwave package, the workflow gains access to the fst2vcd utility, which is now used to convert the native FST output from Icarus Verilog into the more widely compatible VCD format. Both files are then collected as part of the test results artifacts, facilitating debugging across different waveform viewing tools.

Fixes #170

---
*PR created automatically by Jules for task [5031349354873797733](https://jules.google.com/task/5031349354873797733) started by @chatelao*