### PR TITLE
Add RP2350 Pin Mappings for TT DevKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,17 +99,38 @@ The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to proces
 
 ### MicroPython Example (TT DevKit)
 
-You can run a single MAC operation on the Tiny Tapeout DevKit using the onboard RP2040 with MicroPython. The following script performs a 32-element dot product of $1.0 \times 1.0$ with no scaling.
+You can run a single MAC operation on the Tiny Tapeout DevKit using the onboard RP2040 or RP2350 with MicroPython. The following script performs a 32-element dot product of $1.0 \times 1.0$ with no scaling.
+
+#### Tiny Tapeout DevKit Pin Mapping
+
+| Signal | RP2040 (v2.0/v3.1) | RP2350 (v3.2) |
+|--------|-------------------|---------------|
+| `ui_in[7:0]` | GPIO 0-7 | GPIO 17-24 |
+| `uo_out[7:0]` | GPIO 8-15 | GPIO 33-40 |
+| `uio[7:0]` | GPIO 16-23 | GPIO 25-32 |
+| `clk` | GPIO 24 | GPIO 16 |
+| `rst_n` | GPIO 25 | GPIO 14 |
+| `ena` | GPIO 26 | GPIO 15 |
 
 ```python
 import machine
+import os
 import time
 
-# Pin Mapping for TT DevKit RP2040
-UI_IN = [machine.Pin(i, machine.Pin.OUT) for i in range(8)]
-UO_OUT = [machine.Pin(i, machine.Pin.IN) for i in range(8, 16)]
-UIO = [machine.Pin(i, machine.Pin.OUT) for i in range(16, 24)]
-CLK, RST_N, ENA = machine.Pin(24, machine.Pin.OUT), machine.Pin(25, machine.Pin.OUT), machine.Pin(26, machine.Pin.OUT)
+# Identify board version based on machine info
+is_rp2350 = "RP2350" in os.uname().machine
+
+# Pin Mapping for TT DevKit
+if is_rp2350: # v3.2 (RP2350)
+    UI_IN = [machine.Pin(i, machine.Pin.OUT) for i in range(17, 25)]
+    UO_OUT = [machine.Pin(i, machine.Pin.IN) for i in range(33, 41)]
+    UIO = [machine.Pin(i, machine.Pin.OUT) for i in range(25, 33)]
+    CLK, RST_N, ENA = machine.Pin(16, machine.Pin.OUT), machine.Pin(14, machine.Pin.OUT), machine.Pin(15, machine.Pin.OUT)
+else: # v2.0/v3.1 (RP2040)
+    UI_IN = [machine.Pin(i, machine.Pin.OUT) for i in range(8)]
+    UO_OUT = [machine.Pin(i, machine.Pin.IN) for i in range(8, 16)]
+    UIO = [machine.Pin(i, machine.Pin.OUT) for i in range(16, 24)]
+    CLK, RST_N, ENA = machine.Pin(24, machine.Pin.OUT), machine.Pin(25, machine.Pin.OUT), machine.Pin(26, machine.Pin.OUT)
 
 def clock_step():
     CLK.value(1); time.sleep_us(10); CLK.value(0); time.sleep_us(10)

--- a/test/TT_MAC_RUN.PY
+++ b/test/TT_MAC_RUN.PY
@@ -3,19 +3,35 @@ MicroPython MAC Runner for TT DevKit (RP2040)
 This script runs one 32-element MAC operation using the 41-cycle protocol.
 """
 import machine
+import os
 import time
 
-# Pin Configuration (Standard TT DevKit RP2040 Mapping)
-# ui_in: GP0-GP7
-UI_IN = [machine.Pin(i, machine.Pin.OUT) for i in range(8)]
-# uo_out: GP8-GP15
-UO_OUT = [machine.Pin(i, machine.Pin.IN) for i in range(8, 16)]
-# uio: GP16-GP23
-UIO = [machine.Pin(i, machine.Pin.OUT) for i in range(16, 24)]
-# Control Pins
-CLK = machine.Pin(24, machine.Pin.OUT)
-RST_N = machine.Pin(25, machine.Pin.OUT)
-ENA = machine.Pin(26, machine.Pin.OUT)
+# Identify board version based on machine info
+is_rp2350 = "RP2350" in os.uname().machine
+
+# Pin Configuration for TT DevKit
+if is_rp2350: # v3.2 (RP2350)
+    # ui_in: GP17-GP24
+    UI_IN = [machine.Pin(i, machine.Pin.OUT) for i in range(17, 25)]
+    # uo_out: GP33-GP40
+    UO_OUT = [machine.Pin(i, machine.Pin.IN) for i in range(33, 41)]
+    # uio: GP25-GP32
+    UIO = [machine.Pin(i, machine.Pin.OUT) for i in range(25, 33)]
+    # Control Pins
+    CLK = machine.Pin(16, machine.Pin.OUT)
+    RST_N = machine.Pin(14, machine.Pin.OUT)
+    ENA = machine.Pin(15, machine.Pin.OUT)
+else: # v2.0/v3.1 (RP2040)
+    # ui_in: GP0-GP7
+    UI_IN = [machine.Pin(i, machine.Pin.OUT) for i in range(8)]
+    # uo_out: GP8-GP15
+    UO_OUT = [machine.Pin(i, machine.Pin.IN) for i in range(8, 16)]
+    # uio: GP16-GP23
+    UIO = [machine.Pin(i, machine.Pin.OUT) for i in range(16, 24)]
+    # Control Pins
+    CLK = machine.Pin(24, machine.Pin.OUT)
+    RST_N = machine.Pin(25, machine.Pin.OUT)
+    ENA = machine.Pin(26, machine.Pin.OUT)
 
 def set_ui_in(val):
     for i in range(8):


### PR DESCRIPTION
This change adds the pin mappings for the RP2350-based TinyTapeout DevKit (v3.2) to the project documentation and test scripts.

Key updates:
- **README.md**: Added a comparative pin mapping table for RP2040 (v2.0/v3.1) and RP2350 (v3.2).
- **MicroPython Examples**: Updated the example in the README and the `test/TT_MAC_RUN.PY` reference script to include automatic board detection using `os.uname().machine`. This ensures that the same code can run on both hardware versions by selecting the appropriate GPIO assignments for `ui_in`, `uo_out`, `uio`, `clk`, `rst_n`, and `ena`.
- **Verification**: Confirmed that the hardware-independent test suite (cocotb) still passes (27/27 tests) to ensure no regressions were introduced to the documentation or infrastructure.

Fixes #559

---
*PR created automatically by Jules for task [13264404505704515503](https://jules.google.com/task/13264404505704515503) started by @chatelao*