### PR TITLE
Concept: CSR Mapping for RISC-V Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ We gratefully acknowledge these contributions to the open-source hardware and AI
 *Source: [documentation/CONTEXT_DIAGRAM.PUML](documentation/CONTEXT_DIAGRAM.PUML)*
 
 - [Read the documentation for project](documentation/INFO.md)
-- [Project Concept & Roadmap](MXFP8_CONCEPT.md)
+- [Project Concept & Roadmap](documentation/MXFP8_CONCEPT.md)
+- [RISC-V CSR Mapping Concept](documentation/CSR_MAPPING.md)
 
 ## Protocol Description (MCU to TT/FPGA)
 
@@ -52,8 +53,8 @@ The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to proces
 ### Fast Start (Scale Compression)
 If `ui_in[7]` is set to `1` during **STATE_IDLE** (Cycle 0), the unit immediately jumps to **Cycle 3**. It reuses the **Scales**, **Formats**, and **Rounding Modes** from the previous operation, saving 3 clock cycles.
 
-- [MX+ Implementation Roadmap](MX_PLUS.md)
-- [Local Setup Guide (WSL2)](LOCAL_SETUP.md)
+- [MX+ Implementation Roadmap](documentation/MX_PLUS.md)
+- [Local Setup Guide (WSL2)](documentation/LOCAL_SETUP.md)
 - [Silicon Online Viewer](https://gds-viewer.tinytapeout.com/?pdk=ihp-sg13g2&model=https%3A%2F%2Fchatelao.github.io%2Fttihp-fp8-mul%2F%2Ftinytapeout.oas)
 
 ### MicroPython Example (TT DevKit)

--- a/documentation/CSR_MAPPING.md
+++ b/documentation/CSR_MAPPING.md
@@ -1,0 +1,72 @@
+# CSR Mapping Concept: OCP MX Streaming MAC for RISC-V
+
+This document defines the conceptual mapping of the **OCP MX Streaming MAC Unit** configuration and status to **RISC-V Control and Status Registers (CSRs)**. This mapping is intended to bridge the gap between the standalone 41-cycle streaming hardware and a integrated RISC-V Vector Execution Unit (aligned with the **ZvfofpXmin** extension).
+
+## 1. Proposed CSR Layout
+
+To manage the specific requirements of OCP Microscaling Formats (MX), a new custom CSR is proposed: `vmxfmt` (**Vector MX Format Configuration**).
+
+### 1.1. `vmxfmt` (Custom Read/Write CSR, Address 0x800)
+
+| Bits | Name | Description | OCP MX Cycle 1 Mapping |
+|:---|:---|:---|:---|
+| [2:0] | **FMT_A** | Element Format for Tensor A. | `uio_in[2:0]` |
+| [5:3] | **FMT_B** | Element Format for Tensor B. | `uio_in[2:0]` (Cycle 2) |
+| [6] | **OVF** | Overflow Mode (0: Saturation, 1: Wrap). | `uio_in[5]` |
+| [7] | **EXT** | Extended Accuracy (MX+) Enable. | N/A |
+| [31:8] | **RES** | Reserved for future use (e.g., MX++). | - |
+
+#### Format IDs (FMT_A / FMT_B)
+| ID | Format | Type |
+|:---|:---|:---|
+| `000` | E4M3 | MXFP8 |
+| `001` | E5M2 | MXFP8 |
+| `010` | E3M2 | MXFP6 |
+| `011` | E2M3 | MXFP6 |
+| `100` | E2M1 | MXFP4 |
+| `101` | INT8 | MXINT8 |
+| `110` | INT8_SYM | MXINT8 |
+
+---
+
+## 2. Integration with Standard RISC-V CSRs
+
+The design leverages existing RISC-V CSRs where possible to maintain ISA consistency.
+
+### 2.1. Rounding Mode (`frm`)
+The OCP MX Rounding Mode is mapped to the standard RISC-V **`frm`** (Floating-point Rounding Mode) field in the **`fcsr`** (or bits [14:12] of `mstatus`/`sstatus`).
+
+| `frm` | OCP MX Rounding Mode | Description |
+|:---|:---|:---|
+| `000` | **RNE** (11) | Round to Nearest, ties to Even. |
+| `001` | **TRN** (00) | Round towards Zero (Truncate). |
+| `010` | **FLR** (10) | Round down (towards -Infinity). |
+| `011` | **CEL** (01) | Round up (towards +Infinity). |
+
+*Note: OCP MX internal IDs (00-11) are remapped to match RISC-V standard `frm` encodings during hardware integration.*
+
+### 2.2. Saturation Flag (`vxsat`)
+The OCP MX unit's internal saturation detection (which triggers during Aligner or Accumulator clamping) is mapped to the standard RISC-V **`vxsat`** (Vector Fixed-Point Saturation Flag).
+
+- If any element in the 32-element block triggers saturation, the `vxsat` bit is set to 1.
+- This bit is "sticky" and must be cleared manually by software, consistent with the RISC-V Vector Spec.
+
+---
+
+## 3. Operational Flow in a RISC-V System
+
+In an integrated environment, the 41-cycle FSM is abstracted by the instruction decoder.
+
+1. **Configuration**: Software sets the formats and rounding via `csrrw x0, vmxfmt, t0` and `fsrm t1`.
+2. **Instruction**: A vector dot-product instruction (e.g., `vdot.vv v1, v2, v3`) is issued.
+3. **Execution**:
+    - The Vector Execution Unit (VXU) samples the CSRs.
+    - It triggers the 41-cycle sequence internally.
+    - Operands are pulled from the Vector Register File (VRF) instead of external pins.
+    - The final 32-bit result is written back to the destination register.
+4. **Status**: If saturation occurred, the VXU sets the `vxsat` bit in the background.
+
+## 4. Advantages of CSR Mapping
+- **Software Portability**: Compilers can target standard CSR instructions to configure the unit.
+- **Context Switching**: The hardware state (Format, Rounding) is automatically saved/restored as part of the processor's architectural state.
+- **Pipelining**: Decoupling configuration from data streaming allows for better instruction scheduling.

--- a/documentation/OPTIMIZATION_EVALUATION.md
+++ b/documentation/OPTIMIZATION_EVALUATION.md
@@ -24,7 +24,7 @@ This document evaluates the potential impact of advanced FP8 optimizations (from
 
 | Optimization | Size (Area) | Performance | Quality | Recommendation |
 |:---|:---|:---|:---|:---|
-| **CSR Mapping** | 🟡 Moderate Increase | ⚪ Neutral | 🟢 Software Sync | **Required**: For RISC-V (ZvfofpXmin) integration. |
+| **CSR Mapping** | 🟡 Moderate Increase | ⚪ Neutral | 🟢 Software Sync | **Required**: See [CSR_MAPPING.md](CSR_MAPPING.md). |
 | **Principal Dimension Awareness**| ⚪ Neutral (SW) | 🟢 Optimized | ⚪ Neutral | **Documentation**: Ensure drivers understand OCP MX data layouts. |
 | **Format Converters** | 🔴 Moderate Increase | 🟡 Pipelined | 🟢 Flexibility | **Future Phase**: Important for system-level data ingestion. |
 


### PR DESCRIPTION
This submission introduces a detailed architectural concept for integrating the OCP MX Streaming MAC Unit into a RISC-V system. 

Key changes include:
- **New Documentation**: `documentation/CSR_MAPPING.md` which specifies:
    - A custom `vmxfmt` CSR at address `0x800` for managing MX-specific formats (FMT_A, FMT_B), overflow mode (SAT/WRAP), and accuracy extensions (MX+).
    - Mapping of the unit's rounding modes to the standard RISC-V `frm` register.
    - Mapping of hardware saturation events to the "sticky" `vxsat` bit in the RISC-V Vector extension.
- **Improved Discoverability**: Added links to the CSR mapping concept in the main `README.md` and the `OPTIMIZATION_EVALUATION.md` report.
- **Link Maintenance**: Standardized several relative links in the `README.md` to consistently point to the `documentation/` directory, resolving potential broken links during navigation.

All changes were verified against the repository's documentation and naming conventions. A full `cocotb` test suite was executed (after environment setup) to ensure no regressions were introduced by these documentation and structural updates.

Fixes #250

---
*PR created automatically by Jules for task [13848408929585759606](https://jules.google.com/task/13848408929585759606) started by @chatelao*