### PR TITLE
Add PlantUML context diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 # Tiny Tapeout IHP 26a - OCP MXFP8 Streaming MAC Unit
 
-This project implements a Streaming Multiply-Accumulate (MAC) Unit compatible with the OCP Microscaling Formats (MX) Specification (v1.0). It is designed to fit within a single 1x1 Tiny Tapeout tile using the IHP SG13G2 PDK.
+This project implements a Streaming Multiply-Accumulate (MAC) Unit compatible with the OCP Microscaling Formats (MX) Specification (v1.0). It is designed to fit within a single 1x2 Tiny Tapeout tile using the IHP SG13G2 PDK.
+
+## System Context
+
+![System Context Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/documentation/CONTEXT_DIAGRAM.PUML)
+
+*Source: [documentation/CONTEXT_DIAGRAM.PUML](documentation/CONTEXT_DIAGRAM.PUML)*
 
 - [Read the documentation for project](documentation/INFO.md)
 - [Project Concept & Roadmap](MXFP8_CONCEPT.md)

--- a/documentation/CONTEXT_DIAGRAM.PUML
+++ b/documentation/CONTEXT_DIAGRAM.PUML
@@ -1,0 +1,14 @@
+@startuml CONTEXT_DIAGRAM
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
+
+LAYOUT_WITH_LEGEND()
+
+Person(host, "Host System", "FPGA, Microcontroller, or Testbench providing data and control signals.")
+System(mac_unit, "OCP MXFP8 Streaming MAC Unit", "Tiny Tapeout 1x2 ASIC tile implementing OCP Microscaling Formats (MX) Specification (v1.0).")
+
+Rel(host, mac_unit, "Element A & Scale A (8-bit)", "ui_in")
+Rel(host, mac_unit, "Element B & Scale B (8-bit)", "uio_in")
+Rel(host, mac_unit, "Control (clk, rst_n, ena)", "Dedicated Pins")
+Rel(mac_unit, host, "Serialized 32-bit Result (8-bit)", "uo_out")
+
+@enduml


### PR DESCRIPTION
I have added a PlantUML context diagram to the project documentation. 

Summary of changes:
1. Created a new file `documentation/CONTEXT_DIAGRAM.PUML` containing the C4-PlantUML source for the system context diagram.
2. Modified `README.md` to include a "System Context" section featuring the rendered diagram (via the PlantUML proxy) and a link to the source file.
3. Updated the tile size mention in `README.md` from 1x1 to 1x2 to ensure consistency with `info.yaml`.
4. Verified the implementation by running the full cocotb test suite, with all tests passing.

Fixes #181

---
*PR created automatically by Jules for task [5210059436445177980](https://jules.google.com/task/5210059436445177980) started by @chatelao*