### PR TITLE
Add MicroPython Example for TT DevKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,54 @@ If `ui_in[7]` is set to `1` during **STATE_IDLE** (Cycle 0), the unit immediatel
 - [Local Setup Guide (WSL2)](LOCAL_SETUP.md)
 - [Silicon Online Viewer](https://gds-viewer.tinytapeout.com/?pdk=ihp-sg13g2&model=https%3A%2F%2Fchatelao.github.io%2Fttihp-fp8-mul%2F%2Ftinytapeout.oas)
 
+### MicroPython Example (TT DevKit)
+
+You can run a single MAC operation on the Tiny Tapeout DevKit using the onboard RP2040 with MicroPython. The following script performs a 32-element dot product of $1.0 \times 1.0$ with no scaling.
+
+```python
+import machine
+import time
+
+# Pin Mapping for TT DevKit RP2040
+UI_IN = [machine.Pin(i, machine.Pin.OUT) for i in range(8)]
+UO_OUT = [machine.Pin(i, machine.Pin.IN) for i in range(8, 16)]
+UIO = [machine.Pin(i, machine.Pin.OUT) for i in range(16, 24)]
+CLK, RST_N, ENA = machine.Pin(24, machine.Pin.OUT), machine.Pin(25, machine.Pin.OUT), machine.Pin(26, machine.Pin.OUT)
+
+def clock_step():
+    CLK.value(1); time.sleep_us(10); CLK.value(0); time.sleep_us(10)
+
+def run_mac():
+    ENA.value(1); RST_N.value(0); CLK.value(0); time.sleep_ms(10); RST_N.value(1)
+
+    clock_step() # Cycle 0 -> 1
+    # Cycle 1: Scale A (127=1.0) & Config (0x00=E4M3)
+    for i in range(8): UI_IN[i].value((127 >> i) & 1); UIO[i].value(0)
+    clock_step()
+    # Cycle 2: Scale B (127=1.0) & Format B (0x00=E4M3)
+    for i in range(8): UI_IN[i].value((127 >> i) & 1); UIO[i].value(0)
+    clock_step()
+    # Cycle 3-34: Stream 32 elements (0x38=1.0 in E4M3)
+    for i in range(8): UI_IN[i].value((0x38 >> i) & 1); UIO[i].value((0x38 >> i) & 1)
+    for _ in range(32): clock_step()
+    # Cycle 35-36: Flush and Scale
+    for i in range(8): UI_IN[i].value(0); UIO[i].value(0)
+    clock_step(); clock_step()
+    # Cycle 37-40: Read 32-bit Result (MSB first)
+    res = 0
+    for _ in range(4):
+        byte = 0
+        for i in range(8):
+            if UO_OUT[i].value(): byte |= (1 << i)
+        res = (res << 8) | byte
+        clock_step()
+    print(f"Result: {res} (Fixed-point), {res/256.0} (Float)")
+
+run_mac()
+```
+
+*For the full script and advanced usage, see [test/TT_MAC_RUN.PY](test/TT_MAC_RUN.PY).*
+
 ## OCP MX Feature Support
 
 This implementation follows the **OCP Microscaling Formats (MX) Specification (v1.0)**.

--- a/test/TT_MAC_RUN.PY
+++ b/test/TT_MAC_RUN.PY
@@ -1,0 +1,107 @@
+"""
+MicroPython MAC Runner for TT DevKit (RP2040)
+This script runs one 32-element MAC operation using the 41-cycle protocol.
+"""
+import machine
+import time
+
+# Pin Configuration (Standard TT DevKit RP2040 Mapping)
+# ui_in: GP0-GP7
+UI_IN = [machine.Pin(i, machine.Pin.OUT) for i in range(8)]
+# uo_out: GP8-GP15
+UO_OUT = [machine.Pin(i, machine.Pin.IN) for i in range(8, 16)]
+# uio: GP16-GP23
+UIO = [machine.Pin(i, machine.Pin.OUT) for i in range(16, 24)]
+# Control Pins
+CLK = machine.Pin(24, machine.Pin.OUT)
+RST_N = machine.Pin(25, machine.Pin.OUT)
+ENA = machine.Pin(26, machine.Pin.OUT)
+
+def set_ui_in(val):
+    for i in range(8):
+        UI_IN[i].value((val >> i) & 1)
+
+def set_uio_in(val):
+    # Set UIO as output to drive B elements and Config
+    for i in range(8):
+        UIO[i].init(machine.Pin.OUT)
+        UIO[i].value((val >> i) & 1)
+
+def get_uo_out():
+    val = 0
+    for i in range(8):
+        if UO_OUT[i].value():
+            val |= (1 << i)
+    return val
+
+def clock_step():
+    CLK.value(1)
+    time.sleep_us(10) # ~50kHz clock for stability
+    CLK.value(0)
+    time.sleep_us(10)
+
+def run_mac():
+    print("Initializing Streaming MAC...")
+    ENA.value(1)
+    RST_N.value(0)
+    CLK.value(0)
+    time.sleep_ms(10)
+    RST_N.value(1)
+    time.sleep_ms(10)
+
+    # Cycle 0 -> 1
+    clock_step()
+
+    # Cycle 1: Scale A and Config
+    # Format A = E4M3 (0), Rounding = TRN (0), Overflow = SAT (0)
+    set_ui_in(127) # Scale A = 1.0
+    set_uio_in(0x00)
+    clock_step() # Moves to Cycle 2, samples Scale A
+
+    # Cycle 2: Scale B and Format B
+    set_ui_in(127) # Scale B = 1.0
+    set_uio_in(0x00) # Format B = E4M3
+    clock_step() # Moves to Cycle 3, samples Scale B
+
+    # Cycle 3-34: Stream 32 elements (1.0 * 1.0)
+    # 0x38 = 1.0 in E4M3
+    set_ui_in(0x38)
+    set_uio_in(0x38)
+    print("Streaming 32 elements (1.0 * 1.0)...")
+    for _ in range(32):
+        clock_step() # Moves through cycles 3 to 34
+
+    # Cycle 35: Pipeline Flush
+    set_ui_in(0)
+    set_uio_in(0)
+    clock_step() # Moves from 35 to 36
+
+    # Cycle 36: Shared Scaling Calculation
+    clock_step() # Moves from 36 to 37
+
+    # Cycle 37-40: Output (MSB First)
+    print("Reading Result...")
+    result = 0
+    for i in range(4):
+        # Data is present on uo_out during cycles 37, 38, 39, 40
+        byte = get_uo_out()
+        result = (result << 8) | byte
+        print(f" Byte {3-i}: 0x{byte:02x}")
+        clock_step()
+
+    # Signed 32-bit conversion
+    if result & 0x80000000:
+        result -= 0x100000000
+
+    print("-" * 30)
+    print(f"Fixed-Point Result: {result}")
+    print(f"Floating-Point:     {result / 256.0}")
+    print("-" * 30)
+
+    if result == 8192:
+        print("SUCCESS: Result matches expected 32.0 (0x2000)")
+    else:
+        print(f"WARNING: Expected 8192, got {result}")
+
+if __name__ == "__main__":
+    run_mac()


### PR DESCRIPTION
This change adds a MicroPython script and documentation examples to allow users to run the Streaming MAC Unit on the physical Tiny Tapeout DevKit hardware. The script implements the 41-cycle protocol, including scale configuration, data streaming, and result serialization, specifically mapped to the RP2040 GPIOs used on the DevKit.

Fixes #209

---
*PR created automatically by Jules for task [18357706545582048716](https://jules.google.com/task/18357706545582048716) started by @chatelao*