### PR TITLE
Add PlantUML diagrams to SERV integration concept documentation

### DIFF
--- a/documentation/SERV_INTEGRATION_CONCEPT.md
+++ b/documentation/SERV_INTEGRATION_CONCEPT.md
@@ -15,6 +15,8 @@ By aligning these temporal windows, we can create an AI-capable RISC-V system th
 ### Variant A: Extension Interface (Coprocessor)
 This is the most standard and least intrusive method. It uses SERV's built-in **Extension Interface**.
 
+![SERV Variant A: Extension Interface](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/documentation/SERV_VARIANT_A.PUML)
+
 - **Mechanism**: SERV detects a custom R-type instruction and presents `rs1` and `rs2` as 32-bit parallel values on `o_ext_rs1` and `o_ext_rs2`.
 - **Parallel-to-Serial Adapter**: A small wrapper module is required to bridge the 32-bit parallel interface to the OCP MX's 8-bit streaming ports.
     - **Buffer Phase**: The adapter captures the 32-bit values into registers during the first stage of the extension call.
@@ -28,6 +30,8 @@ This is the most standard and least intrusive method. It uses SERV's built-in **
 
 ### Variant B: Internal Snooping (Tightly Coupled)
 This variant taps into the 1-bit streams of SERV's register file, aligning with the bit-serial nature of both cores.
+
+![SERV Variant B: Internal Snooping](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/documentation/SERV_VARIANT_B.PUML)
 
 - **Mechanism**: Instead of waiting for 32-bit parallel values, the OCP MX unit snoops the `o_rdata0` and `o_rdata1` 1-bit streams directly from the `serv_rf_if` (Register File Interface).
 - **Interface**: The OCP MX unit acts as a 1-bit serial consumer.

--- a/documentation/SERV_VARIANT_A.PUML
+++ b/documentation/SERV_VARIANT_A.PUML
@@ -1,0 +1,32 @@
+@startuml SERV_VARIANT_A
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
+
+LAYOUT_WITH_LEGEND()
+
+title SERV Integration - Variant A: Extension Interface (Coprocessor)
+
+Container_Boundary(serv_soc, "SERV-based SoC") {
+    Component(serv_core, "SERV Core", "Bit-serial RISC-V", "Processes 1 bit/cycle")
+
+    Container_Boundary(adapter_block, "Parallel-to-Serial Adapter") {
+        Component(reg_rs1, "32-bit RS1 Reg", "Buffer")
+        Component(reg_rs2, "32-bit RS2 Reg", "Buffer")
+        Component(shift_logic, "Streaming Logic", "FSM", "Shifts 8 bits to OCP MX")
+        Component(reg_rd, "32-bit RD Reg", "Buffer", "Captures OCP MX result")
+    }
+
+    Component(ocp_mx, "OCP MX Unit", "Tiny-Serial (K=8)", "Bit-serial MAC")
+}
+
+Rel_D(serv_core, reg_rs1, "o_ext_rs1", "32-bit Parallel")
+Rel_D(serv_core, reg_rs2, "o_ext_rs2", "32-bit Parallel")
+Rel_D(serv_core, shift_logic, "o_mdu_valid", "Control")
+
+Rel_R(reg_rs1, ocp_mx, "ui_in", "8-bit Stream")
+Rel_R(reg_rs2, ocp_mx, "uio_in", "8-bit Stream")
+Rel_L(ocp_mx, reg_rd, "uo_out", "8-bit Stream")
+
+Rel_U(reg_rd, serv_core, "i_ext_rd", "32-bit Parallel")
+Rel_U(shift_logic, serv_core, "i_ext_ready", "Strobe")
+
+@enduml

--- a/documentation/SERV_VARIANT_B.PUML
+++ b/documentation/SERV_VARIANT_B.PUML
@@ -1,0 +1,25 @@
+@startuml SERV_VARIANT_B
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
+
+LAYOUT_WITH_LEGEND()
+
+title SERV Integration - Variant B: Internal Snooping (Tightly Coupled)
+
+Container_Boundary(serv_core, "SERV Core (Internal)") {
+    Component(rf_if, "Register File IF", "serv_rf_if", "Serial bitstream provider")
+    Component(state, "State & Counter", "serv_state", "Execution tracking (cnt[4:0])")
+}
+
+Container_Boundary(ocp_mx_wrapper, "OCP MX Snooping Wrapper") {
+    Component(capture, "Capture Logic", "Shift Regs", "Samples o_rdata0/1 based on cnt")
+    Component(ocp_mx, "OCP MX Unit", "Tiny-Serial (K=8)", "Processes bit-serial MAC")
+}
+
+Rel_D(rf_if, capture, "o_rdata0 (rs1)", "1-bit Serial")
+Rel_D(rf_if, capture, "o_rdata1 (rs2)", "1-bit Serial")
+Rel_D(state, capture, "cnt[4:0], en", "Sync Signals")
+
+Rel_D(capture, ocp_mx, "ui_in, uio_in", "8-bit Internal Strobe")
+Rel_U(ocp_mx, rf_if, "uo_out (Result)", "Optional Feedthrough")
+
+@enduml


### PR DESCRIPTION
Added two new PlantUML files (`documentation/SERV_VARIANT_A.PUML` and `documentation/SERV_VARIANT_B.PUML`) and updated `documentation/SERV_INTEGRATION_CONCEPT.md` to display them. These diagrams illustrate the hardware integration strategies for the SERV RISC-V core and the OCP MX MAC unit.

Fixes #418

---
*PR created automatically by Jules for task [10011209715107903554](https://jules.google.com/task/10011209715107903554) started by @chatelao*