### PR TITLE
Enhance Tang Nano M3 Testbench Documentation

### DIFF
--- a/docs/hardware/TANG_NANO_M3_TESTBENCH.md
+++ b/docs/hardware/TANG_NANO_M3_TESTBENCH.md
@@ -13,7 +13,30 @@ The Gowin GW1NSR-4C FPGA includes a hard-core Cortex-M3 processor (EMPU). By con
 
 ---
 
-## 2. Hardware Setup (Gowin EDA)
+## 2. Serial Communication Setup
+
+The Cortex-M3 communicates with your PC via **UART0**. There are two ways to connect:
+
+### A. On-board USB-to-UART Bridge
+The Tang Nano 4K features an on-board bridge (BL616 or CH552) that routes the M3's UART signals to the USB-C connector.
+- **Connection**: Connect a USB-C cable from the Tang Nano 4K to your PC.
+- **Port**: It will appear as a standard COM port (Windows) or `/dev/ttyUSBx` (Linux).
+- **Settings**: 115200 Baud, 8 Data bits, 1 Stop bit, No Parity.
+
+### B. External FTDI / UART Adapter
+If you prefer to use an external serial adapter (e.g., FT232R, CP2102), connect it to the physical pins mapped in the fabric.
+
+| Tang Nano 4K Pin | Signal | External Adapter Pin |
+|:---:|:---:|:---:|
+| **18** | `uart_tx` | RXD |
+| **19** | `uart_rx` | TXD |
+| **GND** | Ground | GND |
+
+*Note: Ensure your adapter is set to **3.3V logic levels**. Connecting a 5V adapter may damage the FPGA.*
+
+---
+
+## 3. Hardware Setup (Gowin EDA)
 
 To use the M3, you must instantiate the **Gowin_EMPU_M3** IP core in your project.
 
@@ -38,163 +61,95 @@ Map the M3 signals to the MAC Unit top-level (`tt_um_chatelao_fp8_multiplier`):
 
 ---
 
-## 3. M3 Software CLI (C Implementation)
+## 4. M3 Software CLI (C Implementation)
 
-The following C program implements the 41-cycle MAC protocol and provides a simple UART-based interface.
+The following C program implements the 41-cycle MAC protocol and provides a comprehensive UART-based interface.
 
-### Register Map (Standard Gowin EMPU)
+### Register Map (Gowin EMPU)
 - **UART0**: `0x40000000`
 - **GPIO0**: `0x40010000`
 
-### `main.c`
+### `main.c` Reference
+For the full source, refer to `src_m3/main.c`. Below are the core driver and interactive loop details.
 
-```c
-#include <stdint.h>
-#include <stdio.h>
+#### Interactive CLI Commands
 
-// Register Definitions
-#define UART0_BASE 0x40000000
-#define GPIO0_BASE 0x40010000
-
-#define UART0_DATA  (*(volatile uint32_t *)(UART0_BASE + 0x00))
-#define UART0_STATE (*(volatile uint32_t *)(UART0_BASE + 0x04))
-#define UART0_CTRL  (*(volatile uint32_t *)(UART0_BASE + 0x08))
-#define UART0_BAUD  (*(volatile uint32_t *)(UART0_BASE + 0x0C))
-
-#define GPIO0_DATA  (*(volatile uint32_t *)(GPIO0_BASE + 0x00))
-#define GPIO0_DIR   (*(volatile uint32_t *)(GPIO0_BASE + 0x04))
-
-// GPIO Bit Offsets
-#define BIT_UI_IN   0    // GPIO[7:0]
-#define BIT_UIO_IN  8    // GPIO[15:8]
-#define BIT_CLK     16   // GPIO[16]
-#define BIT_RST     17   // GPIO[17]
-#define BIT_ENA     18   // GPIO[18]
-#define BIT_UO_OUT  19   // GPIO[26:19] (Input to M3)
-
-void uart_putc(char c) {
-    while (UART0_STATE & 0x01); // Wait if TX full
-    UART0_DATA = c;
-}
-
-void uart_puts(const char *s) {
-    while (*s) uart_putc(*s++);
-}
-
-char uart_getc() {
-    while (!(UART0_STATE & 0x02)); // Wait if RX empty
-    return UART0_DATA;
-}
-
-void clock_tick() {
-    GPIO0_DATA |= (1 << BIT_CLK);
-    for(volatile int i=0; i<10; i++); // Small delay
-    GPIO0_DATA &= ~(1 << BIT_CLK);
-    for(volatile int i=0; i<10; i++);
-}
-
-uint32_t run_mac_test(uint8_t format, uint8_t scale_a, uint8_t scale_b, uint8_t element) {
-    uint32_t result = 0;
-
-    // Reset Sequence
-    GPIO0_DATA = (1 << BIT_RST); // Keep reset high (active low)
-    GPIO0_DATA &= ~(1 << BIT_RST); // Pulse reset
-    clock_tick();
-    GPIO0_DATA |= (1 << BIT_RST);
-    GPIO0_DATA |= (1 << BIT_ENA);
-
-    // Cycle 0: IDLE
-    GPIO0_DATA &= ~(0xFFFF << BIT_UI_IN); // Clear ui/uio
-    clock_tick();
-
-    // Cycle 1: Scale A & Format A
-    GPIO0_DATA &= ~(0xFFFF << BIT_UI_IN);
-    GPIO0_DATA |= (scale_a << BIT_UI_IN) | (format << BIT_UIO_IN);
-    clock_tick();
-
-    // Cycle 2: Scale B & Format B
-    GPIO0_DATA &= ~(0xFFFF << BIT_UI_IN);
-    GPIO0_DATA |= (scale_b << BIT_UI_IN) | (format << BIT_UIO_IN);
-    clock_tick();
-
-    // Cycles 3-34: Stream 32 elements
-    GPIO0_DATA &= ~(0xFFFF << BIT_UI_IN);
-    GPIO0_DATA |= (element << BIT_UI_IN) | (element << BIT_UIO_IN);
-    for (int i = 0; i < 32; i++) clock_tick();
-
-    // Cycles 35-36: Flush
-    GPIO0_DATA &= ~(0xFFFF << BIT_UI_IN);
-    clock_tick();
-    clock_tick();
-
-    // Cycles 37-40: Read Result
-    for (int i = 0; i < 4; i++) {
-        uint8_t byte = (GPIO0_DATA >> BIT_UO_OUT) & 0xFF;
-        result = (result << 8) | byte;
-        clock_tick();
-    }
-
-    return result;
-}
-
-int main() {
-    // 1. UART Initialization (assuming 50MHz system clock for 115200 baud)
-    // Divisor = Clock / Baud = 50,000,000 / 115200 ≈ 434
-    UART0_BAUD = 434;
-    UART0_CTRL = 0x03; // Enable TX and RX
-
-    // 2. GPIO Direction
-    // Bits 0-18: Output, Bits 19-26: Input
-    GPIO0_DIR = 0x0007FFFF;
-
-    uart_puts("\n--- MAC Unit M3 Interactive CLI ---\n");
-    uart_puts("Press 't' to run standard test, or 'v' for version.\n");
-
-    while (1) {
-        char cmd = uart_getc();
-        if (cmd == 't') {
-            uart_puts("Running Test (E4M3, 1.0 * 1.0)...\n");
-            uint32_t res = run_mac_test(0x00, 127, 127, 0x38);
-
-            char buf[64];
-            sprintf(buf, "Result: 0x%08X (Decimal: %u.%02u)\n",
-                    (unsigned int)res,
-                    (unsigned int)(res >> 8),
-                    (unsigned int)((res & 0xFF) * 100 / 256));
-            uart_puts(buf);
-        } else if (cmd == 'v') {
-            uart_puts("OCP MXFP8 MAC Unit v1.0 (Tang Nano 4K M3)\n");
-        } else {
-            uart_puts("Unknown command. Use 't' or 'v'.\n");
-        }
-    }
-    return 0;
-}
-```
+| Command | Mode | Format / Operation | Expected Result (1.0 x 1.0 x 32) |
+|:---:|:---:|---|---|
+| `t` | Standard | **E4M3** | `0x00002000` (32.0) |
+| `e` | Standard | **E5M2** | `0x00002000` (32.0) |
+| `i` | Standard | **INT8** (1 x 1 x 32) | `0x00000020` (32) |
+| `y` | Standard | **INT8_SYM** | `0x00000020` (32) |
+| `p` | Packed | **Packed E4M3** (Dual Lane) | `0x00002000` (32.0) |
+| `m` | MX+ | **MX+ Extension** (E4M3, Offset=1) | `0x00001000` (16.0) |
+| `s` | Short | **Short Protocol** (Reuse Scales) | `0x00002000` (32.0) |
+| `l` | Toggle | **LNS Mode** (0:Std, 1:LNS, 2:Hybrid) | Varies |
+| `v` | Info | **Firmware Version** | `1.3.0-M3-MXFP8` |
 
 ---
 
-## 4. Execution
+## 5. Verification Workflow
+
+Once the firmware is running, you can verify the design by sending commands through the serial terminal.
+
+### Example: Verifying E4M3 Dot Product
+1. Open your serial terminal (115200 baud).
+2. Press `t`.
+3. The M3 will drive the MAC unit with 32 elements of `1.0` (E4M3: `0x38`) and unit scales.
+4. **Expected Output**:
+   ```text
+   E4M3 Standard...
+   Result: 0x00002000
+   ```
+   *Explanation: `0x2000` is 8192 in fixed-point. $8192 / 256.0 = 32.0$.*
+
+### Example: Verifying MX+ (High Precision)
+1. Press `m`.
+2. This mode uses a non-zero NBM Offset.
+3. **Expected Output**:
+   ```text
+   MX+ Precision Research (E4M3, Offset=1, BM=Idx31)...
+   Result: 0x00001000
+   ```
+   *Explanation: With Offset=1, the effective value is halved.*
+
+---
+
+## 6. Execution
 
 ### Step 1: Compilation
-Use the **Arm GNU Toolchain** (`arm-none-eabi-gcc`) to compile the source. Ensure you have the correct linker script (`.ld`) for the GW1NSR-4C memory map.
+Use the **Arm GNU Toolchain** (`arm-none-eabi-gcc`) to compile the firmware. The project includes a `Makefile` in `src_m3/` to simplify this process.
 
 ```bash
-arm-none-eabi-gcc -mcpu=cortex-m3 -mthumb -T link.ld main.c -o testbench.elf
-arm-none-eabi-objcopy -O binary testbench.elf testbench.bin
+cd src_m3
+make
 ```
 
-### Step 2: Bitstream Integration
-In Gowin EDA, point the EMPU IP "Instruction Memory" path to your `testbench.bin` file. Re-run Synthesis and PNR.
+This will produce `testbench.bin`, which is the raw machine code for the Cortex-M3.
 
-### Step 3: Flashing and Monitoring
+### Step 2: Generate Memory Initialization File (.mi)
+Gowin EDA's EMPU IP requires a specifically formatted `.mi` file to initialize the internal instruction memory. Use the provided Python utility to convert the binary:
+
+```bash
+python3 bin2mi.py testbench.bin testbench.mi
+```
+
+### Step 3: Bitstream Integration
+1. Open your project in **Gowin EDA**.
+2. Double-click the **Gowin_EMPU_M3** IP in the "Design" tab.
+3. In the "Memory" configuration section, locate the **Instruction Memory** initialization path.
+4. Point it to the `testbench.mi` file generated in the previous step.
+5. Click **OK** and regenerate the IP.
+6. Run **Synthesis** and **Place & Route** to produce the final `.fs` bitstream.
+
+### Step 4: Flashing and Monitoring
 1. Flash the generated `.fs` file to the Tang Nano 4K.
 2. Connect a serial terminal (e.g., PuTTY or `screen`) to the Tang Nano 4K's serial port at **115200 baud**.
 3. Press the Reset button (S1) to restart the M3 and observe the output.
 
 ---
 
-## 5. Troubleshooting
+## 7. Troubleshooting
 
 - **No Serial Output**: Verify that `UART0` is mapped to the correct physical pins (Pin 18/19 are common on Tang Nano boards) and that the baud rate divider is correctly set for your system clock.
 - **Wrong Result**: Ensure the `clock_tick()` timing allows the FPGA fabric to sample the signals correctly. If necessary, increase the delay in the loop.


### PR DESCRIPTION
This PR provides a comprehensive update to the `TANG_NANO_M3_TESTBENCH.md` documentation. It adds an in-depth "how-to" for setting up serial communication (both via the on-board USB-C bridge and external FTDI adapters) and expands the verification workflow with a detailed CLI command table and mathematical expected results. These changes ensure users can successfully deploy and validate their FPGA designs using the on-chip Cortex-M3.

Fixes #573

---
*PR created automatically by Jules for task [7966301767913693492](https://jules.google.com/task/7966301767913693492) started by @chatelao*