### PR TITLE
Add Cortex-M3 Testbench Roadmap for Tang Nano 4K

### DIFF
--- a/TANG_M3_ROADMAP
+++ b/TANG_M3_ROADMAP
@@ -1,0 +1,26 @@
+# Tang Nano 4K Cortex-M3 Testbench Roadmap
+
+1. [ ] **Hardware Setup (Gowin EDA)**
+    - [ ] Instantiate `Gowin_EMPU_M3` IP core in the project.
+    - [ ] Configure IP: Enable AHB/APB buses, UART0, and at least 20 bits for GPIO0.
+    - [ ] Allocate 16KB+ internal SRAM for instruction/data memory.
+    - [ ] Connect fabric signals: Map M3 GPIO[7:0] to `ui_in[7:0]`, GPIO[15:8] to `uio_in[7:0]`, GPIO[16] to `clk`, GPIO[17] to `rst_n`, GPIO[18] to `ena`, and MAC `uo_out[7:0]` to M3 GPIO[26:19].
+2. [ ] **M3 Software Implementation**
+    - [ ] Define base addresses: UART0 (0x40000000) and GPIO0 (0x40010000).
+    - [ ] Implement low-level UART drivers (`uart_putc`, `uart_puts`, `uart_getc`).
+    - [ ] Implement `clock_tick()` with software delay loops.
+    - [ ] Implement `run_mac_test()` to drive the 41-cycle MAC protocol (IDLE -> Setup -> Stream -> Flush -> Read).
+    - [ ] Develop interactive CLI in `main()` to trigger tests ('t') and report version ('v').
+3. [ ] **Toolchain and Compilation**
+    - [ ] Set up Arm GNU Toolchain (`arm-none-eabi-gcc`).
+    - [ ] Obtain/configure linker script (`link.ld`) for the GW1NSR-4C memory map.
+    - [ ] Compile `main.c` and use `objcopy` to generate raw binary (`testbench.bin`).
+4. [ ] **Integration and Execution**
+    - [ ] Point Gowin EDA EMPU IP "Instruction Memory" path to `testbench.bin`.
+    - [ ] Execute Synthesis and Place & Route (PNR).
+    - [ ] Flash the resulting bitstream (`.fs`) to the Tang Nano 4K.
+    - [ ] Connect serial terminal (e.g., PuTTY/screen) at 115200 baud.
+5. [ ] **Troubleshooting and Refinement**
+    - [ ] Validate UART0 physical pin mapping (typically Pins 18/19).
+    - [ ] Verify `clock_tick()` timing for reliable fabric sampling.
+    - [ ] Audit physical pin usage (30-44) to prevent conflicts with external headers.


### PR DESCRIPTION
I have created a new file named `TANG_M3_ROADMAP` in the root directory. This file contains a structured, numbered list of tasks and subtasks (with checkboxes) required to implement the Cortex-M3 testbench for the Tang Nano 4K, as described in `docs/hardware/TANG_NANO_M3_TESTBENCH.md`. The roadmap covers hardware configuration, software development, toolchain setup, integration, and troubleshooting steps. I have also verified the file's content and ensured that it does not interfere with existing project configurations by running the regression test suite.

Fixes #565

---
*PR created automatically by Jules for task [16826363601996906210](https://jules.google.com/task/16826363601996906210) started by @chatelao*