### PR TITLE
Add WaveDrom bitfield documentation for Cycle 0 uio_in

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to proces
 ### Metadata Mapping
 
 #### Cycle 0: IDLE / Initial Metadata
+![Metadata 1 (uio_in) Diagram](https://svg.wavedrom.com/%7B%22reg%22%3A%20%5B%7B%22name%22%3A%20%22BM%20Index%20A%22%2C%20%22bits%22%3A%205%7D%2C%20%7B%22name%22%3A%20%22NBM%20Offset%20A%22%2C%20%22bits%22%3A%203%7D%5D%2C%20%22config%22%3A%20%7B%22bits%22%3A%208%7D%7D)
+*Source: [docs/diagrams/METADATA_C0_UIO_BITFIELD.json](docs/diagrams/METADATA_C0_UIO_BITFIELD.json)*
 - **Standard Start (`ui_in[7]=0`)**:
   - `ui_in[2:0]`: **NBM Offset B** (MX++)
   - `ui_in[5]`: **Loopback Enable** (Debug)

--- a/docs/diagrams/METADATA_C0_UIO_BITFIELD.json
+++ b/docs/diagrams/METADATA_C0_UIO_BITFIELD.json
@@ -1,4 +1,4 @@
 { "reg": [
   {"name": "BM Index A", "bits": 5},
   {"name": "NBM Offset A", "bits": 3}
-]}
+], "config": {"bits": 8}}


### PR DESCRIPTION
This change adds a WaveDrom bitfield diagram to the README.md for the Cycle 0 `uio_in` (Metadata 1) input. This improves the documentation by providing a visual representation of the bit mapping for MX+ and MX++ metadata loaded during the IDLE state, consistent with the documentation style used for Cycle 1. Additionally, the source JSON definition was updated to ensure correct 8-bit rendering.

Fixes #526

---
*PR created automatically by Jules for task [9284046301814671978](https://jules.google.com/task/9284046301814671978) started by @chatelao*