### PR TITLE
Implement OPTIMIZE_FP4 Steps 1 & 2

### DIFF
--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -2,6 +2,7 @@
 
 // This file contains logic derived from fp8_mul by Clive Chan (https://github.com/cchan/fp8_mul)
 module fp8_mul #(
+    parameter SUPPORT_E4M3  = 1,
     parameter SUPPORT_E5M2  = 1,
     parameter SUPPORT_MXFP6 = 1,
     parameter SUPPORT_MXFP4 = 1,
@@ -57,7 +58,7 @@ module fp8_mul #(
             zero_out = 1'b1;
 
             case (fmt)
-                FMT_E4M3: begin
+                FMT_E4M3: if (SUPPORT_E4M3) begin
                     sign_out = data[7];
                     bias_out = 6'sd7;
                     if (is_bm && SUPPORT_MX_PLUS) begin
@@ -159,12 +160,14 @@ module fp8_mul #(
             decode_operand(b, format_a, is_bm_b, sign_b, eb, mb, bias_b, zero_b);
         end
 
-        // 8x8 or 4x4 Multiplier (Variant B: Parameterized Multiplier)
+        // 8x8, 4x4 or 2x2 Multiplier (Variant B: Parameterized Multiplier)
         // Synthesis tools will optimize the multiplier width based on the parameters
         if (SUPPORT_INT8 || SUPPORT_MX_PLUS)
             p_res = (zero_a || zero_b) ? 16'd0 : (ma * mb);
-        else
+        else if (SUPPORT_E4M3 || SUPPORT_E5M2 || SUPPORT_MXFP6)
             p_res = (zero_a || zero_b) ? 16'd0 : ({4'b0, ma[3:0]} * {4'b0, mb[3:0]});
+        else
+            p_res = (zero_a || zero_b) ? 16'd0 : ({{14{1'b0}}, ma[3:2]} * {{14{1'b0}}, mb[3:2]}) << 4;
 
         sign_res = sign_a ^ sign_b;
         exp_sum_res = $signed({2'b0, ea}) + $signed({2'b0, eb}) - ($signed(bias_a) + $signed(bias_b) - 7'sd7);

--- a/src/fp8_mul_lns.v
+++ b/src/fp8_mul_lns.v
@@ -3,6 +3,7 @@
 // This file implements an FP8 multiplier using Logarithmic Number System (LNS).
 // It replaces the 4x4/8x8 multiplier with a simple adder or LUT.
 module fp8_mul_lns #(
+    parameter SUPPORT_E4M3  = 1,
     parameter SUPPORT_E5M2  = 1,
     parameter SUPPORT_MXFP6 = 1,
     parameter SUPPORT_MXFP4 = 1,
@@ -77,7 +78,7 @@ module fp8_mul_lns #(
             is_int_out = 1'b0;
 
             case (fmt)
-                FMT_E4M3: begin
+                FMT_E4M3: if (SUPPORT_E4M3) begin
                     sign_out = data[7];
                     bias_out = 6'sd7;
                     if (is_bm && SUPPORT_MX_PLUS) begin

--- a/src/project.v
+++ b/src/project.v
@@ -13,6 +13,7 @@
 module tt_um_chatelao_fp8_multiplier #(
     parameter ALIGNER_WIDTH = 32,
     parameter ACCUMULATOR_WIDTH = 24,
+    parameter SUPPORT_E4M3  = 1,
     parameter SUPPORT_E5M2  = 0,
     parameter SUPPORT_MXFP6 = 0,
     parameter SUPPORT_MXFP4 = 1,
@@ -253,6 +254,7 @@ module tt_um_chatelao_fp8_multiplier #(
     generate
         if (USE_LNS_MUL) begin : lns_gen
             fp8_mul_lns #(
+                .SUPPORT_E4M3(SUPPORT_E4M3),
                 .SUPPORT_E5M2(SUPPORT_E5M2),
                 .SUPPORT_MXFP6(SUPPORT_MXFP6),
                 .SUPPORT_MXFP4(SUPPORT_MXFP4),
@@ -273,6 +275,7 @@ module tt_um_chatelao_fp8_multiplier #(
             );
             if (SUPPORT_VECTOR_PACKING) begin : gen_lane1
                 fp8_mul_lns #(
+                    .SUPPORT_E4M3(SUPPORT_E4M3),
                     .SUPPORT_E5M2(SUPPORT_E5M2),
                     .SUPPORT_MXFP6(SUPPORT_MXFP6),
                     .SUPPORT_MXFP4(SUPPORT_MXFP4),
@@ -298,6 +301,7 @@ module tt_um_chatelao_fp8_multiplier #(
             end
         end else begin : std_gen
             fp8_mul #(
+                .SUPPORT_E4M3(SUPPORT_E4M3),
                 .SUPPORT_E5M2(SUPPORT_E5M2),
                 .SUPPORT_MXFP6(SUPPORT_MXFP6),
                 .SUPPORT_MXFP4(SUPPORT_MXFP4),
@@ -317,6 +321,7 @@ module tt_um_chatelao_fp8_multiplier #(
             );
             if (SUPPORT_VECTOR_PACKING) begin : gen_lane1
                 fp8_mul #(
+                    .SUPPORT_E4M3(SUPPORT_E4M3),
                     .SUPPORT_E5M2(SUPPORT_E5M2),
                     .SUPPORT_MXFP6(SUPPORT_MXFP6),
                     .SUPPORT_MXFP4(SUPPORT_MXFP4),

--- a/src_gowin/tt_gowin_top.v
+++ b/src_gowin/tt_gowin_top.v
@@ -3,6 +3,7 @@
 module tt_gowin_top #(
     parameter ALIGNER_WIDTH = 32,
     parameter ACCUMULATOR_WIDTH = 24,
+    parameter SUPPORT_E4M3 = 1,
     parameter SUPPORT_E5M2 = 0,
     parameter SUPPORT_MXFP6 = 0,
     parameter SUPPORT_MXFP4 = 1,
@@ -41,6 +42,7 @@ module tt_gowin_top #(
     tt_um_chatelao_fp8_multiplier #(
         .ALIGNER_WIDTH(ALIGNER_WIDTH),
         .ACCUMULATOR_WIDTH(ACCUMULATOR_WIDTH),
+        .SUPPORT_E4M3(SUPPORT_E4M3),
         .SUPPORT_E5M2(SUPPORT_E5M2),
         .SUPPORT_MXFP6(SUPPORT_MXFP6),
         .SUPPORT_MXFP4(SUPPORT_MXFP4),

--- a/test/gate_analysis.py
+++ b/test/gate_analysis.py
@@ -26,6 +26,7 @@ def get_yosys_stats(params):
 
 def main():
     features = [
+        "SUPPORT_E4M3",
         "SUPPORT_E5M2",
         "SUPPORT_MXFP6",
         "SUPPORT_MXFP4",

--- a/test/tb.v
+++ b/test/tb.v
@@ -25,6 +25,7 @@ module tb ();
 
   parameter ALIGNER_WIDTH = 32;
   parameter ACCUMULATOR_WIDTH = 24;
+  parameter SUPPORT_E4M3 = 1;
   parameter SUPPORT_E5M2 = 0;
   parameter SUPPORT_MXFP6 = 0;
   parameter SUPPORT_MXFP4 = 1;
@@ -58,6 +59,7 @@ module tb ();
   tt_um_chatelao_fp8_multiplier #(
       .ALIGNER_WIDTH(ALIGNER_WIDTH),
       .ACCUMULATOR_WIDTH(ACCUMULATOR_WIDTH),
+      .SUPPORT_E4M3(SUPPORT_E4M3),
       .SUPPORT_E5M2(SUPPORT_E5M2),
       .SUPPORT_MXFP6(SUPPORT_MXFP6),
       .SUPPORT_MXFP4(SUPPORT_MXFP4),


### PR DESCRIPTION
This change implements the first two steps of the OPTIMIZE_FP4 roadmap.
1. It adds a `SUPPORT_E4M3` parameter to make the E4M3 format optional, mirroring the existing `SUPPORT_E5M2` and `SUPPORT_MXFP6` parameters.
2. it refactors the multiplier core in `fp8_mul.v` to automatically scale down to a 2x2 significand multiplier (producing a shifted 4-bit product) when all wider formats (E4M3, E5M2, MXFP6, INT8) and MX+ extensions are disabled. This significantly reduces the gate count for FP4-only builds.
Verification was performed using the included gate analysis script and the Cocotb test suite across multiple configurations.

Fixes #380

---
*PR created automatically by Jules for task [5697270306689584666](https://jules.google.com/task/5697270306689584666) started by @chatelao*