### PR TITLE
Implement Conditional Accumulator Absolute Value Optimization

### DIFF
--- a/REVIEW-20216-02-28.md
+++ b/REVIEW-20216-02-28.md
@@ -68,17 +68,17 @@ The documentation is a standout feature of this project.
 The following steps are recommended to address the review findings:
 
 ### Short-Term (Protocol & RTL)
-1.  **Standardize Tile Mentions**: Update all documentation to consistently refer to the **1x2 tile** configuration as the primary target for the "Full" build.
-2.  **Add Verilator Linting**: Integrate a `make lint` target to ensure zero warnings across the codebase.
-3.  **Parameterize Block Size**: Change the hard-coded `32` in the FSM and loops to a `BLOCK_SIZE` parameter.
+*   [ ] **Standardize Tile Mentions**: Update all documentation to consistently refer to the **1x2 tile** configuration as the primary target for the "Full" build.
+*   [ ] **Add Verilator Linting**: Integrate a `make lint` target to ensure zero warnings across the codebase.
+*   [ ] **Parameterize Block Size**: Change the hard-coded `32` in the FSM and loops to a `BLOCK_SIZE` parameter.
 
 ### Mid-Term (Verification & Features)
-4.  **Formal for Aligner**: Add formal properties to `fp8_aligner.v` to verify rounding logic corner cases (e.g., ties-to-even).
-5.  **Subnormal Support (Optional)**: Investigate the area impact of adding partial subnormal support if there is remaining space in the 1x2 tile.
+*   [ ] **Formal for Aligner**: Add formal properties to `fp8_aligner.v` to verify rounding logic corner cases (e.g., ties-to-even).
+*   [ ] **Subnormal Support (Optional)**: Investigate the area impact of adding partial subnormal support if there is remaining space in the 1x2 tile.
 
 ### Long-Term (Architecture)
-6.  **Spatial Variant**: Explore a spatial version of the MAC (processing multiple elements per cycle) for larger tile allocations (e.g., 2x2 or 4x2).
-7.  **MX+ Integration**: Complete the implementation of the MX+ extended mantissa precision roadmap.
+*   [ ] **Spatial Variant**: Explore a spatial version of the MAC (processing multiple elements per cycle) for larger tile allocations (e.g., 2x2 or 4x2).
+*   [ ] **MX+ Integration**: Complete the implementation of the MX+ extended mantissa precision roadmap.
 
 ---
 
@@ -113,7 +113,7 @@ A detailed audit of the RTL against documented optimizations and the OCP MX v1.0
 
 *   [x] **Redundant FSM State Register**: The `state` register in `project.v` is functionally redundant as it is strictly derived from `cycle_count`. Removing the 2-bit `state` register and replacing it with continuous assignments or localparams based on `cycle_count` ranges would save area and simplify the control logic.
 *   [ ] **Optimization 8 Discrepancy (Accumulator Register Reuse)**: `DIE_SIZE_ANALYSIS.md` marks this as **COMPLETED**, but `src/project.v` still instantiates a dedicated 32-bit `scaled_acc_reg`. True completion of this optimization would involve refactoring the `accumulator.v` to act as a shift register during the `STATE_OUTPUT` phase, eliminating the extra 32 registers.
-*   [ ] **Conditional Accumulator Absolute Value**: The `acc_abs` signal and its associated negation logic are currently always present. This logic is only required when `ENABLE_SHARED_SCALING=1`. Wrapping this in a `generate` block would save area for configurations where hardware scaling is offloaded to software.
+*   [x] **Conditional Accumulator Absolute Value**: The `acc_abs` signal and its associated negation logic are currently always present. This logic is only required when `ENABLE_SHARED_SCALING=1`. Wrapping this in a `generate` block would save area for configurations where hardware scaling is offloaded to software.
 *   [ ] **Lane 1 Pipeline Pruning**: When `SUPPORT_VECTOR_PACKING=0`, the multiplier for Lane 1 is correctly pruned, but the pipeline registers in `gen_pipeline` still instantiate registers for Lane 1 (`mul_prod_lane1_reg`, etc.). These should be guarded by an additional `if (SUPPORT_VECTOR_PACKING)` check within the pipeline generation.
 *   [ ] **Rounding Logic Sharing**: The `fp8_aligner.v` implements rounding within the `always @(*)` block. For very area-constrained builds, a single shared rounding incrementer could be used for all rounding modes, rather than the current structure which might be inferred as multiple adders by some synthesis tools.
 
@@ -122,3 +122,9 @@ A detailed audit of the RTL against documented optimizations and the OCP MX v1.0
 *   [ ] **Subnormal Support (DAZ vs. Mandatory Support)**: The OCP spec states that implementations **must** support subnormals for all floating-point element types. The current design implements "Denormals-Are-Zero" (DAZ) to save area. While documented in the review, this remains a formal non-compliance with the "Must" requirement of the specification.
 *   [ ] **NaN/Infinity Propagation**: The current multiplier and aligner focus on numerical accuracy for normal numbers. While the spec requires adherence to OCP 8-bit FP (which includes NaN/Inf for E5M2), the current DAZ implementation and simplified exponent arithmetic may not fully propagate NaNs through the streaming pipeline as strictly required by the spec.
 *   [ ] **Shared Scale NaN Rule**: The spec requires that if a shared scale $X$ is NaN (`11111111`), all values in the block are NaN. The current hardware does not explicitly check for the `0xFF` scale value during the alignment/scaling phase.
+
+---
+
+## 8. Implementation Log
+
+*   **2025-02-28**: Implemented **Conditional Accumulator Absolute Value** (from Section 7.1). The `acc_abs_val` logic in `src/project.v` is now wrapped in a `generate` block, ensuring it is only instantiated when `ENABLE_SHARED_SCALING` is enabled. This results in area savings for "Tiny" and "Ultra-Tiny" configurations.

--- a/documentation/DIE_SIZE_ANALYSIS.md
+++ b/documentation/DIE_SIZE_ANALYSIS.md
@@ -32,7 +32,7 @@ To make the design modular and scalable, Verilog parameters were introduced. Thi
 - [x] **Internal Bit-width**: Fully parameterize the internal registers using `ALIGNER_WIDTH`.
 
 #### Top-Level Integration (`project.v`)
-- [x] **FSM Guarding**: Shared scaling logic is conditionally enabled via `ENABLE_SHARED_SCALING`.
+- [x] **FSM Guarding**: Shared scaling logic and absolute value logic (`acc_abs_val`) are conditionally enabled via `ENABLE_SHARED_SCALING`.
 - [x] **Register Pruning**: (Optional) Conditionally instantiate registers for `format_b`, `scale_b`, and multiplier pipeline.
 - [x] **Fast Start Logic**: Verified correctness with all parameter variants.
 - [x] **FSM State Register Elimination**: The `state` register was removed and replaced with combinatorial logic derived from `cycle_count`.

--- a/src/project.v
+++ b/src/project.v
@@ -281,11 +281,19 @@ module tt_um_chatelao_fp8_multiplier #(
     // 3. Aligner Multiplexing
     // We reuse the fp8_aligner for both element alignment and final shared scaling.
     wire [ACCUMULATOR_WIDTH-1:0] acc_out;
-    wire [ACCUMULATOR_WIDTH-1:0] acc_abs = acc_out[ACCUMULATOR_WIDTH-1] ? -acc_out : acc_out;
+
+    wire [ACCUMULATOR_WIDTH-1:0] acc_abs_val;
+    generate
+        if (ENABLE_SHARED_SCALING) begin : gen_acc_abs
+            assign acc_abs_val = acc_out[ACCUMULATOR_WIDTH-1] ? -acc_out : acc_out;
+        end else begin : gen_no_acc_abs
+            assign acc_abs_val = {ACCUMULATOR_WIDTH{1'b0}};
+        end
+    endgenerate
 
     // Shift aligner inputs by 1 cycle due to multiplier pipeline (if enabled)
     wire [31:0] aligner_lane0_in_prod = (ENABLE_SHARED_SCALING && cycle_count >= capture_cycle) ?
-                                    (ACCUMULATOR_WIDTH > 32 ? acc_abs[31:0] : {{(32-ACCUMULATOR_WIDTH){1'b0}}, acc_abs}) :
+                                    (ACCUMULATOR_WIDTH > 32 ? acc_abs_val[31:0] : {{(32-ACCUMULATOR_WIDTH){1'b0}}, acc_abs_val}) :
                                     {16'd0, mul_prod_lane0_val};
     wire signed [9:0] aligner_lane0_in_exp  = (ENABLE_SHARED_SCALING && cycle_count >= capture_cycle) ? (shared_exp + 10'sd5) :
                                     {{3{mul_exp_sum_lane0_val[6]}}, mul_exp_sum_lane0_val};


### PR DESCRIPTION
Implemented the 'Conditional Accumulator Absolute Value' optimization in `src/project.v` by guarding the `acc_abs_val` logic with a `generate` block conditioned on `ENABLE_SHARED_SCALING`. This change reduces area for configurations where hardware scaling is not required. Also updated the project review document to use checkboxes for tracking deliverables and updated the die size analysis documentation.

Fixes #295

---
*PR created automatically by Jules for task [17734293499530323301](https://jules.google.com/task/17734293499530323301) started by @chatelao*