### PR TITLE
Swap NBM offset A and B loading logic

### DIFF
--- a/docs/diagrams/METADATA_C0_UIO_BITFIELD.PUML
+++ b/docs/diagrams/METADATA_C0_UIO_BITFIELD.PUML
@@ -1,4 +1,7 @@
 @startbitfield
-0-4: BM Index A
-5-7: NBM Offset A
+0-2: NBM Offset B
+3-4: Rounding Mode
+5: Overflow Mode
+6: Packed Mode
+7: MX+ Enable
 @endbitfield

--- a/docs/diagrams/METADATA_C0_UIO_BITFIELD.json
+++ b/docs/diagrams/METADATA_C0_UIO_BITFIELD.json
@@ -1,5 +1,5 @@
 { "reg": [
-  {"name": "NBM Offset A", "bits": 3},
+  {"name": "NBM Offset B", "bits": 3},
   {"name": "Rounding Mode", "bits": 2},
   {"name": "Overflow Mode", "bits": 1},
   {"name": "Packed Mode", "bits": 1},

--- a/docs/diagrams/METADATA_C0_UI_BITFIELD.PUML
+++ b/docs/diagrams/METADATA_C0_UI_BITFIELD.PUML
@@ -1,5 +1,5 @@
 @startbitfield
-0-2: NBM Offset B
+0-2: NBM Offset A
 3-4: Reserved
 5: Loopback En
 6: Debug En

--- a/docs/diagrams/METADATA_C0_UI_BITFIELD.json
+++ b/docs/diagrams/METADATA_C0_UI_BITFIELD.json
@@ -1,5 +1,5 @@
 { "reg": [
-  {"name": "NBM Offset B", "bits": 3},
+  {"name": "NBM Offset A", "bits": 3},
   {"name": "Reserved", "bits": 2},
   {"name": "Loopback En", "bits": 1},
   {"name": "Debug En", "bits": 1},

--- a/src/project.v
+++ b/src/project.v
@@ -159,8 +159,8 @@ module tt_um_chatelao_fp8_multiplier #(
                         mx_plus_en <= uio_in[7];
                         if (!ui_in[7]) begin
                             // NBM Offsets captured in Cycle 0 (Standard Start)
-                            nbm_offset_a <= uio_in[2:0];
-                            nbm_offset_b <= ui_in[2:0];
+                            nbm_offset_a <= ui_in[2:0];
+                            nbm_offset_b <= uio_in[2:0];
                         end
                     end
                     if (logical_cycle == 7'd1) begin

--- a/test/test.py
+++ b/test/test.py
@@ -355,14 +355,14 @@ async def run_mac_test(dut, format_a, format_b, a_elements, b_elements, scale_a=
     # Custom reset to handle Cycle 0 sampling
     dut.ena.value = 1
     # Cycle 0: Initial Metadata
-    # ui_in[2:0]: NBM Offset B
-    # uio_in[2:0]: NBM Offset A
+    # ui_in[2:0]: NBM Offset A
+    # uio_in[2:0]: NBM Offset B
     # uio_in[4:3]: Rounding Mode
     # uio_in[5]: Overflow Mode
     # uio_in[6]: Packed Mode
     # uio_in[7]: MX+ Enable
-    dut.ui_in.value = (nbm_offset_b & 0x7)
-    dut.uio_in.value = (nbm_offset_a & 0x7) | (round_mode << 3) | (overflow_wrap << 5) | (packed_mode << 6) | (mx_plus_mode << 7)
+    dut.ui_in.value = (nbm_offset_a & 0x7)
+    dut.uio_in.value = (nbm_offset_b & 0x7) | (round_mode << 3) | (overflow_wrap << 5) | (packed_mode << 6) | (mx_plus_mode << 7)
 
     dut.rst_n.value = 0
     await ClockCycles(dut.clk, 10)


### PR DESCRIPTION
Swapped the input pin assignments for NBM Offset A and B during the Cycle 0 metadata sampling. NBM Offset A now maps to `ui_in[2:0]` and NBM Offset B maps to `uio_in[2:0]`. This change includes updates to:
- `src/project.v`: Sampling logic.
- `test/test.py`: Cocotb model and driver protocol.
- `docs/diagrams/`: JSON and PlantUML bitfield definitions for Cycle 0 metadata.

The change was verified by running the full test suite (`make`) and the multi-config regression script (`run_all_configs.sh`), all of which passed.

Fixes #536

---
*PR created automatically by Jules for task [12703381156600428567](https://jules.google.com/task/12703381156600428567) started by @chatelao*