### PR TITLE
Add Attribution to Tiny Tapeout and OCP MX Specs

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,4 +3,8 @@ Copyright 2024-2025 [Project Contributors]
 
 This product includes software developed by Clive Chan.
 - fp8_mul (https://github.com/cchan/fp8_mul)
-Copyright Clive Chan
+  Copyright Clive Chan (Arithmetic logic)
+- Tiny Tapeout Verilog Template (https://github.com/tinytapeout/tt-verilog-template)
+  Copyright Tiny Tapeout (Project structure and template)
+- OCP Microscaling Formats (MX) Specification v1.0 (https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf)
+  Published by the Open Compute Project (OCP)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ This project implements a Streaming Multiply-Accumulate (MAC) Unit compatible wi
 
 ## Attributions
 
-This project incorporates logic and concepts from the [fp8_mul](https://github.com/cchan/fp8_mul) project by Clive Chan. We gratefully acknowledge his contributions to the open-source hardware community.
+This project incorporates logic and concepts from several open-source resources:
+- [fp8_mul](https://github.com/cchan/fp8_mul) by Clive Chan (Arithmetic logic).
+- [Tiny Tapeout Verilog Template](https://github.com/tinytapeout/tt-verilog-template) (Project structure).
+- [OCP Microscaling Formats (MX) Specification v1.0](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf) (Numerical and Protocol Specification).
+
+We gratefully acknowledge these contributions to the open-source hardware and AI communities.
 
 ## System Context
 


### PR DESCRIPTION
This PR adds the missing attributions for the Tiny Tapeout templates and the OCP MX specification to the project documentation and legal notice.

Specifically:
- Updated `README.md`'s `## Attributions` section with links to the Tiny Tapeout Verilog Template and the OCP MX Specification.
- Appended the same attributions to the `NOTICE` file to ensure Apache 2.0 compliance.

Fixes #198

---
*PR created automatically by Jules for task [8257840433558640929](https://jules.google.com/task/8257840433558640929) started by @chatelao*