### PR TITLE
Add Hardening to CI/CD pipeline

### DIFF
--- a/.github/workflows/hardening.yaml
+++ b/.github/workflows/hardening.yaml
@@ -1,7 +1,8 @@
-name: gds
+name: hardening
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](../../workflows/gds/badge.svg) ![](../../workflows/docs/badge.svg) ![](../../workflows/test/badge.svg) ![](../../workflows/fpga/badge.svg)
+![](../../workflows/hardening/badge.svg) ![](../../workflows/docs/badge.svg) ![](../../workflows/test/badge.svg) ![](../../workflows/fpga/badge.svg)
 
 # Tiny Tapeout IHP 26a - OCP MXFP8 Streaming MAC Unit
 


### PR DESCRIPTION
I have explicitly included "Hardening" in the CI/CD pipeline by renaming the existing GDS generation workflow to `hardening.yaml` and updating its internal metadata. This aligns the project's terminology with the Tiny Tapeout guide provided. Additionally, I've added a `pull_request` trigger to the workflow to ensure that all incoming changes are verified for ASIC compatibility (hardening) before being merged. I also updated the status badge in the README to point to the new workflow.

Fixes #176

---
*PR created automatically by Jules for task [734548692916103775](https://jules.google.com/task/734548692916103775) started by @chatelao*