### PR TITLE
Update WaveDrom BitPattern width to 8 bits for Cycle 1 Configuration Byte

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to proces
   - `uio_in[2:0]`, `[4:3]`, `[5]`, `[6]` are captured as Format, Rounding, Overflow, and Packed Mode respectively.
 
 #### Cycle 1: Configuration Byte (`uio_in`)
-![Configuration Byte Diagram](https://svg.wavedrom.com/%7B%22reg%22%3A%20%5B%7B%22name%22%3A%20%22Format%20A%22%2C%20%22bits%22%3A%203%7D%2C%20%7B%22name%22%3A%20%22Rounding%22%2C%20%22bits%22%3A%202%7D%2C%20%7B%22name%22%3A%20%22Overflow%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22Packed%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22MX%2B%20Enable%22%2C%20%22bits%22%3A%201%7D%5D%7D)
+![Configuration Byte Diagram](https://svg.wavedrom.com/%7B%22reg%22%3A%20%5B%7B%22name%22%3A%20%22Format%20A%22%2C%20%22bits%22%3A%203%7D%2C%20%7B%22name%22%3A%20%22Rounding%22%2C%20%22bits%22%3A%202%7D%2C%20%7B%22name%22%3A%20%22Overflow%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22Packed%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22MX%2B%20Enable%22%2C%20%22bits%22%3A%201%7D%5D%2C%20%22config%22%3A%20%7B%22bits%22%3A%208%7D%7D)
 *Source: [docs/diagrams/OCP_MX_CONFIG_BITFIELD.json](docs/diagrams/OCP_MX_CONFIG_BITFIELD.json)*
 - `[2:0]`: **Format A** (0: E4M3, 1: E5M2, 2: E3M2, 3: E2M3, 4: E2M1, 5: INT8, 6: INT8_SYM)
 - `[4:3]`: **Rounding Mode** (0: TRN, 1: CEL, 2: FLR, 3: RNE)

--- a/docs/architecture/MXFP8_CONCEPT.md
+++ b/docs/architecture/MXFP8_CONCEPT.md
@@ -103,7 +103,7 @@ The unit communicates with a host using a strictly timed protocol:
 
 **Table 2: Input `uio_in` (Bidirectional)**
 
-![OCP MX Hardware Config Bitfield](https://svg.wavedrom.com/%7B%22reg%22%3A%20%5B%7B%22name%22%3A%20%22Format%20A%22%2C%20%22bits%22%3A%203%7D%2C%20%7B%22name%22%3A%20%22Rounding%22%2C%20%22bits%22%3A%202%7D%2C%20%7B%22name%22%3A%20%22Overflow%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22Packed%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22MX%2B%20Enable%22%2C%20%22bits%22%3A%201%7D%5D%7D)
+![OCP MX Hardware Config Bitfield](https://svg.wavedrom.com/%7B%22reg%22%3A%20%5B%7B%22name%22%3A%20%22Format%20A%22%2C%20%22bits%22%3A%203%7D%2C%20%7B%22name%22%3A%20%22Rounding%22%2C%20%22bits%22%3A%202%7D%2C%20%7B%22name%22%3A%20%22Overflow%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22Packed%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22MX%2B%20Enable%22%2C%20%22bits%22%3A%201%7D%5D%2C%20%22config%22%3A%20%7B%22bits%22%3A%208%7D%7D)
 *Source: [docs/diagrams/OCP_MX_CONFIG_BITFIELD.json](../diagrams/OCP_MX_CONFIG_BITFIELD.json)*
 
 | Phase | Cycles | Bits [7:0] | Function | Description |

--- a/docs/diagrams/OCP_MX_CONFIG_BITFIELD.json
+++ b/docs/diagrams/OCP_MX_CONFIG_BITFIELD.json
@@ -4,4 +4,4 @@
   {"name": "Overflow", "bits": 1},
   {"name": "Packed", "bits": 1},
   {"name": "MX+ Enable", "bits": 1}
-]}
+], "config": {"bits": 8}}


### PR DESCRIPTION
This change updates the WaveDrom BitPattern rendering for the Cycle 1 Configuration Byte (uio_in) to be 8 bits wide instead of the default 32 bits.

Key changes:
- Modified `docs/diagrams/OCP_MX_CONFIG_BITFIELD.json` to include `"config": {"bits": 8}`.
- Updated the encoded WaveDrom URLs in `README.md` and `docs/architecture/MXFP8_CONCEPT.md` to reflect this configuration change.
- Verified that the hardware tests still pass and the documentation correctly references the updated bitfield definition.

Fixes #522

---
*PR created automatically by Jules for task [12931004215677003812](https://jules.google.com/task/12931004215677003812) started by @chatelao*