### PR TITLE
Implement area-saving refactorings for MXFP8 MAC unit

### DIFF
--- a/documentation/DIE_SIZE_ANALYSIS.md
+++ b/documentation/DIE_SIZE_ANALYSIS.md
@@ -25,7 +25,7 @@ To make the design modular and scalable, Verilog parameters were introduced. Thi
 #### Multiplier Core (`fp8_mul.v`)
 - [x] **Conditional Decoding**: Use logic pruning based on `SUPPORT_MXFP6` and `SUPPORT_MXFP4`.
 - [x] **Bias Simplification**: Bias logic is simplified based on supported formats.
-- [ ] **Shared Decoders**: (Optional) Use a single decoder set if `SUPPORT_MIXED_PRECISION` is `0`.
+- [x] **Shared Decoders**: (Optional) Use a single decoder set if `SUPPORT_MIXED_PRECISION` is `0`.
 
 #### Product Aligner (`fp8_aligner.v`)
 - [x] **Configurable Rounding**: Logic for `R_CEL` and `R_FLR` is pruned if `SUPPORT_ADV_ROUNDING` is disabled.
@@ -33,7 +33,7 @@ To make the design modular and scalable, Verilog parameters were introduced. Thi
 
 #### Top-Level Integration (`project.v`)
 - [x] **FSM Guarding**: Shared scaling logic is conditionally enabled via `ENABLE_SHARED_SCALING`.
-- [ ] **Register Pruning**: (Optional) Conditionally instantiate registers for `format_b` and `scale_b`.
+- [x] **Register Pruning**: (Optional) Conditionally instantiate registers for `format_b`, `scale_b`, and multiplier pipeline.
 - [x] **Fast Start Logic**: Verified correctness with all parameter variants.
 
 ## 2. Die Size Analysis (Optimized Architecture)

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -5,7 +5,8 @@ module fp8_mul #(
     parameter SUPPORT_E5M2  = 1,
     parameter SUPPORT_MXFP6 = 1,
     parameter SUPPORT_MXFP4 = 1,
-    parameter SUPPORT_INT8  = 1
+    parameter SUPPORT_INT8  = 1,
+    parameter SUPPORT_MIXED_PRECISION = 1
 )(
     input  wire [7:0] a,
     input  wire [7:0] b,
@@ -117,7 +118,12 @@ module fp8_mul #(
         decode_operand(a, format_a, sign_a, ea, ma, bias_a, zero_a);
 
         // Operand B Decoding
-        decode_operand(b, format_b, sign_b, eb, mb, bias_b, zero_b);
+        if (SUPPORT_MIXED_PRECISION) begin
+            decode_operand(b, format_b, sign_b, eb, mb, bias_b, zero_b);
+        end else begin
+            // Use format_a for both operands to allow hardware sharing
+            decode_operand(b, format_a, sign_b, eb, mb, bias_b, zero_b);
+        end
 
         // 8x8 or 4x4 Multiplier
         if (SUPPORT_INT8)

--- a/src/fp8_mul_lns.v
+++ b/src/fp8_mul_lns.v
@@ -7,6 +7,7 @@ module fp8_mul_lns #(
     parameter SUPPORT_MXFP6 = 1,
     parameter SUPPORT_MXFP4 = 1,
     parameter SUPPORT_INT8  = 1,
+    parameter SUPPORT_MIXED_PRECISION = 1,
     parameter USE_LNS_MUL_PRECISE = 0
 )(
     input  wire [7:0] a,
@@ -139,7 +140,12 @@ module fp8_mul_lns #(
         decode_operand(a, format_a, sign_a, ea, ma, bias_a, zero_a, is_inta);
 
         // Operand B Decoding
-        decode_operand(b, format_b, sign_b, eb, mb, bias_b, zero_b, is_intb);
+        if (SUPPORT_MIXED_PRECISION) begin
+            decode_operand(b, format_b, sign_b, eb, mb, bias_b, zero_b, is_intb);
+        end else begin
+            // Use format_a for both operands to allow hardware sharing
+            decode_operand(b, format_a, sign_b, eb, mb, bias_b, zero_b, is_intb);
+        end
 
         // Combined Log-Adder (Mitchell or Precise)
         if (is_inta || is_intb) begin

--- a/src/project.v
+++ b/src/project.v
@@ -48,11 +48,9 @@ module tt_um_chatelao_fp8_multiplier #(
     reg       overflow_wrap;
 
     // Register Pruning for scale_a, scale_b, format_b
-    /* verilator lint_off UNUSEDSIGNAL */
     wire [7:0] scale_a_val;
     wire [7:0] scale_b_val;
     wire [2:0] format_b_val;
-    /* verilator lint_on UNUSEDSIGNAL */
 
     generate
         if (ENABLE_SHARED_SCALING) begin : gen_scale_a
@@ -151,6 +149,7 @@ module tt_um_chatelao_fp8_multiplier #(
                 .SUPPORT_MXFP6(SUPPORT_MXFP6),
                 .SUPPORT_MXFP4(SUPPORT_MXFP4),
                 .SUPPORT_INT8(SUPPORT_INT8),
+                .SUPPORT_MIXED_PRECISION(SUPPORT_MIXED_PRECISION),
                 .USE_LNS_MUL_PRECISE(USE_LNS_MUL_PRECISE)
             ) multiplier (
                 .a(ui_in),
@@ -166,7 +165,8 @@ module tt_um_chatelao_fp8_multiplier #(
                 .SUPPORT_E5M2(SUPPORT_E5M2),
                 .SUPPORT_MXFP6(SUPPORT_MXFP6),
                 .SUPPORT_MXFP4(SUPPORT_MXFP4),
-                .SUPPORT_INT8(SUPPORT_INT8)
+                .SUPPORT_INT8(SUPPORT_INT8),
+                .SUPPORT_MIXED_PRECISION(SUPPORT_MIXED_PRECISION)
             ) multiplier (
                 .a(ui_in),
                 .b(uio_in),
@@ -180,21 +180,36 @@ module tt_um_chatelao_fp8_multiplier #(
     endgenerate
 
     // Pipeline registers for multiplier output
-    reg [15:0] mul_prod_reg;
-    reg signed [6:0] mul_exp_sum_reg;
-    reg mul_sign_reg;
+    wire [15:0] mul_prod_val;
+    wire signed [6:0] mul_exp_sum_val;
+    wire mul_sign_val;
 
-    always @(posedge clk) begin
-        if (!rst_n) begin
-            mul_prod_reg <= 16'd0;
-            mul_exp_sum_reg <= 7'd0;
-            mul_sign_reg <= 1'b0;
-        end else if (ena) begin
-            mul_prod_reg <= mul_prod;
-            mul_exp_sum_reg <= mul_exp_sum;
-            mul_sign_reg <= mul_sign;
+    generate
+        if (SUPPORT_PIPELINING) begin : gen_pipeline
+            reg [15:0] mul_prod_reg;
+            reg signed [6:0] mul_exp_sum_reg;
+            reg mul_sign_reg;
+
+            always @(posedge clk) begin
+                if (!rst_n) begin
+                    mul_prod_reg <= 16'd0;
+                    mul_exp_sum_reg <= 7'd0;
+                    mul_sign_reg <= 1'b0;
+                end else if (ena) begin
+                    mul_prod_reg <= mul_prod;
+                    mul_exp_sum_reg <= mul_exp_sum;
+                    mul_sign_reg <= mul_sign;
+                end
+            end
+            assign mul_prod_val = mul_prod_reg;
+            assign mul_exp_sum_val = mul_exp_sum_reg;
+            assign mul_sign_val = mul_sign_reg;
+        end else begin : gen_no_pipeline
+            assign mul_prod_val = mul_prod;
+            assign mul_exp_sum_val = mul_exp_sum;
+            assign mul_sign_val = mul_sign;
         end
-    end
+    endgenerate
 
     // 2. Shared Scale Calculation
     // S = XA + XB - 254. UE8M0 has bias 127.
@@ -208,10 +223,10 @@ module tt_um_chatelao_fp8_multiplier #(
     // Shift aligner inputs by 1 cycle due to multiplier pipeline (if enabled)
     wire [31:0] aligner_in_prod = (ENABLE_SHARED_SCALING && cycle_count >= 6'd36) ?
                                     (ACCUMULATOR_WIDTH > 32 ? acc_abs[31:0] : {{(32-ACCUMULATOR_WIDTH){1'b0}}, acc_abs}) :
-                                    {16'd0, SUPPORT_PIPELINING ? mul_prod_reg : mul_prod};
+                                    {16'd0, mul_prod_val};
     wire signed [9:0] aligner_in_exp  = (ENABLE_SHARED_SCALING && cycle_count >= 6'd36) ? (shared_exp + 10'sd5) :
-                                    (SUPPORT_PIPELINING ? {{3{mul_exp_sum_reg[6]}}, mul_exp_sum_reg} : {{3{mul_exp_sum[6]}}, mul_exp_sum});
-    wire aligner_in_sign = (ENABLE_SHARED_SCALING && cycle_count >= 6'd36) ? acc_out[ACCUMULATOR_WIDTH-1] : (SUPPORT_PIPELINING ? mul_sign_reg : mul_sign);
+                                    {{3{mul_exp_sum_val[6]}}, mul_exp_sum_val};
+    wire aligner_in_sign = (ENABLE_SHARED_SCALING && cycle_count >= 6'd36) ? acc_out[ACCUMULATOR_WIDTH-1] : mul_sign_val;
 
     wire [31:0] aligned_res;
     fp8_aligner #(


### PR DESCRIPTION
This PR implements the optional refactorings from `DIE_SIZE_ANALYSIS.md` to optimize the die size of the OCP MXFP8 Streaming MAC Unit for 1x1 Tiny Tapeout tiles.

### Key Changes:
1.  **Shared Decoders**: Added `SUPPORT_MIXED_PRECISION` parameter to `fp8_mul.v` and `fp8_mul_lns.v`. When disabled (`0`), the logic for operand B decoding reuses the `format_a` logic, saving area on redundant decoders.
2.  **Register Pruning**: Enhanced `project.v` to conditionally instantiate multiplier pipeline registers based on `SUPPORT_PIPELINING`. This complements the existing pruning for `scale_a`, `scale_b`, and `format_b`.
3.  **Documentation**: Updated `documentation/DIE_SIZE_ANALYSIS.md` to reflect the completion of these area-saving measures.

### Verification:
- **Full Build**: Standard configuration tests passed.
- **Shared Decoders**: Tested with `SUPPORT_MIXED_PRECISION=0`, all tests passed.
- **No Pipelining**: Tested with `SUPPORT_PIPELINING=0`, all tests passed.
- **Static Analysis**: Verified logic sharing and pruning via code review and manual inspection of the generated RTL structure.

Fixes #244

---
*PR created automatically by Jules for task [1132339054164690623](https://jules.google.com/task/1132339054164690623) started by @chatelao*