### PR TITLE
Swap NBM Offset A and B Input Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to proces
 ### Metadata Mapping
 
 #### Cycle 0: IDLE / Initial Metadata
-![Metadata 0 (ui_in) Diagram](https://svg.wavedrom.com/%7B%22reg%22%3A%20%5B%7B%22name%22%3A%20%22NBM%20Offset%20B%22%2C%20%22bits%22%3A%203%7D%2C%20%7B%22name%22%3A%20%22Reserved%22%2C%20%22bits%22%3A%202%7D%2C%20%7B%22name%22%3A%20%22Loopback%20En%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22Debug%20En%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22Short%20Protocol%22%2C%20%22bits%22%3A%201%7D%5D%2C%20%22config%22%3A%20%7B%22bits%22%3A%208%7D%7D)
+![Metadata 0 (ui_in) Diagram](https://svg.wavedrom.com/%7B%22reg%22%3A%20%5B%7B%22name%22%3A%20%22NBM%20Offset%20A%22%2C%20%22bits%22%3A%203%7D%2C%20%7B%22name%22%3A%20%22LNS%20Mode%22%2C%20%22bits%22%3A%202%7D%2C%20%7B%22name%22%3A%20%22Loopback%20En%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22Debug%20En%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22Short%20Protocol%22%2C%20%22bits%22%3A%201%7D%5D%2C%20%22config%22%3A%20%7B%22bits%22%3A%208%7D%7D)
 *Source: [docs/diagrams/METADATA_C0_UI_BITFIELD.json](docs/diagrams/METADATA_C0_UI_BITFIELD.json)*
-![Metadata 1 (uio_in) Diagram](https://svg.wavedrom.com/%7B%20%22reg%22%3A%20%5B%20%7B%22name%22%3A%20%22NBM%20Offset%20A%22%2C%20%22bits%22%3A%203%7D%2C%20%7B%22name%22%3A%20%22Rounding%20Mode%22%2C%20%22bits%22%3A%202%7D%2C%20%7B%22name%22%3A%20%22Overflow%20Mode%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22Packed%20Mode%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22MX%2B%20Enable%22%2C%20%22bits%22%3A%201%7D%20%5D%2C%20%22config%22%3A%20%7B%22bits%22%3A%208%7D%7D)
+![Metadata 1 (uio_in) Diagram](https://svg.wavedrom.com/%7B%20%22reg%22%3A%20%5B%20%7B%22name%22%3A%20%22NBM%20Offset%20B%22%2C%20%22bits%22%3A%203%7D%2C%20%7B%22name%22%3A%20%22Rounding%20Mode%22%2C%20%22bits%22%3A%202%7D%2C%20%7B%22name%22%3A%20%22Overflow%20Mode%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22Packed%20Mode%22%2C%20%22bits%22%3A%201%7D%2C%20%7B%22name%22%3A%20%22MX%2B%20Enable%22%2C%20%22bits%22%3A%201%7D%20%5D%2C%20%22config%22%3A%20%7B%22bits%22%3A%208%7D%7D)
 *Source: [docs/diagrams/METADATA_C0_UIO_BITFIELD.json](docs/diagrams/METADATA_C0_UIO_BITFIELD.json)*
 
 - **Common Metadata** (captured in both Standard and Short protocols):
+  - `ui_in[4:3]`: **LNS Mode** (0: Normal, 1: LNS, 2: Hybrid)
   - `ui_in[5]`: **Loopback Enable** (Debug)
   - `ui_in[6]`: **Debug Enable** (Enables metadata echo at Cycle 35/19)
   - `uio_in[4:3]`: **Rounding Mode** (0: TRN, 1: CEL, 2: FLR, 3: RNE)
@@ -65,8 +66,8 @@ The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to proces
   - `uio_in[6]`: **Packed Mode** (1: Enable Vector Packing for FP4/MXFP4)
   - `uio_in[7]`: **MX+ Enable** (1: Enable MX+ extensions)
 - **Standard Start (`ui_in[7]=0`)**:
-  - `ui_in[2:0]`: **NBM Offset B** (MX++)
-  - `uio_in[2:0]`: **NBM Offset A** (MX++)
+  - `ui_in[2:0]`: **NBM Offset A** (MX++)
+  - `uio_in[2:0]`: **NBM Offset B** (MX++)
 - **Short Protocol (`ui_in[7]=1`)**:
   - Immediately jumps to Cycle 3, reusing previous Scales.
   - `uio_in[2:0]` is captured as **Format A**.

--- a/docs/diagrams/METADATA_C0_UIO_BITFIELD.PUML
+++ b/docs/diagrams/METADATA_C0_UIO_BITFIELD.PUML
@@ -1,4 +1,7 @@
 @startbitfield
-0-4: BM Index A
-5-7: NBM Offset A
+0-2: NBM Offset B
+3-4: Rounding Mode
+5: Overflow Mode
+6: Packed Mode
+7: MX+ Enable
 @endbitfield

--- a/docs/diagrams/METADATA_C0_UIO_BITFIELD.json
+++ b/docs/diagrams/METADATA_C0_UIO_BITFIELD.json
@@ -1,5 +1,5 @@
 { "reg": [
-  {"name": "NBM Offset A", "bits": 3},
+  {"name": "NBM Offset B", "bits": 3},
   {"name": "Rounding Mode", "bits": 2},
   {"name": "Overflow Mode", "bits": 1},
   {"name": "Packed Mode", "bits": 1},

--- a/docs/diagrams/METADATA_C0_UI_BITFIELD.PUML
+++ b/docs/diagrams/METADATA_C0_UI_BITFIELD.PUML
@@ -1,6 +1,6 @@
 @startbitfield
-0-2: NBM Offset B
-3-4: Reserved
+0-2: NBM Offset A
+3-4: LNS Mode
 5: Loopback En
 6: Debug En
 7: Short Protocol

--- a/docs/diagrams/METADATA_C0_UI_BITFIELD.json
+++ b/docs/diagrams/METADATA_C0_UI_BITFIELD.json
@@ -1,5 +1,5 @@
 { "reg": [
-  {"name": "NBM Offset B", "bits": 3},
+  {"name": "NBM Offset A", "bits": 3},
   {"name": "LNS Mode", "bits": 2},
   {"name": "Loopback En", "bits": 1},
   {"name": "Debug En", "bits": 1},

--- a/src/project.v
+++ b/src/project.v
@@ -160,8 +160,8 @@ module tt_um_chatelao_fp8_multiplier #(
                         mx_plus_en <= uio_in[7];
                         if (!ui_in[7]) begin
                             // NBM Offsets captured in Cycle 0 (Standard Start)
-                            nbm_offset_a <= uio_in[2:0];
-                            nbm_offset_b <= ui_in[2:0];
+                            nbm_offset_a <= ui_in[2:0];
+                            nbm_offset_b <= uio_in[2:0];
                         end
                     end
                     if (logical_cycle == 7'd1) begin

--- a/test/test.py
+++ b/test/test.py
@@ -360,15 +360,15 @@ async def run_mac_test(dut, format_a, format_b, a_elements, b_elements, scale_a=
     # Custom reset to handle Cycle 0 sampling
     dut.ena.value = 1
     # Cycle 0: Initial Metadata
-    # ui_in[2:0]: NBM Offset B
+    # ui_in[2:0]: NBM Offset A
     # ui_in[4:3]: LNS Mode
-    # uio_in[2:0]: NBM Offset A
+    # uio_in[2:0]: NBM Offset B
     # uio_in[4:3]: Rounding Mode
     # uio_in[5]: Overflow Mode
     # uio_in[6]: Packed Mode
     # uio_in[7]: MX+ Enable
-    dut.ui_in.value = (nbm_offset_b & 0x7) | (lns_mode << 3)
-    dut.uio_in.value = (nbm_offset_a & 0x7) | (round_mode << 3) | (overflow_wrap << 5) | (packed_mode << 6) | (mx_plus_mode << 7)
+    dut.ui_in.value = (nbm_offset_a & 0x7) | (lns_mode << 3)
+    dut.uio_in.value = (nbm_offset_b & 0x7) | (round_mode << 3) | (overflow_wrap << 5) | (packed_mode << 6) | (mx_plus_mode << 7)
 
     dut.rst_n.value = 0
     await ClockCycles(dut.clk, 10)


### PR DESCRIPTION
Swapped the input mapping for NBM Offset A and B during the initialization phase (Cycle 0). Updated the RTL, testbench, and all relevant documentation to ensure consistency across the project.

Fixes #540

---
*PR created automatically by Jules for task [12431513217294337030](https://jules.google.com/task/12431513217294337030) started by @chatelao*