### PR TITLE
Swap Format B and Scale B inputs in Cycle 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to proces
 |-------|--------------------|---------------------|----------------------|-------------|
 | 0     | -                  | -                   | 0x00                 | **IDLE**: Waiting for start. |
 | 1     | **Scale A**        | **Config Byte**     | 0x00                 | Load Scale A and Operation Mode. |
-| 2     | **Format B**       | **Scale B**         | 0x00                 | Load Scale B and Format B. |
+| 2     | **Scale B**        | **Format B**        | 0x00                 | Load Scale B and Format B. |
 | 3-34  | **Element $A_i$**  | **Element $B_i$**   | 0x00                 | Stream 32 pairs of elements. |
 | 35    | -                  | -                   | 0x00                 | Pipeline flush. |
 | 36    | -                  | -                   | 0x00                 | Final Shared Scaling calculation. |
@@ -46,7 +46,7 @@ The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to proces
 - `[4:3]`: **Rounding Mode** (0: TRN, 1: CEL, 2: FLR, 3: RNE)
 - `[5]`: **Overflow Mode** (0: SAT, 1: WRAP)
 
-### Format B Byte (Cycle 2, `ui_in`)
+### Format B Byte (Cycle 2, `uio_in`)
 - `[2:0]`: **Format B** (Same encoding as Format A)
 
 ### Fast Start (Scale Compression)

--- a/documentation/INFO.md
+++ b/documentation/INFO.md
@@ -19,7 +19,7 @@ The unit supports both **E4M3** and **E5M2** element formats:
 ### Operational Protocol (40-Cycle Sequence)
 To minimize resource usage, operands are streamed into the unit over 40 clock cycles (0-39):
 1. **Cycle 1**: Load Scale A ($X_A$ on `ui_in`) and Configuration (on `uio_in`).
-2. **Cycle 2**: Load Scale B ($X_B$ on `uio_in`).
+2. **Cycle 2**: Load Scale B ($X_B$ on `ui_in`) and Format B (on `uio_in`).
 3. **Cycles 3-34**: Stream 32 pairs of elements $A_i$ and $B_i$.
 4. **Cycle 35**: Pipeline flush cycle.
 5. **Cycles 36-39**: The 32-bit accumulator result is shifted out 8 bits at a time on `uo_out`.
@@ -29,7 +29,7 @@ To minimize resource usage, operands are streamed into the unit over 40 clock cy
 The design uses a clocked FSM. To test:
 1. Reset the unit (`rst_n` = 0) then enable it (`ena` = 1).
 2. On Cycle 1, provide Scale A on `ui_in`.
-3. On Cycle 2, provide Scale B on `uio_in`.
+3. On Cycle 2, provide Scale B on `ui_in` and Format B on `uio_in`.
 4. From Cycle 3 to 34, provide elements $A_i$ on `ui_in` and $B_i$ on `uio_in` at each clock edge.
 5. Cycle 35 is used for internal pipeline synchronization.
 6. From Cycle 36 to 39, read the 32-bit result from `uo_out` (Byte 3 to Byte 0).

--- a/documentation/ZvfofpXmin_GAP.md
+++ b/documentation/ZvfofpXmin_GAP.md
@@ -28,7 +28,7 @@ This document analyzes the architectural and functional gaps between the current
 ## 3. Numerical & Protocol Gaps
 
 ### 3.1. Block Scaling Management
-- **Streaming MAC**: Explicitly loads Scale A and Scale B in Cycles 1 and 2. It supports "Fast Start" to reuse scales.
+- **Streaming MAC**: Explicitly loads Scale A (Cycle 1) and Scale B (Cycle 2). It supports "Fast Start" to reuse scales.
 - **ZvfofpXmin**: OCP MX scales are likely handled as metadata associated with vector registers or stored in specific scale-vector registers. A significant gap exists in how the ISA handles the "shared" nature of the scale across a vector block.
 
 ### 3.2. Subnormal Handling

--- a/src/project.v
+++ b/src/project.v
@@ -91,8 +91,8 @@ module tt_um_chatelao_fp8_multiplier #(
                            end
                     6'd2:  begin
                              state    <= STATE_STREAM;
-                             scale_b  <= uio_in;
-                             format_b <= SUPPORT_MIXED_PRECISION ? ui_in[2:0] : format_a; // Use format_a if mixed disabled
+                             scale_b  <= ui_in;
+                             format_b <= SUPPORT_MIXED_PRECISION ? uio_in[2:0] : format_a; // Use format_a if mixed disabled
                            end
                     6'd36: state <= STATE_OUTPUT;
                     6'd40: state   <= STATE_IDLE;

--- a/test/test.py
+++ b/test/test.py
@@ -202,8 +202,8 @@ async def run_mac_test(dut, format_a, format_b, a_elements, b_elements, scale_a=
     await ClockCycles(dut.clk, 1)
 
     # Cycle 2: Load Scale B and Format B
-    dut.ui_in.value = format_b
-    dut.uio_in.value = scale_b
+    dut.ui_in.value = scale_b
+    dut.uio_in.value = format_b
     await ClockCycles(dut.clk, 1)
 
     expected_acc = 0


### PR DESCRIPTION
This change swaps the input mapping for "Format B" and "Scale B" during the second cycle of the 41-cycle streaming protocol. In the updated protocol:
- Cycle 1: Scale A (ui_in), Config (uio_in)
- Cycle 2: Scale B (ui_in), Format B (uio_in)

Previously, Cycle 2 had Format B on `ui_in` and Scale B on `uio_in`. This adjustment ensures a more consistent mapping where scales are primarily provided on `ui_in` during the configuration phase. The implementation in `src/project.v`, the verification logic in `test/test.py`, and all relevant documentation have been synchronized.

Fixes #204

---
*PR created automatically by Jules for task [1054801461368283009](https://jules.google.com/task/1054801461368283009) started by @chatelao*