### PR TITLE
Increase Boundary Font Size by 70%

### DIFF
--- a/documentation/CONTEXT_DIAGRAM.PUML
+++ b/documentation/CONTEXT_DIAGRAM.PUML
@@ -2,6 +2,21 @@
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
 
 LAYOUT_WITH_LEGEND()
+skinparam rectangle<<boundary>> {
+    FontSize 20
+}
+skinparam rectangle<<container_boundary>> {
+    FontSize 20
+}
+skinparam rectangle<<system_boundary>> {
+    FontSize 20
+}
+skinparam rectangle<<enterprise_boundary>> {
+    FontSize 20
+}
+UpdateBoundaryStyle("container", $type="<size:20>container</size>")
+UpdateBoundaryStyle("system", $type="<size:20>system</size>")
+UpdateBoundaryStyle("enterprise", $type="<size:20>enterprise</size>")
 
 Person(host, "Host System", "FPGA, Microcontroller, or Testbench")
 


### PR DESCRIPTION
Increased the font size for all dashed boundary boxes in the C4-PlantUML context diagram by 70% (from 12pt to 20pt). The implementation uses centralized `skinparam` definitions for common boundary stereotypes and `UpdateBoundaryStyle` for type captions, ensuring a maintainable and consistent look without affecting standard blue component boxes.

Fixes #247

---
*PR created automatically by Jules for task [4704354309753577598](https://jules.google.com/task/4704354309753577598) started by @chatelao*