### PR TITLE
MX+ Step 3: Outlier Identification

### DIFF
--- a/documentation/MX_PLUS.md
+++ b/documentation/MX_PLUS.md
@@ -50,7 +50,7 @@ By preserving the precision of the outlier, MX+ achieves a **10x reduction in qu
   - **Variant D (Header Cycle Extension)**: Add a dedicated "Metadata Cycle" (Cycle 0) before Scale A.
 - **Reasoning**: **Variant B** is selected. It maintains the 41-cycle standard protocol, ensuring backward compatibility with existing software drivers and minimizing the latency impact of the extension.
 
-### Step 2: Internal Storage & Parameterization
+### Step 2: Internal Storage & Parameterization (Status: **COMPLETED**)
 - **Goal**: Add parameterized hardware support for MX+.
 - **Preparation**:
   - Define `bm_index_a` and `bm_index_b` registers in `src/project.v`.
@@ -66,7 +66,7 @@ By preserving the precision of the outlier, MX+ achieves a **10x reduction in qu
 
 ## Phase 2: MX+ Operand Decoding
 
-### Step 3: Outlier Identification in Multiplier
+### Step 3: Outlier Identification in Multiplier (Status: **COMPLETED**)
 - **Goal**: Detect when the current streaming element is the designated Block Max.
 - **Preparation**:
   - Update `fp8_mul` module interface to accept outlier metadata.

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -12,6 +12,8 @@ module fp8_mul #(
     input  wire [7:0] b,
     input  wire [2:0] format_a,
     input  wire [2:0] format_b,
+    input  wire       is_bm_a,
+    input  wire       is_bm_b,
     output wire [15:0] prod,    // Mantissa product
     output wire signed [6:0] exp_sum, // Combined exponent (biased)
     output wire       sign

--- a/src/fp8_mul_lns.v
+++ b/src/fp8_mul_lns.v
@@ -14,6 +14,8 @@ module fp8_mul_lns #(
     input  wire [7:0] b,
     input  wire [2:0] format_a,
     input  wire [2:0] format_b,
+    input  wire       is_bm_a,
+    input  wire       is_bm_b,
     output wire [15:0] prod,    // Mantissa product
     output wire signed [6:0] exp_sum, // Combined exponent (biased)
     output wire       sign

--- a/src/project.v
+++ b/src/project.v
@@ -193,6 +193,15 @@ module tt_um_chatelao_fp8_multiplier #(
     wire [7:0] a_lane1 = actual_packed_mode ? {4'd0, ui_in[7:4]}  : 8'd0;
     wire [7:0] b_lane1 = actual_packed_mode ? {4'd0, uio_in[7:4]} : 8'd0;
 
+    // MX+ Centralized Flagging (Step 3)
+    wire [4:0] element_index_lane0 = actual_packed_mode ? { (cycle_count[4:0] - 5'd3), 1'b0 } : (cycle_count[4:0] - 5'd3);
+    wire [4:0] element_index_lane1 = actual_packed_mode ? { (cycle_count[4:0] - 5'd3), 1'b1 } : 5'd0;
+
+    wire is_bm_a_lane0 = SUPPORT_MX_PLUS && (state == STATE_STREAM) && (element_index_lane0 == bm_index_a_val);
+    wire is_bm_b_lane0 = SUPPORT_MX_PLUS && (state == STATE_STREAM) && (element_index_lane0 == bm_index_b_val);
+    wire is_bm_a_lane1 = SUPPORT_MX_PLUS && (state == STATE_STREAM) && actual_packed_mode && (element_index_lane1 == bm_index_a_val);
+    wire is_bm_b_lane1 = SUPPORT_MX_PLUS && (state == STATE_STREAM) && actual_packed_mode && (element_index_lane1 == bm_index_b_val);
+
     generate
         if (USE_LNS_MUL) begin : lns_gen
             fp8_mul_lns #(
@@ -207,6 +216,8 @@ module tt_um_chatelao_fp8_multiplier #(
                 .b(b_lane0),
                 .format_a(format_a),
                 .format_b(format_b_val),
+                .is_bm_a(is_bm_a_lane0),
+                .is_bm_b(is_bm_b_lane0),
                 .prod(mul_prod_lane0),
                 .exp_sum(mul_exp_sum_lane0),
                 .sign(mul_sign_lane0)
@@ -224,6 +235,8 @@ module tt_um_chatelao_fp8_multiplier #(
                     .b(b_lane1),
                     .format_a(format_a),
                     .format_b(format_b_val),
+                    .is_bm_a(is_bm_a_lane1),
+                    .is_bm_b(is_bm_b_lane1),
                     .prod(mul_prod_lane1),
                     .exp_sum(mul_exp_sum_lane1),
                     .sign(mul_sign_lane1)
@@ -245,6 +258,8 @@ module tt_um_chatelao_fp8_multiplier #(
                 .b(b_lane0),
                 .format_a(format_a),
                 .format_b(format_b_val),
+                .is_bm_a(is_bm_a_lane0),
+                .is_bm_b(is_bm_b_lane0),
                 .prod(mul_prod_lane0),
                 .exp_sum(mul_exp_sum_lane0),
                 .sign(mul_sign_lane0)
@@ -261,6 +276,8 @@ module tt_um_chatelao_fp8_multiplier #(
                     .b(b_lane1),
                     .format_a(format_a),
                     .format_b(format_b_val),
+                    .is_bm_a(is_bm_a_lane1),
+                    .is_bm_b(is_bm_b_lane1),
                     .prod(mul_prod_lane1),
                     .exp_sum(mul_exp_sum_lane1),
                     .sign(mul_sign_lane1)
@@ -509,6 +526,28 @@ module tt_um_chatelao_fp8_multiplier #(
                     6'd4: assert(uo_out == f_scaled_acc_reg[7:0]);
                     default: assert(uo_out == 8'd0);
                 endcase
+            end
+        end
+    end
+
+    // 7. MX+ Block Max Detection
+    always @(posedge clk) begin
+        if (rst_n && SUPPORT_MX_PLUS && state == STATE_STREAM) begin
+            if (element_index_lane0 == bm_index_a_val) assert(is_bm_a_lane0);
+            else assert(!is_bm_a_lane0);
+
+            if (element_index_lane0 == bm_index_b_val) assert(is_bm_b_lane0);
+            else assert(!is_bm_b_lane0);
+
+            if (actual_packed_mode) begin
+                if (element_index_lane1 == bm_index_a_val) assert(is_bm_a_lane1);
+                else assert(!is_bm_a_lane1);
+
+                if (element_index_lane1 == bm_index_b_val) assert(is_bm_b_lane1);
+                else assert(!is_bm_b_lane1);
+            end else begin
+                assert(!is_bm_a_lane1);
+                assert(!is_bm_b_lane1);
             end
         end
     end

--- a/test/results_initial.xml
+++ b/test/results_initial.xml
@@ -1,0 +1,20 @@
+<testsuites name="results">
+  <testsuite name="all" package="all">
+    <property name="random_seed" value="1772388193" />
+    <testcase name="test_mxfp8_mac_shared_scale" classname="test" file="/app/test/test.py" lineno="395" time="0.017225027084350586" sim_time_ns="1010.0" ratio_time="58635.61172090191" />
+    <testcase name="test_mxfp8_mac_e4m3" classname="test" file="/app/test/test.py" lineno="414" time="0.0070612430572509766" sim_time_ns="510.0" ratio_time="72225.2436100888" />
+    <testcase name="test_mxfp8_mac_e5m2" classname="test" file="/app/test/test.py" lineno="423" time="0.006573200225830078" sim_time_ns="510.0" ratio_time="77587.7780195865" />
+    <testcase name="test_rounding_modes" classname="test" file="/app/test/test.py" lineno="432" time="0.00010180473327636719" sim_time_ns="0.0" ratio_time="0.0" />
+    <testcase name="test_overflow_saturation" classname="test" file="/app/test/test.py" lineno="469" time="0.02384638786315918" sim_time_ns="1020.0" ratio_time="42773.77378298123" />
+    <testcase name="test_accumulator_saturation" classname="test" file="/app/test/test.py" lineno="483" time="0.0207827091217041" sim_time_ns="1020.0" ratio_time="49079.26074636626" />
+    <testcase name="test_mxfp4_packed_serial" classname="test" file="/app/test/test.py" lineno="497" time="0.00011563301086425781" sim_time_ns="0.0" ratio_time="0.0" />
+    <testcase name="test_mxfp4_packed" classname="test" file="/app/test/test.py" lineno="514" time="8.296966552734375e-05" sim_time_ns="0.0" ratio_time="0.0" />
+    <testcase name="test_mixed_precision" classname="test" file="/app/test/test.py" lineno="531" time="8.320808410644531e-05" sim_time_ns="0.0" ratio_time="0.0" />
+    <testcase name="test_mxfp_mac_randomized" classname="test" file="/app/test/test.py" lineno="553" time="0.4007115364074707" sim_time_ns="25500.0" ratio_time="63636.80024941899" />
+    <testcase name="test_fast_start_scale_compression" classname="test" file="/app/test/test.py" lineno="583" time="0.012183427810668945" sim_time_ns="900.0" ratio_time="73870.83618715877" />
+    <testcase name="test_yaml_cases" classname="test" file="/app/test/test.py" lineno="729" time="0.09620046615600586" sim_time_ns="2040.0" ratio_time="21205.71844934497" />
+    <testcase name="test_mx_fp4_yaml" classname="test" file="/app/test/test.py" lineno="733" time="0.035384178161621094" sim_time_ns="1530.0000000000036" ratio_time="43239.664717138876" />
+    <testcase name="test_mxplus_yaml" classname="test" file="/app/test/test.py" lineno="737" time="0.01840806007385254" sim_time_ns="510.0" ratio_time="27705.255086842208" />
+    <testcase name="test_mxfp8_subnormals" classname="test" file="/app/test/test.py" lineno="741" time="0.007010221481323242" sim_time_ns="510.0" ratio_time="72750.91113151719" />
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
This change implements Step 3 of the MX+ extension roadmap. It introduces centralized logic in the top-level FSM to identify which streaming elements correspond to the designated Block Max (BM) outliers for both operands. This is achieved by calculating element indices from the cycle counter and comparing them against stored metadata. The outlier flags are then passed to the multiplier lanes. This prepares the datapath for the upcoming Step 4, where the multiplier will repurpose the exponent bits of these flagged elements for increased precision.

Fixes #324

---
*PR created automatically by Jules for task [17088042071205774439](https://jules.google.com/task/17088042071205774439) started by @chatelao*