### PR TITLE
Migrate bitfield diagrams to PlantUML

### DIFF
--- a/docs/architecture/MXFP8_CONCEPT.md
+++ b/docs/architecture/MXFP8_CONCEPT.md
@@ -103,7 +103,7 @@ The unit communicates with a host using a strictly timed protocol:
 
 **Table 2: Input `uio_in` (Bidirectional)**
 
-![OCP MX Hardware Config Bitfield](https://wavedrom.com/api/bitfield?src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/docs/diagrams/OCP_MX_CONFIG_BITFIELD.json)
+![OCP MX Hardware Config Bitfield](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/docs/diagrams/OCP_MX_CONFIG_BITFIELD.PUML)
 
 | Phase | Cycles | Bits [7:0] | Function | Description |
 |-------|--------|------------|----------|-------------|

--- a/docs/diagrams/MX_SETFMT_BITFIELD.PUML
+++ b/docs/diagrams/MX_SETFMT_BITFIELD.PUML
@@ -1,0 +1,8 @@
+@startbitfield
+0-2: FMT_A
+3-4: RM
+5: OVF
+6: PACK
+7: EXT
+8-31: Reserved
+@endbitfield

--- a/docs/diagrams/MX_SETFMT_BITFIELD.json
+++ b/docs/diagrams/MX_SETFMT_BITFIELD.json
@@ -1,8 +1,0 @@
-[
-  {"bits": 3, "name": "Format A", "attr": "FMT_A"},
-  {"bits": 2, "name": "Rounding", "attr": "RM"},
-  {"bits": 1, "name": "Overflow", "attr": "OVF"},
-  {"bits": 1, "name": "Packed", "attr": "PACK"},
-  {"bits": 1, "name": "MX+", "attr": "EXT"},
-  {"bits": 24, "name": "Reserved"}
-]

--- a/docs/diagrams/OCP_MX_CONFIG_BITFIELD.PUML
+++ b/docs/diagrams/OCP_MX_CONFIG_BITFIELD.PUML
@@ -1,0 +1,7 @@
+@startbitfield
+0-2: Format A
+3-4: Rounding
+5: Overflow
+6: Packed
+7: MX+ Enable
+@endbitfield

--- a/docs/diagrams/OCP_MX_CONFIG_BITFIELD.json
+++ b/docs/diagrams/OCP_MX_CONFIG_BITFIELD.json
@@ -1,7 +1,0 @@
-[
-  {"bits": 3, "name": "Format A", "attr": "FFF"},
-  {"bits": 2, "name": "Rounding", "attr": "WW"},
-  {"bits": 1, "name": "Overflow", "attr": "O"},
-  {"bits": 1, "name": "Packed", "attr": "P"},
-  {"bits": 1, "name": "MX+ Enable", "attr": "X"}
-]

--- a/docs/diagrams/VMXFMT_BITFIELD.PUML
+++ b/docs/diagrams/VMXFMT_BITFIELD.PUML
@@ -1,0 +1,7 @@
+@startbitfield
+0-2: FMT_A
+3-5: FMT_B
+6: OVF
+7: EXT
+8-31: Reserved
+@endbitfield

--- a/docs/diagrams/VMXFMT_BITFIELD.json
+++ b/docs/diagrams/VMXFMT_BITFIELD.json
@@ -1,7 +1,0 @@
-[
-  {"bits": 3, "name": "Format A", "attr": "FMT_A"},
-  {"bits": 3, "name": "Format B", "attr": "FMT_B"},
-  {"bits": 1, "name": "Overflow", "attr": "OVF"},
-  {"bits": 1, "name": "Extended", "attr": "EXT"},
-  {"bits": 24, "name": "Reserved"}
-]

--- a/docs/integration/CSR_RVV_CONCEPT_AND_ROADMAP.md
+++ b/docs/integration/CSR_RVV_CONCEPT_AND_ROADMAP.md
@@ -8,7 +8,7 @@ To manage the specific requirements of OCP Microscaling Formats (MX), a new cust
 
 ### 1.1. `vmxfmt` (Custom Read/Write CSR, Address 0x800)
 
-![vmxfmt Bitfield](https://wavedrom.com/api/bitfield?src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/docs/diagrams/VMXFMT_BITFIELD.json)
+![vmxfmt Bitfield](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/docs/diagrams/VMXFMT_BITFIELD.PUML)
 
 | Bits | Name | Description | OCP MX Cycle 1 Mapping |
 |:---|:---|:---|:---|

--- a/docs/integration/SERV_INTEGRATION_CONCEPT.md
+++ b/docs/integration/SERV_INTEGRATION_CONCEPT.md
@@ -72,7 +72,7 @@ The following table defines the bitfields for the OCP-MX-V extension:
 
 ### 4.2. Register Bit-Mapping
 
-![MX.SETFMT Bitfield](https://wavedrom.com/api/bitfield?src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/docs/diagrams/MX_SETFMT_BITFIELD.json)
+![MX.SETFMT Bitfield](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/docs/diagrams/MX_SETFMT_BITFIELD.PUML)
 
 - **`MX.SETFMT`**: `rs1[2:0]` = format_a, `rs1[4:3]` = round_mode, `rs1[5]` = overflow_wrap, `rs1[6]` = packed_mode, `rs1[7]` = mx_plus_en.
 - **`MX.MAC`**: `rs1` contains 4x 8-bit elements (A0-A3), `rs2` contains 4x 8-bit elements (B0-B3).


### PR DESCRIPTION
Migrated WaveDrom bitfield JSON diagrams to PlantUML @startbitfield format to resolve rendering issues with the online WaveDrom API. Updated documentation and verified all tests pass.

Fixes #510

---
*PR created automatically by Jules for task [17467021454452417671](https://jules.google.com/task/17467021454452417671) started by @chatelao*