### PR TITLE
Add Cycle 0 ui_in bitfield documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to proces
 ### Metadata Mapping
 
 #### Cycle 0: IDLE / Initial Metadata
+![Metadata 0 (ui_in) Diagram](https://svg.wavedrom.com/%7B%22reg%22%3A%20%5B%7B%22name%22%3A%20%22NBM%20Offset%20B%22%2C%20%22bits%22%3A%203%7D%2C%20%7B%22name%22%3A%20%22Reserved%22%2C%20%22bits%22%3A%202%7D%2C%20%7B%22name%22%3A%20%22Loopback%20En%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22Debug%20En%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22Short%20Protocol%22%2C%20%22bits%22%3A%201%7D%5D%2C%20%22config%22%3A%20%7B%22bits%22%3A%208%7D%7D)
+*Source: [docs/diagrams/METADATA_C0_UI_BITFIELD.json](docs/diagrams/METADATA_C0_UI_BITFIELD.json)*
 ![Metadata 1 (uio_in) Diagram](https://svg.wavedrom.com/%7B%22reg%22%3A%20%5B%7B%22name%22%3A%20%22BM%20Index%20A%22%2C%20%22bits%22%3A%205%7D%2C%20%7B%22name%22%3A%20%22NBM%20Offset%20A%22%2C%20%22bits%22%3A%203%7D%5D%2C%20%22config%22%3A%20%7B%22bits%22%3A%208%7D%7D)
 *Source: [docs/diagrams/METADATA_C0_UIO_BITFIELD.json](docs/diagrams/METADATA_C0_UIO_BITFIELD.json)*
 - **Standard Start (`ui_in[7]=0`)**:

--- a/docs/diagrams/METADATA_C0_UI_BITFIELD.json
+++ b/docs/diagrams/METADATA_C0_UI_BITFIELD.json
@@ -4,4 +4,4 @@
   {"name": "Loopback En", "bits": 1},
   {"name": "Debug En", "bits": 1},
   {"name": "Short Protocol", "bits": 1}
-]}
+], "config": {"bits": 8}}


### PR DESCRIPTION
This change adds bitfield documentation for the `ui_in` input during Cycle 0 (Metadata 0) to the README. It includes a visual WaveDrom diagram and a link to the underlying JSON source. The JSON definition was also updated to ensure consistent 8-bit rendering.

Fixes #529

---
*PR created automatically by Jules for task [12742956293150848965](https://jules.google.com/task/12742956293150848965) started by @chatelao*