### PR TITLE
Add WaveDrom Bitfield JSON Diagrams

### DIFF
--- a/docs/diagrams/MX_SETFMT_BITFIELD.json
+++ b/docs/diagrams/MX_SETFMT_BITFIELD.json
@@ -1,0 +1,8 @@
+{ "reg": [
+  {"name": "FMT_A", "bits": 3},
+  {"name": "RM", "bits": 2},
+  {"name": "OVF", "bits": 1},
+  {"name": "PACK", "bits": 1},
+  {"name": "EXT", "bits": 1},
+  {"name": "Reserved", "bits": 24}
+]}

--- a/docs/diagrams/OCP_MX_CONFIG_BITFIELD.json
+++ b/docs/diagrams/OCP_MX_CONFIG_BITFIELD.json
@@ -1,0 +1,7 @@
+{ "reg": [
+  {"name": "Format A", "bits": 3},
+  {"name": "Rounding", "bits": 2},
+  {"name": "Overflow", "bits": 1},
+  {"name": "Packed", "bits": 1},
+  {"name": "MX+ Enable", "bits": 1}
+]}

--- a/docs/diagrams/VMXFMT_BITFIELD.json
+++ b/docs/diagrams/VMXFMT_BITFIELD.json
@@ -1,0 +1,7 @@
+{ "reg": [
+  {"name": "FMT_A", "bits": 3},
+  {"name": "FMT_B", "bits": 3},
+  {"name": "OVF", "bits": 1},
+  {"name": "EXT", "bits": 1},
+  {"name": "Reserved", "bits": 24}
+]}


### PR DESCRIPTION
Added WaveDrom-compatible JSON bitfield diagrams for the OCP MX configuration byte and related RISC-V registers (MX_SETFMT and VMXFMT) in the docs/diagrams/ directory. These diagrams provide machine-readable definitions that align with the project's hardware specifications and existing PlantUML visualizations. verified the implementation by running the full cocotb test suite and performing a manual review of the generated JSON files.

Fixes #512

---
*PR created automatically by Jules for task [10011759609389083090](https://jules.google.com/task/10011759609389083090) started by @chatelao*