### PR TITLE
Chg - Implement next step of OPTIMIZE_FP4.md (Step 3: Exponent Refactoring)

### DIFF
--- a/documentation/OPTIMIZE_FP4.md
+++ b/documentation/OPTIMIZE_FP4.md
@@ -45,7 +45,7 @@ While FP8 requires a 32-bit or 40-bit accumulator to maintain precision across 3
 - **Action**: Refactor the multiplier in `fp8_mul.v` to use a hierarchical structure that scales its bit-width based on the feature parameters.
 - **Goal**: Automatically instantiate a minimal 2x2 multiplier for FP4-only builds, while preserving 8x8 capability for multi-format builds.
 
-### Step 3: Minimal Exponent Path Refactoring
+### Step 3: Minimal Exponent Path Refactoring (COMPLETED)
 - **Action**: Parameterize the internal exponent bit-width and bias constants throughout the datapath.
 - **Goal**: Shrink the exponent arithmetic logic from 6 bits to 3 bits when only narrow formats are enabled.
 

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -8,7 +8,8 @@ module fp8_mul #(
     parameter SUPPORT_MXFP4 = 1,
     parameter SUPPORT_INT8  = 1,
     parameter SUPPORT_MIXED_PRECISION = 1,
-    parameter SUPPORT_MX_PLUS = 0
+    parameter SUPPORT_MX_PLUS = 0,
+    parameter EXP_SUM_WIDTH = 7
 )(
     input  wire [7:0] a,
     input  wire [7:0] b,
@@ -17,7 +18,7 @@ module fp8_mul #(
     input  wire       is_bm_a,
     input  wire       is_bm_b,
     output wire [15:0] prod,    // Mantissa product
-    output wire signed [6:0] exp_sum, // Combined exponent (biased)
+    output wire signed [EXP_SUM_WIDTH-1:0] exp_sum, // Combined exponent (biased)
     output wire       sign
 );
     // Format Selection
@@ -29,14 +30,19 @@ module fp8_mul #(
     localparam FMT_INT8 = 3'b101;
     localparam FMT_INT8_SYM = 3'b110;
 
+    localparam INTERNAL_EXP_WIDTH = (SUPPORT_E5M2) ? 5 :
+                                    (SUPPORT_E4M3 || SUPPORT_INT8 || SUPPORT_MX_PLUS) ? 4 :
+                                    (SUPPORT_MXFP6) ? 3 : 2;
+    localparam INTERNAL_BIAS_WIDTH = INTERNAL_EXP_WIDTH + 1;
+
     reg sign_a, sign_b;
-    reg [4:0] ea, eb;
+    reg [INTERNAL_EXP_WIDTH-1:0] ea, eb;
     reg [7:0] ma, mb;
-    reg signed [5:0] bias_a, bias_b;
+    reg signed [INTERNAL_BIAS_WIDTH-1:0] bias_a, bias_b;
     reg zero_a, zero_b;
 
     reg [15:0] p_res;
-    reg signed [6:0] exp_sum_res;
+    reg signed [EXP_SUM_WIDTH-1:0] exp_sum_res;
     reg sign_res;
 
     task automatic decode_operand(
@@ -44,81 +50,81 @@ module fp8_mul #(
         input [2:0] fmt,
         input is_bm,
         output reg sign_out,
-        output reg [4:0] exp_out,
+        output reg [INTERNAL_EXP_WIDTH-1:0] exp_out,
         output reg [7:0] mant_out,
-        output reg signed [5:0] bias_out,
+        output reg signed [INTERNAL_BIAS_WIDTH-1:0] bias_out,
         output reg zero_out
     );
         begin
             // Defaults for unsupported formats
             sign_out = 1'b0;
-            exp_out = 5'd0;
+            exp_out = {INTERNAL_EXP_WIDTH{1'b0}};
             mant_out = 8'd0;
-            bias_out = 6'sd0;
+            bias_out = {INTERNAL_BIAS_WIDTH{1'b0}};
             zero_out = 1'b1;
 
             case (fmt)
                 FMT_E4M3: if (SUPPORT_E4M3) begin
                     sign_out = data[7];
-                    bias_out = 6'sd7;
+                    bias_out = 7;
                     if (is_bm && SUPPORT_MX_PLUS) begin
-                        exp_out = 5'd11; // 15 - 4 (mantissa shift compensation)
+                        exp_out = 11; // 15 - 4 (mantissa shift compensation)
                         mant_out = {1'b1, data[6:0]};
                         zero_out = 1'b0;
                     end else begin
-                        exp_out = (data[6:3] == 4'd0) ? 5'd1 : {1'b0, data[6:3]};
+                        exp_out = (data[6:3] == 4'd0) ? 1 : data[6:3];
                         mant_out = {4'b0, (data[6:3] != 4'd0), data[2:0]};
                         zero_out = (data[6:0] == 7'd0);
                     end
                 end
                 FMT_E5M2: if (SUPPORT_E5M2) begin
                     sign_out = data[7];
-                    bias_out = 6'sd15;
+                    bias_out = 15;
                     if (is_bm && SUPPORT_MX_PLUS) begin
-                        exp_out = 5'd26; // 30 - 4 (mantissa shift compensation)
+                        exp_out = 26; // 30 - 4 (mantissa shift compensation)
                         mant_out = {1'b1, data[6:0]};
                         zero_out = 1'b0;
                     end else begin
-                        exp_out = (data[6:2] == 5'd0) ? 5'd1 : data[6:2];
+                        exp_out = (data[6:2] == 5'd0) ? 1 : data[6:2];
                         mant_out = {4'b0, (data[6:2] != 5'd0), data[1:0], 1'b0};
                         zero_out = (data[6:0] == 7'd0);
                     end
                 end
                 FMT_E3M2: if (SUPPORT_MXFP6) begin
                     sign_out = data[5];
-                    bias_out = 6'sd3;
+                    bias_out = 3;
                     if (is_bm && SUPPORT_MX_PLUS) begin
-                        exp_out = 5'd5; // 7 - 2 (mantissa shift compensation)
+                        exp_out = 5; // 7 - 2 (mantissa shift compensation)
                         mant_out = {2'b0, 1'b1, data[4:0]};
                         zero_out = 1'b0;
                     end else begin
-                        exp_out = (data[4:2] == 3'd0) ? 5'd1 : {2'b0, data[4:2]};
+                        exp_out = (data[4:2] == 3'd0) ? 1 : data[4:2];
                         mant_out = {4'b0, (data[4:2] != 3'd0), data[1:0], 1'b0};
                         zero_out = (data[4:0] == 5'd0);
                     end
                 end
                 FMT_E2M3: if (SUPPORT_MXFP6) begin
                     sign_out = data[5];
-                    bias_out = 6'sd1;
+                    bias_out = 1;
                     if (is_bm && SUPPORT_MX_PLUS) begin
-                        exp_out = 5'd1; // 3 - 2 (mantissa shift compensation)
+                        exp_out = 1; // 3 - 2 (mantissa shift compensation)
                         mant_out = {2'b0, 1'b1, data[4:0]};
                         zero_out = 1'b0;
                     end else begin
-                        exp_out = (data[4:3] == 2'd0) ? 5'd1 : {3'b0, data[4:3]};
+                        exp_out = (data[4:3] == 2'd0) ? 1 : data[4:3];
                         mant_out = {4'b0, (data[4:3] != 2'd0), data[2:0]};
                         zero_out = (data[4:0] == 5'd0);
                     end
                 end
                 FMT_E2M1: if (SUPPORT_MXFP4) begin
                     sign_out = data[3];
-                    bias_out = 6'sd1;
+                    bias_out = 1;
                     if (is_bm && SUPPORT_MX_PLUS) begin
-                        exp_out = 5'd3; // No compensation needed (shift 0)
+                        exp_out = 3; // No compensation needed (shift 0)
                         mant_out = {4'b0, 1'b1, data[2:0]};
                         zero_out = 1'b0;
                     end else begin
-                        exp_out = (data[2:1] == 2'd0) ? 5'd1 : {3'b0, data[2:1]};
+                        exp_out = (data[2:1] == 2'd0) ? 1 : data[2:1];
                         mant_out = {4'b0, (data[2:1] != 2'd0), data[0], 2'b0};
                         zero_out = (data[2:0] == 3'd0);
                     end
@@ -126,22 +132,22 @@ module fp8_mul #(
                 FMT_INT8: if (SUPPORT_INT8) begin
                     sign_out = data[7];
                     mant_out = data[7] ? -data : data;
-                    exp_out = 5'd0;
-                    bias_out = 6'sd3;
+                    exp_out = 0;
+                    bias_out = 3;
                     zero_out = (data == 8'd0);
                 end
                 FMT_INT8_SYM: if (SUPPORT_INT8) begin
                     sign_out = data[7];
                     mant_out = (data == 8'h80) ? 8'd127 : (data[7] ? -data : data);
-                    exp_out = 5'd0;
-                    bias_out = 6'sd3;
+                    exp_out = 0;
+                    bias_out = 3;
                     zero_out = (data == 8'd0);
                 end
                 default: begin
                     sign_out = data[7];
-                    exp_out = (data[6:3] == 4'd0) ? 5'd1 : {1'b0, data[6:3]};
+                    exp_out = (data[6:3] == 4'd0) ? 1 : data[6:3];
                     mant_out = {4'b0, (data[6:3] != 4'd0), data[2:0]};
-                    bias_out = 6'sd7;
+                    bias_out = 7;
                     zero_out = (data[6:0] == 7'd0);
                 end
             endcase
@@ -170,7 +176,7 @@ module fp8_mul #(
             p_res = (zero_a || zero_b) ? 16'd0 : ({{14{1'b0}}, ma[3:2]} * {{14{1'b0}}, mb[3:2]}) << 4;
 
         sign_res = sign_a ^ sign_b;
-        exp_sum_res = $signed({2'b0, ea}) + $signed({2'b0, eb}) - ($signed(bias_a) + $signed(bias_b) - 7'sd7);
+        exp_sum_res = $signed({2'b0, ea}) + $signed({2'b0, eb}) - ($signed(bias_a) + $signed(bias_b) - $signed({{(EXP_SUM_WIDTH-3){1'b0}}, 3'sd7}));
     end
 
     assign sign = sign_res;

--- a/src/fp8_mul_lns.v
+++ b/src/fp8_mul_lns.v
@@ -10,7 +10,8 @@ module fp8_mul_lns #(
     parameter SUPPORT_INT8  = 1,
     parameter SUPPORT_MIXED_PRECISION = 1,
     parameter SUPPORT_MX_PLUS = 0,
-    parameter USE_LNS_MUL_PRECISE = 0
+    parameter USE_LNS_MUL_PRECISE = 0,
+    parameter EXP_SUM_WIDTH = 7
 )(
     input  wire [7:0] a,
     input  wire [7:0] b,
@@ -19,7 +20,7 @@ module fp8_mul_lns #(
     input  wire       is_bm_a,
     input  wire       is_bm_b,
     output wire [15:0] prod,    // Mantissa product
-    output wire signed [6:0] exp_sum, // Combined exponent (biased)
+    output wire signed [EXP_SUM_WIDTH-1:0] exp_sum, // Combined exponent (biased)
     output wire       sign
 );
     // Format Selection
@@ -31,15 +32,20 @@ module fp8_mul_lns #(
     localparam FMT_INT8 = 3'b101;
     localparam FMT_INT8_SYM = 3'b110;
 
+    localparam INTERNAL_EXP_WIDTH = (SUPPORT_E5M2) ? 5 :
+                                    (SUPPORT_E4M3 || SUPPORT_INT8 || SUPPORT_MX_PLUS) ? 4 :
+                                    (SUPPORT_MXFP6) ? 3 : 2;
+    localparam INTERNAL_BIAS_WIDTH = INTERNAL_EXP_WIDTH + 1;
+
     reg sign_a, sign_b;
-    reg [4:0] ea, eb;
+    reg [INTERNAL_EXP_WIDTH-1:0] ea, eb;
     reg [7:0] ma, mb;
-    reg signed [5:0] bias_a, bias_b;
+    reg signed [INTERNAL_BIAS_WIDTH-1:0] bias_a, bias_b;
     reg zero_a, zero_b;
     reg is_inta, is_intb;
 
     reg [15:0] p_res;
-    reg signed [6:0] exp_sum_res;
+    reg signed [EXP_SUM_WIDTH-1:0] exp_sum_res;
     reg sign_res;
     reg [3:0] m_sum;
 
@@ -62,83 +68,83 @@ module fp8_mul_lns #(
         input [2:0] fmt,
         input is_bm,
         output reg sign_out,
-        output reg [4:0] exp_out,
+        output reg [INTERNAL_EXP_WIDTH-1:0] exp_out,
         output reg [7:0] mant_out,
-        output reg signed [5:0] bias_out,
+        output reg signed [INTERNAL_BIAS_WIDTH-1:0] bias_out,
         output reg zero_out,
         output reg is_int_out
     );
         begin
             // Defaults for unsupported formats
             sign_out = 1'b0;
-            exp_out = 5'd0;
+            exp_out = {INTERNAL_EXP_WIDTH{1'b0}};
             mant_out = 8'd0;
-            bias_out = 6'sd0;
+            bias_out = {INTERNAL_BIAS_WIDTH{1'b0}};
             zero_out = 1'b1;
             is_int_out = 1'b0;
 
             case (fmt)
                 FMT_E4M3: if (SUPPORT_E4M3) begin
                     sign_out = data[7];
-                    bias_out = 6'sd7;
+                    bias_out = 7;
                     if (is_bm && SUPPORT_MX_PLUS) begin
-                        exp_out = 5'd11; // 15 - 4 (mantissa shift compensation)
+                        exp_out = 11; // 15 - 4 (mantissa shift compensation)
                         mant_out = {1'b1, data[6:0]};
                         zero_out = 1'b0;
                     end else begin
-                        exp_out = (data[6:3] == 4'd0) ? 5'd1 : {1'b0, data[6:3]};
+                        exp_out = (data[6:3] == 4'd0) ? 1 : data[6:3];
                         mant_out = {4'b0, (data[6:3] != 4'd0), data[2:0]};
                         zero_out = (data[6:0] == 7'd0);
                     end
                 end
                 FMT_E5M2: if (SUPPORT_E5M2) begin
                     sign_out = data[7];
-                    bias_out = 6'sd15;
+                    bias_out = 15;
                     if (is_bm && SUPPORT_MX_PLUS) begin
-                        exp_out = 5'd26; // 30 - 4 (mantissa shift compensation)
+                        exp_out = 26; // 30 - 4 (mantissa shift compensation)
                         mant_out = {1'b1, data[6:0]};
                         zero_out = 1'b0;
                     end else begin
-                        exp_out = (data[6:2] == 5'd0) ? 5'd1 : data[6:2];
+                        exp_out = (data[6:2] == 5'd0) ? 1 : data[6:2];
                         mant_out = {4'b0, (data[6:2] != 5'd0), data[1:0], 1'b0};
                         zero_out = (data[6:0] == 7'd0);
                     end
                 end
                 FMT_E3M2: if (SUPPORT_MXFP6) begin
                     sign_out = data[5];
-                    bias_out = 6'sd3;
+                    bias_out = 3;
                     if (is_bm && SUPPORT_MX_PLUS) begin
-                        exp_out = 5'd5; // 7 - 2 (mantissa shift compensation)
+                        exp_out = 5; // 7 - 2 (mantissa shift compensation)
                         mant_out = {2'b0, 1'b1, data[4:0]};
                         zero_out = 1'b0;
                     end else begin
-                        exp_out = (data[4:2] == 3'd0) ? 5'd1 : {2'b0, data[4:2]};
+                        exp_out = (data[4:2] == 3'd0) ? 1 : data[4:2];
                         mant_out = {4'b0, (data[4:2] != 3'd0), data[1:0], 1'b0};
                         zero_out = (data[4:0] == 5'd0);
                     end
                 end
                 FMT_E2M3: if (SUPPORT_MXFP6) begin
                     sign_out = data[5];
-                    bias_out = 6'sd1;
+                    bias_out = 1;
                     if (is_bm && SUPPORT_MX_PLUS) begin
-                        exp_out = 5'd1; // 3 - 2 (mantissa shift compensation)
+                        exp_out = 1; // 3 - 2 (mantissa shift compensation)
                         mant_out = {2'b0, 1'b1, data[4:0]};
                         zero_out = 1'b0;
                     end else begin
-                        exp_out = (data[4:3] == 2'd0) ? 5'd1 : {3'b0, data[4:3]};
+                        exp_out = (data[4:3] == 2'd0) ? 1 : data[4:3];
                         mant_out = {4'b0, (data[4:3] != 2'd0), data[2:0]};
                         zero_out = (data[4:0] == 5'd0);
                     end
                 end
                 FMT_E2M1: if (SUPPORT_MXFP4) begin
                     sign_out = data[3];
-                    bias_out = 6'sd1;
+                    bias_out = 1;
                     if (is_bm && SUPPORT_MX_PLUS) begin
-                        exp_out = 5'd3; // No compensation needed (shift 0)
+                        exp_out = 3; // No compensation needed (shift 0)
                         mant_out = {4'b0, 1'b1, data[2:0]};
                         zero_out = 1'b0;
                     end else begin
-                        exp_out = (data[2:1] == 2'd0) ? 5'd1 : {3'b0, data[2:1]};
+                        exp_out = (data[2:1] == 2'd0) ? 1 : data[2:1];
                         mant_out = {4'b0, (data[2:1] != 2'd0), data[0], 2'b0};
                         zero_out = (data[2:0] == 3'd0);
                     end
@@ -146,24 +152,24 @@ module fp8_mul_lns #(
                 FMT_INT8: if (SUPPORT_INT8) begin
                     sign_out = data[7];
                     mant_out = data[7] ? -data : data;
-                    exp_out = 5'd0;
-                    bias_out = 6'sd3;
+                    exp_out = 0;
+                    bias_out = 3;
                     zero_out = (data == 8'd0);
                     is_int_out = 1'b1;
                 end
                 FMT_INT8_SYM: if (SUPPORT_INT8) begin
                     sign_out = data[7];
                     mant_out = (data == 8'h80) ? 8'd127 : (data[7] ? -data : data);
-                    exp_out = 5'd0;
-                    bias_out = 6'sd3;
+                    exp_out = 0;
+                    bias_out = 3;
                     zero_out = (data == 8'd0);
                     is_int_out = 1'b1;
                 end
                 default: begin
                     sign_out = data[7];
-                    exp_out = (data[6:3] == 4'd0) ? 5'd1 : {1'b0, data[6:3]};
+                    exp_out = (data[6:3] == 4'd0) ? 1 : data[6:3];
                     mant_out = {4'b0, (data[6:3] != 4'd0), data[2:0]};
-                    bias_out = 6'sd7;
+                    bias_out = 7;
                     zero_out = (data[6:0] == 7'd0);
                 end
             endcase
@@ -186,15 +192,15 @@ module fp8_mul_lns #(
         if (is_inta || is_intb) begin
             // Logarithmic multiplication doesn't apply easily to INT8 in this architecture.
             p_res = 16'd0;
-            exp_sum_res = 7'sd0;
+            exp_sum_res = {EXP_SUM_WIDTH{1'b0}};
         end else begin
             if (zero_a || zero_b) begin
                 p_res = 16'd0;
-                exp_sum_res = 7'sd0;
+                exp_sum_res = {EXP_SUM_WIDTH{1'b0}};
             end else if (SUPPORT_MX_PLUS && (is_bm_a || is_bm_b)) begin
                 // To maintain the precision benefits of MX+, BM elements use a standard multiplier
                 p_res = ma * mb;
-                exp_sum_res = $signed({2'b0, ea}) + $signed({2'b0, eb}) - ($signed(bias_a) + $signed(bias_b) - 7'sd7);
+                exp_sum_res = $signed({2'b0, ea}) + $signed({2'b0, eb}) - ($signed(bias_a) + $signed(bias_b) - $signed({{(EXP_SUM_WIDTH-3){1'b0}}, 3'sd7}));
             end else begin
                 if (USE_LNS_MUL_PRECISE) begin
                     m_sum = lns_lut[{ma[2:0], mb[2:0]}];
@@ -204,7 +210,7 @@ module fp8_mul_lns #(
                     m_sum = ma[2:0] + mb[2:0];
                 end
                 p_res = {9'd0, 1'b1, m_sum[2:0], 3'd0}; // (1.m_res) << 6
-                exp_sum_res = $signed({2'b0, ea}) + $signed({2'b0, eb}) - ($signed(bias_a) + $signed(bias_b) - 7'sd7) + $signed({6'b0, m_sum[3]});
+                exp_sum_res = $signed({2'b0, ea}) + $signed({2'b0, eb}) - ($signed(bias_a) + $signed(bias_b) - $signed({{(EXP_SUM_WIDTH-3){1'b0}}, 3'sd7})) + $signed({{(EXP_SUM_WIDTH-1){1'b0}}, m_sum[3]});
             end
         end
         sign_res = sign_a ^ sign_b;

--- a/src/project.v
+++ b/src/project.v
@@ -212,9 +212,13 @@ module tt_um_chatelao_fp8_multiplier #(
     // MXFP8 Datapath Integration (Step 12: Pipelining & Scale Compression)
     // ------------------------------------------------------------------------
 
+    // Exponent Width Parameterization (Step 3 of OPTIMIZE_FP4)
+    localparam EXP_SUM_WIDTH = (SUPPORT_E5M2) ? 7 :
+                               (SUPPORT_E4M3 || SUPPORT_INT8 || SUPPORT_MX_PLUS) ? 6 : 5;
+
     // 1. Multiplier & Pipeline Stage
     wire [15:0] mul_prod_lane0, mul_prod_lane1;
-    wire signed [6:0] mul_exp_sum_lane0, mul_exp_sum_lane1;
+    wire signed [EXP_SUM_WIDTH-1:0] mul_exp_sum_lane0, mul_exp_sum_lane1;
     wire mul_sign_lane0, mul_sign_lane1;
 
     reg [3:0] packed_a_buf, packed_b_buf;
@@ -261,7 +265,8 @@ module tt_um_chatelao_fp8_multiplier #(
                 .SUPPORT_INT8(SUPPORT_INT8),
                 .SUPPORT_MIXED_PRECISION(SUPPORT_MIXED_PRECISION),
                 .SUPPORT_MX_PLUS(SUPPORT_MX_PLUS),
-                .USE_LNS_MUL_PRECISE(USE_LNS_MUL_PRECISE)
+                .USE_LNS_MUL_PRECISE(USE_LNS_MUL_PRECISE),
+                .EXP_SUM_WIDTH(EXP_SUM_WIDTH)
             ) multiplier_lane0 (
                 .a(a_lane0),
                 .b(b_lane0),
@@ -282,7 +287,8 @@ module tt_um_chatelao_fp8_multiplier #(
                     .SUPPORT_INT8(SUPPORT_INT8),
                     .SUPPORT_MIXED_PRECISION(SUPPORT_MIXED_PRECISION),
                     .SUPPORT_MX_PLUS(SUPPORT_MX_PLUS),
-                    .USE_LNS_MUL_PRECISE(USE_LNS_MUL_PRECISE)
+                    .USE_LNS_MUL_PRECISE(USE_LNS_MUL_PRECISE),
+                    .EXP_SUM_WIDTH(EXP_SUM_WIDTH)
                 ) multiplier_lane1 (
                     .a(a_lane1),
                     .b(b_lane1),
@@ -296,7 +302,7 @@ module tt_um_chatelao_fp8_multiplier #(
                 );
             end else begin : no_lane1
                 assign mul_prod_lane1 = 16'd0;
-                assign mul_exp_sum_lane1 = 7'd0;
+                assign mul_exp_sum_lane1 = {EXP_SUM_WIDTH{1'b0}};
                 assign mul_sign_lane1 = 1'b0;
             end
         end else begin : std_gen
@@ -307,7 +313,8 @@ module tt_um_chatelao_fp8_multiplier #(
                 .SUPPORT_MXFP4(SUPPORT_MXFP4),
                 .SUPPORT_INT8(SUPPORT_INT8),
                 .SUPPORT_MIXED_PRECISION(SUPPORT_MIXED_PRECISION),
-                .SUPPORT_MX_PLUS(SUPPORT_MX_PLUS)
+                .SUPPORT_MX_PLUS(SUPPORT_MX_PLUS),
+                .EXP_SUM_WIDTH(EXP_SUM_WIDTH)
             ) multiplier_lane0 (
                 .a(a_lane0),
                 .b(b_lane0),
@@ -327,7 +334,8 @@ module tt_um_chatelao_fp8_multiplier #(
                     .SUPPORT_MXFP4(SUPPORT_MXFP4),
                     .SUPPORT_INT8(SUPPORT_INT8),
                     .SUPPORT_MIXED_PRECISION(SUPPORT_MIXED_PRECISION),
-                    .SUPPORT_MX_PLUS(SUPPORT_MX_PLUS)
+                    .SUPPORT_MX_PLUS(SUPPORT_MX_PLUS),
+                    .EXP_SUM_WIDTH(EXP_SUM_WIDTH)
                 ) multiplier_lane1 (
                     .a(a_lane1),
                     .b(b_lane1),
@@ -341,7 +349,7 @@ module tt_um_chatelao_fp8_multiplier #(
                 );
             end else begin : no_lane1
                 assign mul_prod_lane1 = 16'd0;
-                assign mul_exp_sum_lane1 = 7'd0;
+                assign mul_exp_sum_lane1 = {EXP_SUM_WIDTH{1'b0}};
                 assign mul_sign_lane1 = 1'b0;
             end
         end
@@ -350,7 +358,7 @@ module tt_um_chatelao_fp8_multiplier #(
     // Pipeline registers for multiplier output
     /* verilator lint_off UNUSEDSIGNAL */
     wire [15:0] mul_prod_lane0_val, mul_prod_lane1_val;
-    wire signed [6:0] mul_exp_sum_lane0_val, mul_exp_sum_lane1_val;
+    wire signed [EXP_SUM_WIDTH-1:0] mul_exp_sum_lane0_val, mul_exp_sum_lane1_val;
     wire mul_sign_lane0_val, mul_sign_lane1_val;
     /* verilator lint_on UNUSEDSIGNAL */
     wire is_bm_a_lane0_val, is_bm_b_lane0_val;
@@ -359,14 +367,14 @@ module tt_um_chatelao_fp8_multiplier #(
     generate
         if (SUPPORT_PIPELINING) begin : gen_pipeline
             reg [15:0] mul_prod_lane0_reg;
-            reg signed [6:0] mul_exp_sum_lane0_reg;
+            reg signed [EXP_SUM_WIDTH-1:0] mul_exp_sum_lane0_reg;
             reg mul_sign_lane0_reg;
             reg is_bm_a_lane0_reg, is_bm_b_lane0_reg;
 
             always @(posedge clk) begin
                 if (!rst_n) begin
                     mul_prod_lane0_reg <= 16'd0;
-                    mul_exp_sum_lane0_reg <= 7'd0;
+                    mul_exp_sum_lane0_reg <= {EXP_SUM_WIDTH{1'b0}};
                     mul_sign_lane0_reg <= 1'b0;
                     is_bm_a_lane0_reg <= 1'b0;
                     is_bm_b_lane0_reg <= 1'b0;
@@ -386,14 +394,14 @@ module tt_um_chatelao_fp8_multiplier #(
 
             if (SUPPORT_VECTOR_PACKING) begin : gen_pipeline_lane1
                 reg [15:0] mul_prod_lane1_reg;
-                reg signed [6:0] mul_exp_sum_lane1_reg;
+                reg signed [EXP_SUM_WIDTH-1:0] mul_exp_sum_lane1_reg;
                 reg mul_sign_lane1_reg;
                 reg is_bm_a_lane1_reg, is_bm_b_lane1_reg;
 
                 always @(posedge clk) begin
                     if (!rst_n) begin
                         mul_prod_lane1_reg <= 16'd0;
-                        mul_exp_sum_lane1_reg <= 7'd0;
+                        mul_exp_sum_lane1_reg <= {EXP_SUM_WIDTH{1'b0}};
                         mul_sign_lane1_reg <= 1'b0;
                         is_bm_a_lane1_reg <= 1'b0;
                         is_bm_b_lane1_reg <= 1'b0;
@@ -412,7 +420,7 @@ module tt_um_chatelao_fp8_multiplier #(
                 assign is_bm_b_lane1_val = is_bm_b_lane1_reg;
             end else begin : gen_no_pipeline_lane1
                 assign mul_prod_lane1_val = 16'd0;
-                assign mul_exp_sum_lane1_val = 7'd0;
+                assign mul_exp_sum_lane1_val = {EXP_SUM_WIDTH{1'b0}};
                 assign mul_sign_lane1_val = 1'b0;
                 assign is_bm_a_lane1_val = 1'b0;
                 assign is_bm_b_lane1_val = 1'b0;
@@ -450,12 +458,12 @@ module tt_um_chatelao_fp8_multiplier #(
 
     // MX++ Exponent Offset (Step 6)
     // Subtract offsets if the element is NOT a BM.
-    wire signed [9:0] exp_sum_lane0_adj = {{3{mul_exp_sum_lane0_val[6]}}, mul_exp_sum_lane0_val} -
+    wire signed [9:0] exp_sum_lane0_adj = {{(10-EXP_SUM_WIDTH){mul_exp_sum_lane0_val[EXP_SUM_WIDTH-1]}}, mul_exp_sum_lane0_val} -
                                           (is_bm_a_lane0_val ? 10'd0 : {7'd0, nbm_offset_a_val}) -
                                           (is_bm_b_lane0_val ? 10'd0 : {7'd0, nbm_offset_b_val});
 
     /* verilator lint_off UNUSEDSIGNAL */
-    wire signed [9:0] exp_sum_lane1_adj = {{3{mul_exp_sum_lane1_val[6]}}, mul_exp_sum_lane1_val} -
+    wire signed [9:0] exp_sum_lane1_adj = {{(10-EXP_SUM_WIDTH){mul_exp_sum_lane1_val[EXP_SUM_WIDTH-1]}}, mul_exp_sum_lane1_val} -
                                           (is_bm_a_lane1_val ? 10'd0 : {7'd0, nbm_offset_a_val}) -
                                           (is_bm_b_lane1_val ? 10'd0 : {7'd0, nbm_offset_b_val});
     /* verilator lint_on UNUSEDSIGNAL */


### PR DESCRIPTION
Implementation of Step 3 of the OPTIMIZE_FP4 roadmap. This change refactors the exponent arithmetic datapath to use parameterized bit-widths, enabling significant area savings when the MAC unit is configured for narrow formats like FP4 (E2M1). The refactoring maintains full backward compatibility for FP8/INT8 modes and has been verified against the complete functional test suite.

Fixes #383

---
*PR created automatically by Jules for task [7843045034445064582](https://jules.google.com/task/7843045034445064582) started by @chatelao*