### PR TITLE
Add USE_LNS_MUL option analysis to die size documentation

### DIFF
--- a/documentation/DIE_SIZE_ANALYSIS.md
+++ b/documentation/DIE_SIZE_ANALYSIS.md
@@ -15,6 +15,7 @@ To make the design modular and scalable, Verilog parameters were introduced. Thi
 | `SUPPORT_MXFP4` | `1` | Enables decoding for E2M1 format. | ~80 |
 | `SUPPORT_ADV_ROUNDING` | `1` | Enables CEIL and FLOOR rounding modes. | ~100 |
 | `SUPPORT_MIXED_PRECISION` | `1` | Allows independent format selection for A and B. | ~150 |
+| `USE_LNS_MUL` | `0` | Toggles between standard and approximate LNS multiplier. | ~400 |
 | `ALIGNER_WIDTH` | `40` | Internal datapath width for the product aligner. | ~200 (if 64->40) |
 
 ### 1.2. Recommended Refactorings
@@ -95,10 +96,10 @@ The implementation has been refactored to support aggressive area optimizations,
 
 | Build Variant | Parameter Configuration | Gates (Cells) | Tile Size |
 |---|---|---|---|
-| **Baseline (Full)** | All features enabled, 40/32 width | 3418 | 1x1* |
-| **Lite** | Disable MXFP6/4 | 3365 | 1x1* |
-| **Tiny** | All optional features disabled | 2272 | 1x1 |
-| **Ultra-Tiny** | Tiny config + Reduced widths (32/24) | 2010 | 1x1 |
+| **Baseline (Full)** | All features enabled, 40/32 width | 3442 | 1x1* |
+| **Lite** | Disable MXFP6/4 | 3138 | 1x1* |
+| **Tiny** | All optional features disabled | 2267 | 1x1 |
+| **Ultra-Tiny** | Tiny config + Reduced widths (32/24) | 2004 | 1x1 |
 
 *\*The "Full" and "Lite" builds now approach the 1x1 tile limit thanks to the register reuse and FSM optimizations.*
 
@@ -114,6 +115,7 @@ The implementation has been refactored to support aggressive area optimizations,
 | `SUPPORT_ADV_ROUNDING` | ✅ | ✅ | ❌ | ❌ |
 | `SUPPORT_MIXED_PRECISION` | ✅ | ✅ | ❌ | ❌ |
 | `ENABLE_SHARED_SCALING` | ✅ | ✅ | ❌ | ❌ |
+| `USE_LNS_MUL` | ❌ | ❌ | ❌ | ❌ |
 | `ALIGNER_WIDTH` | **40** | **40** | **40** | **32** |
 | `ACCUMULATOR_WIDTH` | **32** | **32** | **32** | **24** |
 
@@ -121,18 +123,19 @@ The implementation has been refactored to support aggressive area optimizations,
 
 | Feature Flag | Configuration | Total Cells | Delta (vs Full) |
 |---|---|---|---|
-| **Baseline (Full)** | All features enabled | 3418 | 0 |
-| `SUPPORT_E5M2` | Disable E5M2 | 3395 | -23 |
-| `SUPPORT_MXFP6` | Disable MXFP6 | 3402 | -16 |
-| `SUPPORT_MXFP4` | Disable MXFP4 | 3419 | +1 |
-| `SUPPORT_INT8` | Disable INT8 (4x4 mult) | 2950 | -468 |
-| `SUPPORT_PIPELINING` | Disable Pipelining | 3392 | -26 |
-| `SUPPORT_ADV_ROUNDING` | Disable Adv. Rounding | 3168 | -250 |
-| `SUPPORT_MIXED_PRECISION`| Disable Mixed Precision| 3418 | 0 |
-| `ENABLE_SHARED_SCALING` | Disable hardware scaling | 3166 | -252 |
-| **Tiny (All Disabled)** | All features disabled | 2272 | -1146 |
-| **Ultra-Tiny** | Reduced internal widths | 2010 | -1408 |
-| **1x1 Tile Target (Min)**| Min. widths (24/20) | 1691 | -1727 |
+| **Baseline (Full)** | All features enabled | 3442 | 0 |
+| `SUPPORT_E5M2` | Disable E5M2 | 3408 | -34 |
+| `SUPPORT_MXFP6` | Disable MXFP6 | 3417 | -25 |
+| `SUPPORT_MXFP4` | Disable MXFP4 | 3444 | +2 |
+| `SUPPORT_INT8` | Disable INT8 (4x4 mult) | 2970 | -472 |
+| `SUPPORT_PIPELINING` | Disable Pipelining | 3418 | -24 |
+| `SUPPORT_ADV_ROUNDING` | Disable Adv. Rounding | 3192 | -250 |
+| `SUPPORT_MIXED_PRECISION`| Disable Mixed Precision| 3442 | 0 |
+| `ENABLE_SHARED_SCALING` | Disable hardware scaling | 3170 | -272 |
+| `USE_LNS_MUL` | Enable LNS Multiplier | 3024 | -418 |
+| **Tiny (All Disabled)** | All features disabled | 2267 | -1175 |
+| **Ultra-Tiny** | Reduced internal widths | 2004 | -1438 |
+| **1x1 Tile Target (Min)**| Min. widths (24/20) | 1681 | -1761 |
 
 ## 5. Deployment & CI/CD Progress
 

--- a/test/gate_analysis.py
+++ b/test/gate_analysis.py
@@ -33,10 +33,12 @@ def main():
         "SUPPORT_PIPELINING",
         "SUPPORT_ADV_ROUNDING",
         "SUPPORT_MIXED_PRECISION",
-        "ENABLE_SHARED_SCALING"
+        "ENABLE_SHARED_SCALING",
+        "USE_LNS_MUL"
     ]
 
     baseline_params = {f: 1 for f in features}
+    baseline_params["USE_LNS_MUL"] = 0 # Baseline is standard multiplier
     baseline_params["ALIGNER_WIDTH"] = 40
     baseline_params["ACCUMULATOR_WIDTH"] = 32
 
@@ -54,13 +56,19 @@ def main():
 
     for feature in features:
         params = baseline_params.copy()
-        params[feature] = 0
+        if feature == "USE_LNS_MUL":
+            params[feature] = 1
+            label = "Enable " + feature
+        else:
+            params[feature] = 0
+            label = "Disable " + feature
+
         gates = get_yosys_stats(params)
         if gates is not None:
             delta = gates - baseline_gates
-            print(f"{'Disable ' + feature:<30} | {gates:<10} | {delta:<10}")
+            print(f"{label:<30} | {gates:<10} | {delta:<10}")
         else:
-            print(f"{'Disable ' + feature:<30} | {'FAILED':<10} | {'N/A':<10}")
+            print(f"{label:<30} | {'FAILED':<10} | {'N/A':<10}")
 
     tiny_params = {f: 0 for f in features}
     tiny_params["ALIGNER_WIDTH"] = 40


### PR DESCRIPTION
This change incorporates a detailed gate count analysis of the `USE_LNS_MUL` (Logarithmic Number System) multiplier option into the project's die size documentation. 

Key updates:
1. **`documentation/DIE_SIZE_ANALYSIS.md`**:
    - Added `USE_LNS_MUL` to the list of configurable parameters with its estimated gate savings (~400).
    - Updated the "Optimization Summary" and "Automated Gate Impact Analysis" tables with fresh data from a successful `yosys` synthesis run (Baseline: 3442, Lite: 3138, Tiny: 2267).
    - Documented that enabling `USE_LNS_MUL` reduces the total gate count by approximately 418 gates compared to the standard multiplier.
    - Updated the Variant Feature Comparison Matrix to show `USE_LNS_MUL` is disabled by default in standard builds.
2. **`test/gate_analysis.py`**:
    - Modified the script to support both "opt-out" (disabling features) and "opt-in" (enabling features like `USE_LNS_MUL`) analysis relative to the baseline.
    - Included `USE_LNS_MUL` in the automated gate impact report.

Verification was performed by running the updated `test/gate_analysis.py` tool and confirming the output matches the documented figures. Additionally, functional verification of the LNS multiplier was confirmed via Cocotb simulation.

Fixes #211

---
*PR created automatically by Jules for task [9513950932474638391](https://jules.google.com/task/9513950932474638391) started by @chatelao*