### PR TITLE
Documentation and Diagram Synchronization for OCP MX MAC Unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to proces
 
 | Cycle | Input `ui_in[7:0]` | Input `uio_in[7:0]` | Output `uo_out[7:0]` | Description |
 |-------|--------------------|---------------------|----------------------|-------------|
-| 0     | -                  | -                   | 0x00                 | **IDLE**: Waiting for start. |
+| 0     | **Metadata 0**     | **Metadata 1**      | 0x00                 | **IDLE**: Load MX+ / Debug or Start Fast Protocol. |
 | 1     | **Scale A**        | **Config Byte**     | 0x00                 | Load Scale A and Operation Mode. |
-| 2     | **Scale B**        | **Format B**        | 0x00                 | Load Scale B and Format B. |
+| 2     | **Scale B**        | **MX+ / Format B**  | 0x00                 | Load Scale B, Format B, and BM Index B. |
 | 3-34  | **Element $A_i$**  | **Element $B_i$**   | 0x00                 | Stream 32 pairs of elements (Standard).* |
 | 35    | -                  | -                   | 0x00                 | Pipeline flush. |
 | 36    | -                  | -                   | 0x00                 | Final Shared Scaling calculation. |
@@ -49,23 +49,32 @@ The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to proces
 
 *\*Note: For 4-bit formats (MXFP4), the unit supports **Vector Packing** (uio_in[6]=1 in Cycle 1). This reduces the STREAM phase to 16 cycles (Cycles 3-18) and the total sequence to 25 cycles.*
 
-### Configuration Byte (Cycle 1, `uio_in`)
+### Metadata Mapping
 
+#### Cycle 0: IDLE / Initial Metadata
+- **Standard Start (`ui_in[7]=0`)**:
+  - `ui_in[2:0]`: **NBM Offset B** (MX++)
+  - `ui_in[5]`: **Loopback Enable** (Debug)
+  - `ui_in[6]`: **Debug Enable** (Enables metadata echo at Cycle 35/19)
+  - `uio_in[4:0]`: **BM Index A** (MX+)
+  - `uio_in[7:5]`: **NBM Offset A** (MX++)
+- **Short Protocol (`ui_in[7]=1`)**:
+  - Immediately jumps to Cycle 3, reusing previous Scales.
+  - `uio_in[2:0]`, `[4:3]`, `[5]`, `[6]` are captured as Format, Rounding, Overflow, and Packed Mode respectively.
+
+#### Cycle 1: Configuration Byte (`uio_in`)
 ![Configuration Byte Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/docs/diagrams/OCP_MX_CONFIG_BITFIELD.PUML)
-
 *Source: [docs/diagrams/OCP_MX_CONFIG_BITFIELD.PUML](docs/diagrams/OCP_MX_CONFIG_BITFIELD.PUML)*
-
 - `[2:0]`: **Format A** (0: E4M3, 1: E5M2, 2: E3M2, 3: E2M3, 4: E2M1, 5: INT8, 6: INT8_SYM)
 - `[4:3]`: **Rounding Mode** (0: TRN, 1: CEL, 2: FLR, 3: RNE)
 - `[5]`: **Overflow Mode** (0: SAT, 1: WRAP)
 - `[6]`: **Packed Mode** (1: Enable Vector Packing for FP4/MXFP4)
 - `[7]`: **MX+ Enable** (1: Enable MX+ extensions)
 
-### Format B Byte (Cycle 2, `uio_in`)
-- `[2:0]`: **Format B** (Same encoding as Format A)
-
-### Fast Start (Scale Compression)
-If `ui_in[7]` is set to `1` during **STATE_IDLE** (Cycle 0), the unit immediately jumps to **Cycle 3**. It reuses the **Scales**, **Formats**, and **Rounding Modes** from the previous operation, saving 3 clock cycles.
+#### Cycle 2: Scale B / MX+ Metadata
+- `ui_in[7:0]`: **Scale B**
+- `uio_in[2:0]`: **Format B** (Enabled if `SUPPORT_MIXED_PRECISION=1`)
+- `uio_in[7:3]`: **BM Index B** (MX+)
 
 - [Silicon Online Viewer](https://gds-viewer.tinytapeout.com/?pdk=ihp-sg13g2&model=https%3A%2F%2Fchatelao.github.io%2Fttihp-fp8-mul%2F%2Ftinytapeout.oas)
 

--- a/docs/diagrams/CONTEXT_DIAGRAM.PUML
+++ b/docs/diagrams/CONTEXT_DIAGRAM.PUML
@@ -11,84 +11,77 @@ skinparam rectangle<<container_boundary>> {
 skinparam rectangle<<system_boundary>> {
     FontSize 20
 }
-skinparam rectangle<<enterprise_boundary>> {
-    FontSize 20
-}
 UpdateBoundaryStyle("container", $type="container")
 UpdateBoundaryStyle("system", $type="system")
-UpdateBoundaryStyle("enterprise", $type="enterprise")
 
 Person(host, "Host System", "FPGA, Microcontroller, or Testbench")
 
 Container_Boundary(mac_unit, "OCP MXFP8 Streaming MAC Unit") {
 
     Container_Boundary(fsm_block, "FSM & Control") {
-        Component(counter, "Cycle Counter", "6-bit", "Tracks 41-cycle protocol.")
+        Component(counter, "Cycle Counter", "7-bit", "Tracks protocol cycles (Standard/Packed).")
         Component(fsm_logic, "State Machine", "Verilog", "IDLE, LOAD, STREAM, OUTPUT transitions.")
-        Component(config_regs, "Config Registers", "Registers", "Stores scales, formats, and rounding modes.")
-        Component(fast_start, "Fast Start Logic", "Logic", "Handles scale compression (Cycle 0).")
+        Component(config_regs, "Config Registers", "Registers", "Stores scales, formats, modes, and MX+ metadata.")
+        Component(fast_start, "Short Protocol Logic", "Logic", "Cycle 0 metadata capture & fast start.")
 
-        Rel_D(fast_start, counter, "Override", "Cycle 3")
-        Rel_D(counter, fsm_logic, "Count", "6-bit")
+        Rel_D(fast_start, counter, "Jump", "Cycle 3")
+        Rel_D(counter, fsm_logic, "Count", "7-bit")
         Rel_D(fsm_logic, config_regs, "Load", "Enable")
     }
 
-    Container_Boundary(mul_block, "FP8 Multiplier") {
-        Component(decoders, "Operand Decoders", "fp8_mul.v", "Supports E5M2, E4M3, MXFP6, MXFP4, INT8.")
-        Component(m_mul, "Mantissa Multiplier", "8x8 or 4x4", "Signed or approximate (LNS) multiplication.")
-        Component(exp_arith, "Exponent Arithmetic", "Logic", "Summation and bias adjustment.")
-        Component(sign_logic, "Sign Logic", "XOR", "Result sign calculation.")
-        Component(mul_regs, "Pipeline Registers", "Registers", "Stores multiplier output (1 cycle latency).")
+    Container_Boundary(mul_block, "Dual-Lane Multiplier") {
+        Component(decoders, "Operand Decoders", "fp8_mul[_lns].v", "Supports MXFP8/6/4, INT8, and MX+ repurposed exponents.")
+        Component(m_mul, "Significand Multiplier", "8x8 / 4x4", "Parallel or Bit-Serial LNS logic.")
+        Component(exp_arith, "Exponent Path", "Logic", "Summation, bias adjustment, and MX++ offsets.")
+        Component(mul_regs, "Pipeline Registers", "Registers", "Optional 1-cycle latency staging.")
 
-        Rel_D(decoders, m_mul, "Mantissas", "8-bit")
-        Rel_D(decoders, exp_arith, "Exponents", "5-bit")
-        Rel_D(decoders, sign_logic, "Signs", "1-bit")
-        Rel_D(m_mul, mul_regs, "Prod", "16-bit")
-        Rel_D(exp_arith, mul_regs, "Exp", "7-bit")
-        Rel_D(sign_logic, mul_regs, "Sign", "1-bit")
+        Rel_D(decoders, m_mul, "Significands")
+        Rel_D(decoders, exp_arith, "Exponents")
+        Rel_D(m_mul, mul_regs, "Prod")
+        Rel_D(exp_arith, mul_regs, "Exp/Sign")
     }
 
-    Container_Boundary(align_block, "Aligner & Scaler") {
-        Component(shifter, "Barrel Shifter", "fp8_aligner.v", "Parameterized (WIDTH) alignment.")
-        Component(round_unit, "Rounding Unit", "Logic", "Implements RNE, TRN, CEL, FLR.")
-        Component(sticky_gen, "Sticky Bit Gen", "OR-reduction", "Accurate rounding for right-shifts.")
-        Component(sat_logic, "Saturation Logic", "Clamping", "Handles overflow and 32-bit clamping.")
+    Container_Boundary(align_block, "Dual Aligner Stage") {
+        Component(shifter, "Barrel Shifters", "fp8_aligner.v", "Parameterized (WIDTH) alignment & MXFP4 optimization.")
+        Component(round_unit, "Rounding & Saturation", "Logic", "RNE, TRN, CEL, FLR modes + Clamping.")
 
-        Rel_R(shifter, sticky_gen, "LSBs", "Masked")
-        Rel_D(shifter, round_unit, "Base", "WIDTH-bit")
-        Rel_D(sticky_gen, round_unit, "Sticky", "1-bit")
-        Rel_D(round_unit, sat_logic, "Rounded", "WIDTH-bit")
+        Rel_D(shifter, round_unit, "Aligned Data")
     }
 
     Container_Boundary(acc_block, "Accumulator") {
-        Component(adder, "32-bit Signed Adder", "accumulator.v", "Core summation logic.")
-        Component(ovf_det, "Overflow Detector", "Logic", "SAT/WRAP logic based on config.")
-        Component(acc_reg, "Accumulation Reg", "Register", "Stores the running 32-bit sum.")
+        Component(adder, "Signed Adder", "accumulator.v", "Sums dual lanes into fixed-point accumulator.")
+        Component(acc_reg, "Accumulation Reg", "Register", "Stores running sum (WIDTH-bit).")
 
-        Rel_D(adder, ovf_det, "Sum", "WIDTH+1-bit")
-        Rel_D(ovf_det, acc_reg, "Sum/Sat", "WIDTH-bit")
-        Rel_U(acc_reg, adder, "Feedback", "32-bit")
+        Rel_D(adder, acc_reg, "Update")
+        Rel_U(acc_reg, adder, "Feedback")
+    }
+
+    Container_Boundary(exception_block, "Exception & Robustness") {
+        Component(sticky, "Sticky Registers", "DFFs", "Latches NaN/Inf from multipliers and scale factors.")
+        Component(override, "Output Mux", "Logic", "Overrides results with OCP special patterns.")
+
+        Rel_D(sticky, override, "Trigger")
     }
 
     Container_Boundary(serial_block, "Output Serializer") {
-        Component(serial_reg, "Scaled Result Reg", "Register", "32-bit Scaled Result Register (scaled_acc_reg).")
-        Component(byte_mux, "Byte Multiplexer", "Verilog", "Selects 8-bit chunk from 32-bit result.")
+        Component(byte_mux, "Byte Multiplexer", "Verilog", "Extracts 8-bit chunks for uo_out.")
 
-        Rel_D(serial_reg, byte_mux, "32-bit", "Internal")
+        Rel_U(byte_mux, override, "Result Data")
     }
 }
 
-Rel_D(host, fsm_logic, "Control & Config", "clk, rst_n, ena, ui_in, uio_in")
-Rel_D(host, decoders, "Streaming Elements", "ui_in, uio_in (Cycles 3-34)")
+Rel_D(host, fsm_logic, "Control", "clk, rst_n, ena")
+Rel_D(host, config_regs, "Metadata", "ui_in, uio_in (Cycles 0-2)")
+Rel_D(host, decoders, "Streaming Data", "ui_in, uio_in (STREAM phase)")
 
-Rel_R(config_regs, decoders, "Format A/B", "3-bit indices")
+Rel_R(config_regs, decoders, "Formats/MX+", "Metadata")
 Rel_D(config_regs, round_unit, "Rounding Mode", "2-bit")
-Rel_D(fsm_logic, acc_reg, "Ctrl", "en, clear")
+Rel_D(fsm_logic, acc_reg, "Ctrl", "en, clear, load, shift")
 
-Rel_D(mul_regs, shifter, "Partial Product", "16-bit Mantissa, 7-bit Exp")
-Rel_D(sat_logic, adder, "Aligned Data", "Internal Datapath")
-Rel_U(acc_reg, shifter, "Feedback", "Shared Scaling Path (Cycle 36)")
-Rel_D(sat_logic, serial_reg, "Result", "32-bit Scaled")
-Rel_U(byte_mux, host, "Result Byte", "uo_out (Cycles 37-40)")
+Rel_D(mul_regs, shifter, "Partial Product")
+Rel_D(round_unit, adder, "Aligned Elements")
+Rel_U(acc_reg, shifter, "Feedback", "Shared Scaling Path")
+Rel_D(acc_reg, byte_mux, "32-bit Internal")
+Rel_U(override, host, "uo_out", "Cycles 37-40 / 21-24")
 
 @enduml

--- a/docs/diagrams/METADATA_C0_UIO_BITFIELD.PUML
+++ b/docs/diagrams/METADATA_C0_UIO_BITFIELD.PUML
@@ -1,0 +1,4 @@
+@startbitfield
+0-4: BM Index A
+5-7: NBM Offset A
+@endbitfield

--- a/docs/diagrams/METADATA_C0_UIO_BITFIELD.json
+++ b/docs/diagrams/METADATA_C0_UIO_BITFIELD.json
@@ -1,0 +1,4 @@
+{ "reg": [
+  {"name": "BM Index A", "bits": 5},
+  {"name": "NBM Offset A", "bits": 3}
+]}

--- a/docs/diagrams/METADATA_C0_UI_BITFIELD.PUML
+++ b/docs/diagrams/METADATA_C0_UI_BITFIELD.PUML
@@ -1,0 +1,7 @@
+@startbitfield
+0-2: NBM Offset B
+3-4: Reserved
+5: Loopback En
+6: Debug En
+7: Short Protocol
+@endbitfield

--- a/docs/diagrams/METADATA_C0_UI_BITFIELD.json
+++ b/docs/diagrams/METADATA_C0_UI_BITFIELD.json
@@ -1,0 +1,7 @@
+{ "reg": [
+  {"name": "NBM Offset B", "bits": 3},
+  {"name": "Reserved", "bits": 2},
+  {"name": "Loopback En", "bits": 1},
+  {"name": "Debug En", "bits": 1},
+  {"name": "Short Protocol", "bits": 1}
+]}

--- a/docs/diagrams/METADATA_C2_UIO_BITFIELD.PUML
+++ b/docs/diagrams/METADATA_C2_UIO_BITFIELD.PUML
@@ -1,0 +1,4 @@
+@startbitfield
+0-2: Format B
+3-7: BM Index B
+@endbitfield

--- a/docs/diagrams/METADATA_C2_UIO_BITFIELD.json
+++ b/docs/diagrams/METADATA_C2_UIO_BITFIELD.json
@@ -1,0 +1,4 @@
+{ "reg": [
+  {"name": "Format B", "bits": 3},
+  {"name": "BM Index B", "bits": 5}
+]}

--- a/docs/info.md
+++ b/docs/info.md
@@ -18,8 +18,9 @@ The unit supports both **E4M3** and **E5M2** element formats:
 
 ### Operational Protocol (41-Cycle Standard / 25-Cycle Packed)
 To minimize resource usage, operands are streamed into the unit over a fixed sequence:
+0. **Cycle 0**: Load MX+ Metadata (BM Indices/Offsets) and Debug flags, or trigger **Short Protocol** (Fast Start) by setting `ui_in[7]=1`.
 1. **Cycle 1**: Load Scale A ($X_A$ on `ui_in`) and Configuration (on `uio_in`).
-2. **Cycle 2**: Load Scale B ($X_B$ on `ui_in`) and Format B (on `uio_in`).
+2. **Cycle 2**: Load Scale B ($X_B$ on `ui_in`), Format B, and BM Index B (on `uio_in`).
 3. **Streaming Phase**:
    - **Standard Mode**: Cycles 3-34 (32 pairs of elements).
    - **Packed Lane Mode (FP4)**: Cycles 3-18 (16 cycles, 2 elements/cycle, dual-lane).
@@ -31,9 +32,10 @@ To minimize resource usage, operands are streamed into the unit over a fixed seq
 
 The design uses a clocked FSM. To test:
 1. Reset the unit (`rst_n` = 0) then enable it (`ena` = 1).
-2. On Cycle 1, provide Scale A on `ui_in` and Config on `uio_in` (Set `uio_in[6]=1` for Packed Mode).
-3. On Cycle 2, provide Scale B on `ui_in` and Format B on `uio_in`.
-4. Stream elements $A_i$ and $B_i$:
+2. On Cycle 0, provide MX+ metadata on `ui_in`/`uio_in`. Set `ui_in[7]=1` to trigger the **Short Protocol**, which reuses Scales from the previous block while capturing new Formats and Rounding Modes from `uio_in`.
+3. On Cycle 1, provide Scale A on `ui_in` and Config on `uio_in` (Set `uio_in[6]=1` for Packed Mode).
+4. On Cycle 2, provide Scale B on `ui_in`, Format B, and BM Index B on `uio_in`.
+5. Stream elements $A_i$ and $B_i$:
    - **Standard**: 32 cycles.
    - **Packed Lane**: 16 cycles (two 4-bit elements per cycle: `[7:4]=E_i+1`, `[3:0]=E_i`).
    - **Packed Serial**: 32 cycles. Load a packed byte on odd cycles (3, 5...); Hardware waits on even cycles (4, 6...).


### PR DESCRIPTION
This submission synchronizes the project's documentation and architectural diagrams with the latest hardware implementation. Key updates include:
1. **Architectural Diagrams**: Updated the System Context diagram to show the dual-lane multiplier, 7-bit cycle counter, and new exception handling logic.
2. **Operational Protocol**: Documented the full operational sequence, including the new Cycle 0 for MX+ metadata/Short Protocol trigger and Cycle 2 for secondary metadata.
3. **Bitfield Definitions**: Created new PlantUML and machine-readable JSON bitfield definitions for all metadata-carrying cycles.
4. **Consistency**: Ensured all documentation (README, info.md) and diagrams are bit-accurate to the current RTL and validated through the cocotb test suite.

Fixes #518

---
*PR created automatically by Jules for task [7602225132360803242](https://jules.google.com/task/7602225132360803242) started by @chatelao*