### PR TITLE
Add WaveDrom Bitfield Diagram for Configuration Byte to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,22 @@ The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to proces
 *\*Note: For 4-bit formats (MXFP4), the unit supports **Vector Packing** (uio_in[6]=1 in Cycle 1). This reduces the STREAM phase to 16 cycles (Cycles 3-18) and the total sequence to 25 cycles.*
 
 ### Configuration Byte (Cycle 1, `uio_in`)
+
+```wavedrom
+{ "reg": [
+  {"name": "Format A", "bits": 3},
+  {"name": "Rounding", "bits": 2},
+  {"name": "Overflow", "bits": 1},
+  {"name": "Packed", "bits": 1},
+  {"name": "MX+ Enable", "bits": 1}
+]}
+```
+
 - `[2:0]`: **Format A** (0: E4M3, 1: E5M2, 2: E3M2, 3: E2M3, 4: E2M1, 5: INT8, 6: INT8_SYM)
 - `[4:3]`: **Rounding Mode** (0: TRN, 1: CEL, 2: FLR, 3: RNE)
 - `[5]`: **Overflow Mode** (0: SAT, 1: WRAP)
 - `[6]`: **Packed Mode** (1: Enable Vector Packing for FP4/MXFP4)
+- `[7]`: **MX+ Enable** (1: Enable MX+ extensions)
 
 ### Format B Byte (Cycle 2, `uio_in`)
 - `[2:0]`: **Format B** (Same encoding as Format A)


### PR DESCRIPTION
This PR adds a WaveDrom-based bitfield diagram to the README.md to visually represent the 8-bit Configuration Byte used in Cycle 1 of the MAC unit's protocol. It also updates the accompanying text description to include the previously omitted MX+ Enable bit ([7]), ensuring full documentation of the register layout.

Fixes #514

---
*PR created automatically by Jules for task [14528181922871669259](https://jules.google.com/task/14528181922871669259) started by @chatelao*