### PR TITLE
Add NVIDIA Blackwell Tensor Core Documentation

### DIFF
--- a/documentation/BLACKWELL_TENSOR_CORE.md
+++ b/documentation/BLACKWELL_TENSOR_CORE.md
@@ -1,0 +1,27 @@
+# NVIDIA 5th Generation Tensor Cores (Blackwell Architecture)
+
+## Overview
+The NVIDIA Blackwell architecture introduces the **5th Generation Tensor Cores**, designed to accelerate the most demanding AI and high-performance computing (HPC) workloads. A key innovation in this generation is the native support for ultra-low precision data formats, specifically **FP4** and **FP6**, which significantly increase throughput and efficiency for Large Language Model (LLM) serving.
+
+## Key Features
+- **Native FP4 and FP6 Support**: Blackwell Tensor Cores provide native hardware acceleration for 4-bit and 6-bit floating-point formats, doubling the throughput compared to FP8.
+- **Microscaling (MX) Compatibility**: The architecture is designed to work seamlessly with **OCP Microscaling (MX) formats**, utilizing block-based scaling to maintain high numerical accuracy at low bit-widths.
+- **Increased Throughput**: Each Tensor Core can complete one FP4 `mma.m16n8k64` operation every 16 cycles, delivering massive performance gains for matrix multiply-and-accumulate operations.
+- **Improved Efficiency**: By reducing the bit-width of weights and activations, Blackwell minimizes memory bandwidth pressure and power consumption while maintaining model performance.
+
+## Architecture & Hierarchy
+The Blackwell Tensor Core follows a structured hierarchy to manage parallel data processing:
+1.  **Tensor Core**: The top-level unit, where each warp executes on a single Tensor Core containing **32 Dot Product Engines (DPEs)**.
+2.  **Octet**: A subdivision of the Tensor Core. A warp consists of **4 Octets**.
+3.  **Threadgroup**: Each Octet contains **2 Threadgroups**. Four threads form a threadgroup that utilizes **4 DPEs**.
+4.  **Dot Product Engine (DPE)**: The fundamental compute unit. Each DPE processes 16 FP4 input pairs per cycle (one MXFP4 block pair every two cycles).
+
+## Dataflow
+1.  **Register File**: Input fragments for matrices A and B are stored in the register file.
+2.  **Intermediate Buffers**: Threads collaboratively load operand matrices from registers into intermediate buffers.
+3.  **Dot Product Engine (DPE)**:
+    - **Vector Multiplier**: Performs element-wise multiplication of the input pairs.
+    - **Adder Tree**: Conducts multi-level additions to produce the partial dot product result.
+4.  **Accumulator**: The result from the adder tree is accumulated with the bias or previous sum.
+5.  **Normalization & Conversion**: The accumulated result (typically in FP32) is normalized and converted to the desired output format.
+6.  **Write-back**: The final result is written back to the register file.

--- a/documentation/BLACKWELL_TENSOR_CORE.puml
+++ b/documentation/BLACKWELL_TENSOR_CORE.puml
@@ -1,0 +1,50 @@
+@startuml BLACKWELL_TENSOR_CORE
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
+
+LAYOUT_WITH_LEGEND()
+
+title NVIDIA 5th Gen Tensor Core (Blackwell) - Hierarchy & Dataflow
+
+Container_Boundary(tensor_core, "Tensor Core (32 DPEs)") {
+
+    Container_Boundary(octet_0, "Octet (8 DPEs)") {
+
+        Container_Boundary(threadgroup_0, "Threadgroup (4 DPEs)") {
+
+            Component(dpe_0, "Dot Product Engine (DPE)", "Compute", "Vector Multiplier & Adder Tree")
+            Component(dpe_1, "Dot Product Engine (DPE)", "Compute")
+            Component(dpe_2, "Dot Product Engine (DPE)", "Compute")
+            Component(dpe_3, "Dot Product Engine (DPE)", "Compute")
+        }
+
+        Container_Boundary(threadgroup_1, "Threadgroup (4 DPEs)") {
+            Component(dpe_4, "Dot Product Engine (DPE)", "Compute")
+            Component(dpe_n, "...", "Compute")
+        }
+    }
+
+    Container_Boundary(octet_1, "Octet") {
+        Component(octet_n, "...", "Subdivision")
+    }
+}
+
+Component(rf, "Register File", "Storage", "Fragments for A, B, C, D")
+Component(buffers, "Intermediate Buffers", "SRAM", "Operand staging")
+Component(acc, "Accumulator", "Logic", "FP32 Summation")
+Component(norm, "Normalization & Conversion", "Logic", "Format adjustment")
+
+Rel_D(rf, buffers, "Load Matrix Fragments", "Warp Threads")
+Rel_D(buffers, dpe_0, "MXFP4/FP8 Operands", "16 pairs/cycle")
+Rel_D(buffers, dpe_1, "Operands")
+Rel_D(buffers, dpe_2, "Operands")
+Rel_D(buffers, dpe_3, "Operands")
+
+Rel_D(dpe_0, acc, "Partial Product")
+Rel_D(dpe_1, acc, "Partial Product")
+Rel_D(dpe_2, acc, "Partial Product")
+Rel_D(dpe_3, acc, "Partial Product")
+
+Rel_D(acc, norm, "Accumulated Sum")
+Rel_D(norm, rf, "Write-back", "Matrix D")
+
+@enduml


### PR DESCRIPTION
Added documentation and a PlantUML diagram for the NVIDIA 5th Generation Tensor Cores (Blackwell architecture). The documentation covers key features like FP4/FP6 support and Microscaling (MX) compatibility, while the diagram visualizes the 4-level architectural hierarchy and the compute dataflow.

Fixes #275

---
*PR created automatically by Jules for task [6258065995082854397](https://jules.google.com/task/6258065995082854397) started by @chatelao*