### PR TITLE
Update TPU v7 TensorCore diagram style

### DIFF
--- a/documentation/GOOGLE_V7_TPU_TENSORCORE.PUML
+++ b/documentation/GOOGLE_V7_TPU_TENSORCORE.PUML
@@ -1,55 +1,62 @@
 @startuml GOOGLE_V7_TPU_TENSORCORE
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
+
+LAYOUT_WITH_LEGEND()
+
+title Google TPU v7 TensorCore - Hierarchy & Dataflow
+
 skinparam rectangle<<boundary>> {
     FontSize 20
 }
+skinparam rectangle<<container_boundary>> {
+    FontSize 20
+}
+skinparam rectangle<<system_boundary>> {
+    FontSize 20
+}
+UpdateBoundaryStyle("container", $type="container")
+UpdateBoundaryStyle("system", $type="system")
 
-package "Level 1: TPU v7 Core (TensorCore)" <<boundary>> {
-    component [Vector Processing Unit (VPU)] as vpu
-    component [HBM Interface] as hbm
+Container_Boundary(core, "Level 1: TPU v7 Core (TensorCore)") {
+    Component(hbm, "HBM Interface", "I/O", "High-bandwidth memory access")
 
-    package "Level 2: Matrix Multiply Unit (MXU)" <<boundary>> {
-        component [MXU Control Logic] as mxu_ctrl
-        component [Weight SRAM] as weight_sram
+    Container_Boundary(mxu, "Level 2: Matrix Multiply Unit (MXU)") {
+        Component(mxu_ctrl, "MXU Control Logic", "Logic", "Sequencing & dataflow control")
+        Component(weight_sram, "Weight SRAM", "Storage", "Local buffer for stationary weights")
 
-        package "Level 3: PE Array (Systolic Grid)" <<boundary>> {
+        Container_Boundary(pe_array, "Level 3: PE Array (Systolic Grid)") {
 
-            package "Level 4: Processing Element (PE)" <<boundary>> {
-                component [MX+ Decoder] as decoder
-                component [4x4/8x8 Multiplier] as mul
-                component [Product Aligner] as aligner
-                component [32-bit Local Accumulator] as acc
-
-                decoder -> mul : Mantissa/Exp
-                mul -> aligner : Product
-                aligner -> acc : Aligned Sum
+            Container_Boundary(pe, "Level 4: Processing Element (PE)") {
+                Component(decoder, "MX+ Decoder", "Logic", "Format decoding (MXFP4/6/8, MX+)")
+                Component(mul, "4x4/8x8 Multiplier", "Compute", "Mantissa multiplication")
+                Component(aligner, "Product Aligner", "Logic", "Exponent-based alignment")
+                Component(acc, "32-bit Local Accumulator", "Logic", "Partial sum accumulation")
             }
 
-            component [PE (Row i, Col j+1)] as pe_right
-            component [PE (Row i+1, Col j)] as pe_down
+            Component(pe_right, "PE (Row i, Col j+1)", "PE", "Next neighbor in systolic row")
+            Component(pe_down, "PE (Row i+1, Col j)", "PE", "Next neighbor in systolic column")
         }
     }
+
+    Component(vpu, "Vector Processing Unit (VPU)", "Logic", "Vector operations & activation functions")
 }
 
 ' Dataflow: Weights
-hbm -[#blue]-> weight_sram : Load Weights
-weight_sram -[#blue]-> decoder : Stationary Weight (W_ij)
+Rel_D(hbm, weight_sram, "Load Weights", "HBM to SRAM")
+Rel_D(weight_sram, decoder, "Stationary Weight (W_ij)", "Weight-stationary")
 
 ' Dataflow: Activations
-mxu_ctrl -[#red]-> decoder : Stream Activation (A_i)
-decoder -[#red]-> pe_right : Pass Activation
+Rel_D(mxu_ctrl, decoder, "Stream Activation (A_i)", "Activation streaming")
+Rel_R(decoder, mul, "Mantissa/Exp")
+Rel_R(decoder, pe_right, "Pass Activation", "Systolic row")
 
 ' Dataflow: Partial Sums
-pe_down <-[#green]- acc : Reduced Partial Sum
-acc <-[#green]- mxu_ctrl : Input Partial Sum (Up)
+Rel_D(mul, aligner, "Product")
+Rel_D(aligner, acc, "Aligned Sum")
+Rel_D(mxu_ctrl, acc, "Input Partial Sum (Up)", "Initial row sum")
+Rel_D(acc, pe_down, "Reduced Partial Sum", "Systolic column")
 
 ' Output to VPU
-acc -[#green]down-> vpu : Final Dot Product
-
-legend right
-  | Color | Description |
-  | <#blue> | Weights (Stationary) |
-  | <#red> | Activations (Streaming) |
-  | <#green> | Partial Sums (Reduction) |
-endlegend
+Rel_D(acc, vpu, "Final Dot Product", "Accumulated dot product")
 
 @enduml


### PR DESCRIPTION
Updated the Google TPU v7 TensorCore architecture diagram to use the C4-PlantUML layout style for consistency with other project documentation. The 4-level hierarchy (Core, MXU, PE Array, PE) and dataflow relationships were preserved while adopting the standardized visual language of the C4 model.

Fixes #289

---
*PR created automatically by Jules for task [5428382988913326593](https://jules.google.com/task/5428382988913326593) started by @chatelao*