### PR TITLE
Add illustrative example to MX+ documentation

### DIFF
--- a/documentation/MX_PLUS.md
+++ b/documentation/MX_PLUS.md
@@ -7,6 +7,33 @@ In standard MX formats, the exponent of the largest magnitude value in a block (
 
 **MX+** leverages this redundancy by repurposing the exponent bits of the BM element as an extended mantissa, significantly increasing its precision without increasing the total bit width of the format.
 
+### Illustrative Example: MXFP4 vs. MXFP4+
+Consider a 4-element block from a Mistral-7B activation tensor:
+**Original (BF16)**: `[-0.39, -9.84, -0.20, 0.99]`
+
+In this block, the **Block Max (BM)** is `-9.84` (at index 1).
+
+#### 1. Shared Scale Determination
+The shared scale is determined by the BM element's magnitude. For MXFP4 (E2M1), which has a maximum representable exponent ($e_{max}$) of 2:
+- $\lfloor \log_2(9.84) \rfloor = 3$
+- $shared\_exp = 3 - 2 = 1$
+- **Shared Scale ($X$)** = $2^1 = \mathbf{2.0}$
+
+#### 2. Quantization Results Comparison
+
+| Index | BF16 Value | Standard MXFP4 ($X=2.0$) | MXFP4+ ($X=2.0$) |
+| :--- | :--- | :--- | :--- |
+| 0 | -0.39 | 0.0 | 0.0 |
+| **1 (BM)** | **-9.84** | **-8.0** | **-10.0** |
+| 2 | -0.20 | 0.0 | 0.0 |
+| 3 | 0.99 | 1.0 | 1.0 |
+
+**Numerical Analysis**:
+- **Standard MXFP4**: The BM element uses standard E2M1 ($P_i \in \{4.0, 6.0\}$ after scaling). Nearest value to $9.84/2.0 = 4.92$ is $4.0$, resulting in $X \cdot P_i = -8.0$. **Error = 1.84**.
+- **MXFP4+**: The BM element repurposes its 2 exponent bits as mantissa, allowing 3 mantissa bits ($P_i \in \{4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5\}$). Nearest value to $4.92$ is $5.0$, resulting in $X \cdot P_i = -10.0$. **Error = 0.16**.
+
+By preserving the precision of the outlier, MX+ achieves a **10x reduction in quantization error** for the most critical value in the block while maintaining a 4-bit footprint.
+
 ---
 
 ## Phase 1: Metadata & Protocol Extension


### PR DESCRIPTION
Added an illustrative example to `documentation/MX_PLUS.md` that compares standard MXFP4 and MXFP4+ quantization using a 4-element block from Mistral-7B activation data. The example includes shared scale determination and a numerical error analysis showing the precision benefits of MX+.

Fixes #269

---
*PR created automatically by Jules for task [10056952565644888897](https://jules.google.com/task/10056952565644888897) started by @chatelao*