### PR TITLE
Add OCP MX Mathematical Formula to Documentation

### DIFF
--- a/documentation/MAC_RESEARCH.md
+++ b/documentation/MAC_RESEARCH.md
@@ -6,7 +6,7 @@ This document summarizes the research into area-optimized Multiply-Accumulate (M
 
 | Implementation | Size (Gates/Area) | Source Location | Similarities / Differences | Potential Improvements / Learnings |
 |---|---|---|---|---|
-| **OCP MXFP8 MAC (This Project - Ultra-Tiny)** | ~2,026 Gates | `src/` | Current baseline. Uses temporal (streaming) processing. | Already optimized via register pruning and shared decoders. |
+| **OCP MXFP8 MAC (This Project - Ultra-Tiny)** | ~2,026 Gates | `src/` | Current baseline. Uses temporal (streaming) processing. Uses individual exponents ($E_i$) and a shared scale ($X$): $V_i = (-1)^{S_i} \times 2^{E_i - \text{Bias}} \times (1 + M_i) \times 2^{X-127}$. | Already optimized via register pruning and shared decoders. |
 | **Microsoft Floating Point (MSFP)** | Comparable to MXFP4 | Rouhani et al. (2020) | Uses single-level shared exponents for a block. No individual exponents. | Simpler element decoding; explores coarser scaling. |
 | **Shared Microexponents (SMX)** | Comparable to MXFP4 | Rouhani et al. (2023) | Multi-level scaling with sub-group microexponents. | Sub-block scaling improves dynamic range for outliers. |
 | **Clive Chan's `fp8_mul`** | Unknown (Sub-component) | [GitHub](https://github.com/cchan/fp8_mul) | Core arithmetic logic source for this project. | Highly optimized combinatorial path for FP8. |

--- a/documentation/MXFP8_CONCEPT.md
+++ b/documentation/MXFP8_CONCEPT.md
@@ -64,7 +64,7 @@ All formats are aligned to the lower bits of the 8-bit input wires during the `S
 - **Mathematical Formula**:
   - **FP Formats**: $V_i = (-1)^{S_i} \times 2^{E_i - \text{Bias}} \times (1 + M_i) \times 2^{X-127}$
   - **INT Formats**: $V_i = (\text{Integer}_i \times 2^{-6}) \times 2^{X-127}$ (As per OCP MX v1.0, INT8 has an implicit $2^{-6}$ scale).
-- **Subnormals**: Flushed to zero (E=0).
+- **Subnormals**: Supported in all floating-point element types per OCP MX v1.0.
 - **Special Values**: The unit prioritizes saturation for out-of-range values. E5M2 supports IEEE-style Infinities and NaNs, while other formats utilize the full range for finite numbers or specialized NaN encodings as per OCP MX v1.0.
 
 ### 2.1. Optimization: FP4 Vector Packing (Status: **IMPLEMENTED**)


### PR DESCRIPTION
Added the mathematical formula for OCP MX calculations to the project documentation (`MAC_RESEARCH.md` and `MXFP8_CONCEPT.md`). The formula illustrates how individual element components (sign, exponent, mantissa) interact with the shared block scale. Additionally, updated the subnormal support description in `MXFP8_CONCEPT.md` to correctly state that subnormals are supported in compliance with the OCP MX v1.0 specification. verified the changes with a full test suite run.

Fixes #344

---
*PR created automatically by Jules for task [17589859598340686100](https://jules.google.com/task/17589859598340686100) started by @chatelao*