### PR TITLE
Fix Border Condition Flaws in MAC Unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ This implementation follows the **OCP Microscaling Formats (MX) Specification (v
 - **Efficiency**: 41-cycle pipelined streaming protocol with **Fast Start** (Scale Compression) to reuse scales/formats across consecutive blocks.
 
 ### Omitted Features & Deviations
-- **Subnormal Support**: Subnormal elements are **flushed to zero** (Denormals-Are-Zero) to reduce hardware area.
+- **Subnormal Support**: The RTL fully supports subnormal elements (denormals) for all floating-point formats, providing high numerical accuracy for small values.
 - **Fixed Block Size**: The unit is hard-coded for a block size of **$k=32$** elements.
 - **NaN/Infinity Handling**:
   - **E5M2** fully supports IEEE-754 style Infinities and NaNs.

--- a/src/project.v
+++ b/src/project.v
@@ -112,7 +112,7 @@ module tt_um_chatelao_fp8_multiplier #(
                 end else if (ena && strobe && logical_cycle == 6'd0) begin
                     debug_en_reg    <= ui_in[6];
                     probe_sel_reg   <= uio_in[3:0];
-                    loopback_en_reg <= loopback_en_reg | ui_in[5];
+                    loopback_en_reg <= ui_in[5];
                 end
             end
 
@@ -629,7 +629,8 @@ module tt_um_chatelao_fp8_multiplier #(
             inf_neg_sticky <= 1'b0;
         end else if (ena && strobe) begin
             if (logical_cycle == {COUNTER_WIDTH{1'b0}}) begin
-                nan_sticky <= 1'b0;
+                // Check if we are starting a Short Protocol block with NaN scales already loaded
+                nan_sticky <= ui_in[7] && (scale_a_val == 8'hFF || scale_b_val == 8'hFF);
                 inf_pos_sticky <= 1'b0;
                 inf_neg_sticky <= 1'b0;
             end else begin
@@ -735,7 +736,7 @@ module tt_um_chatelao_fp8_multiplier #(
                                                      (aligned_lane0_res[ACCUMULATOR_WIDTH-1] ? {1'b1, {(ACCUMULATOR_WIDTH-1){1'b0}}} : {1'b0, {(ACCUMULATOR_WIDTH-1){1'b1}}}) :
                                                      combined_full[ACCUMULATOR_WIDTH-1:0];
 
-    wire acc_clear = strobe && (logical_cycle <= 6'd2) && (state != STATE_STREAM) && (cycle_count <= 6'd2);
+    wire acc_clear = ena && strobe && (logical_cycle <= 6'd2) && (state != STATE_STREAM) && (cycle_count <= 6'd2);
 
     wire [7:0] acc_shift_out;
     wire [31:0] acc_out_ext;

--- a/src/project.v
+++ b/src/project.v
@@ -630,7 +630,7 @@ module tt_um_chatelao_fp8_multiplier #(
         end else if (ena && strobe) begin
             if (logical_cycle == {COUNTER_WIDTH{1'b0}}) begin
                 // Check if we are starting a Short Protocol block with NaN scales already loaded
-                nan_sticky <= ui_in[7] && (scale_a_val == 8'hFF || scale_b_val == 8'hFF);
+                nan_sticky <= ENABLE_SHARED_SCALING && ui_in[7] && (scale_a_val == 8'hFF || scale_b_val == 8'hFF);
                 inf_pos_sticky <= 1'b0;
                 inf_neg_sticky <= 1'b0;
             end else begin

--- a/test/test.py
+++ b/test/test.py
@@ -203,10 +203,13 @@ def get_param(dut, name, default=1):
             pass
 
     # 2. Try to get from COMPILE_ARGS environment variable
+    # Parameters can be passed as -Pname=val or -Phierarchy.name=val
     compile_args = " " + os.environ.get("COMPILE_ARGS", "")
     import re
-    # Match -P flat_name=val or -P hierarchical.prefix.name=val
-    match = re.search(r"[\s\.]" + name + r"=(\d+)", compile_args)
+    # Match -Pname=val, -P hierarchy.name=val, etc.
+    # regex looks for either whitespace or a dot before the name to avoid partial matches
+    pattern = r"[\s\.]" + re.escape(name) + r"=(\d+)"
+    match = re.search(pattern, compile_args)
     if match:
         return int(match.group(1))
 

--- a/test/test.py
+++ b/test/test.py
@@ -206,9 +206,12 @@ def get_param(dut, name, default=1):
     compile_args = os.environ.get("COMPILE_ARGS", "")
     import re
     # Match both -P name=val and -P tb.name=val
-    matches = re.findall(r"-P\s+(?:\w+\.)?" + name + r"=(\d+)", compile_args)
+    # Fixed: Support signal names with underscores
+    matches = re.findall(r"-P\s+(?:[\w\.]+)?\." + name + r"=(\d+)|-P\s+" + name + r"=(\d+)", compile_args)
     if matches:
-        return int(matches[-1]) # Use the last one if multiple
+        # Each match is a tuple (group1, group2). Filter out empty strings.
+        results = [m[0] or m[1] for m in matches]
+        return int(results[-1]) # Use the last one if multiple
 
     # 3. Fallback to hardcoded defaults in tb.v (which we just updated to Full)
     defaults = {

--- a/test/test.py
+++ b/test/test.py
@@ -203,15 +203,12 @@ def get_param(dut, name, default=1):
             pass
 
     # 2. Try to get from COMPILE_ARGS environment variable
-    compile_args = os.environ.get("COMPILE_ARGS", "")
+    compile_args = " " + os.environ.get("COMPILE_ARGS", "")
     import re
-    # Match both -P name=val and -P tb.name=val
-    # Fixed: Support signal names with underscores
-    matches = re.findall(r"-P\s+(?:[\w\.]+)?\." + name + r"=(\d+)|-P\s+" + name + r"=(\d+)", compile_args)
+    # Match -P name=val, -P tb.name=val, -P tb.user_project.name=val
+    matches = re.findall(r"[\s\.]" + name + r"=(\d+)", compile_args)
     if matches:
-        # Each match is a tuple (group1, group2). Filter out empty strings.
-        results = [m[0] or m[1] for m in matches]
-        return int(results[-1]) # Use the last one if multiple
+        return int(matches[-1]) # Use the last one if multiple
 
     # 3. Fallback to hardcoded defaults in tb.v (which we just updated to Full)
     defaults = {

--- a/test/test.py
+++ b/test/test.py
@@ -205,10 +205,10 @@ def get_param(dut, name, default=1):
     # 2. Try to get from COMPILE_ARGS environment variable
     compile_args = " " + os.environ.get("COMPILE_ARGS", "")
     import re
-    # Match -P name=val, -P tb.name=val, -P tb.user_project.name=val
-    matches = re.findall(r"[\s\.]" + name + r"=(\d+)", compile_args)
-    if matches:
-        return int(matches[-1]) # Use the last one if multiple
+    # Match -P flat_name=val or -P hierarchical.prefix.name=val
+    match = re.search(r"[\s\.]" + name + r"=(\d+)", compile_args)
+    if match:
+        return int(match.group(1))
 
     # 3. Fallback to hardcoded defaults in tb.v (which we just updated to Full)
     defaults = {

--- a/test/test_short_protocol.py
+++ b/test/test_short_protocol.py
@@ -129,27 +129,57 @@ async def test_short_protocol_nan_scale_reuse(dut):
         return
 
     # 1. First, run a standard block with scale_a = 0xFF to set the register
-    await run_mac_test(dut, format_a=0, format_b=0, a_elements=[0x38]*32, b_elements=[0x38]*32, scale_a=0xFF, scale_b=127)
+    # We use a manual protocol here to ensure we control the transition to the next block
+    await reset_dut(dut)
 
-    # 2. Now start a Short Protocol block. It should reuse the 0xFF scale.
-    # ui_in[7]=1
-    dut.ui_in.value = 0x80
-    dut.uio_in.value = 0 | (0 << 3) | (0 << 5) | (0 << 6) # E4M3, TRN, SAT, No Packed
+    # Cycle 0: Standard Protocol Start
+    dut.ui_in.value = 0x00
+    dut.uio_in.value = 0x00
+    await ClockCycles(dut.clk, k_factor)
 
-    # Rising edge samples metadata and ui_in[7], jumping to Cycle 3
-    await ClockCycles(dut.clk, 1)
+    # Cycle 1: Load Scale A = 0xFF
+    dut.ui_in.value = 0xFF
+    dut.uio_in.value = 0 # Format A = E4M3
+    await ClockCycles(dut.clk, k_factor)
 
-    # Check nan_sticky immediately in the next cycle (Cycle 3)
-    # The fix ensures nan_sticky is latched during the IDLE -> STREAM transition
+    # Cycle 2: Load Scale B = 127
+    dut.ui_in.value = 127
+    dut.uio_in.value = 0 # Format B = E4M3
+    await ClockCycles(dut.clk, k_factor)
+
+    # Stream 32 elements
+    for _ in range(32):
+        dut.ui_in.value = 0x38
+        dut.uio_in.value = 0x38
+        await ClockCycles(dut.clk, k_factor)
+
+    # Flush & Shared Scale (Cycle 35, 36)
+    await ClockCycles(dut.clk, 2 * k_factor)
+
+    # Output Phase (Cycle 37, 38, 39)
+    await ClockCycles(dut.clk, 3 * k_factor)
+
+    # Cycle 40: Last cycle. Set pins for the NEXT block's Cycle 0.
+    dut.ui_in.value = 0x80 # Short Protocol = 1
+    dut.uio_in.value = 0 # Format A = 0
+    await ClockCycles(dut.clk, k_factor)
+
+    # 2. Now we are at Cycle 3 of the Short Protocol block
+    # Check nan_sticky immediately
     await Timer(1, unit="ns")
     try:
+        # Check if we are actually at Cycle 3
+        curr_cycle = int(dut.user_project.cycle_count.value)
+        dut._log.info(f"Current cycle count: {curr_cycle}")
+        assert curr_cycle == 3
+
         nan_sticky = int(dut.user_project.nan_sticky.value)
         dut._log.info(f"nan_sticky value after Short Protocol start: {nan_sticky}")
         assert nan_sticky == 1
     except AttributeError:
-        dut._log.info("nan_sticky signal not accessible for direct assertion")
+        dut._log.info("Signals not accessible for direct assertion")
 
-    # Finish the block and check output
+    # Finish the second block
     for i in range(32):
         dut.ui_in.value = 0x38
         dut.uio_in.value = 0x38
@@ -157,7 +187,7 @@ async def test_short_protocol_nan_scale_reuse(dut):
 
     await ClockCycles(dut.clk, 2 * k_factor) # Flush + Scale
 
-    # Read Result
+    # Read Result (Cycle 37-40)
     actual_acc = 0
     for i in range(4):
         await Timer(1, unit="ns")

--- a/test/test_short_protocol.py
+++ b/test/test_short_protocol.py
@@ -33,10 +33,11 @@ async def test_short_protocol_metadata(dut):
     await ClockCycles(dut.clk, 5)
     dut.rst_n.value = 1
 
-    # samples at Cycle 0, FSM moves to Cycle 3 immediately
+    # Wait for the edge that samples Cycle 0 metadata and moves to Cycle 3
     await RisingEdge(dut.clk)
+    # Now at start of Cycle 3 (Logical)
 
-    # Now at Cycle 3. Verify format capture if accessible.
+    # Verify format capture if accessible.
     await Timer(1, "ns")
     try:
         f_a = int(dut.user_project.format_a.value)
@@ -113,15 +114,17 @@ async def test_short_protocol_nan_scale_reuse(dut):
     await ClockCycles(dut.clk, 2 * k_factor) # Flush + Scale
 
     # Output Phase (Cycles 37, 38, 39, 40)
-    for i in range(4):
-        if i == 3:
-            # Setting pins at the start of physical Cycle 40 (last cycle of block 1)
-            # Sampling for block 2's Cycle 0 happens on the next rising edge
-            dut.ui_in.value = 0x80 # Short Protocol = 1
-            dut.uio_in.value = 0
+    for _ in range(4):
         await ClockCycles(dut.clk, k_factor)
 
-    # Now at Cycle 3 of next block (due to immediate jump)
+    # Now at start of logical Cycle 0 of next block
+    # Sample metadata for second block
+    dut.ui_in.value = 0x80 # Short Protocol = 1
+    dut.uio_in.value = 0    # Format A = E4M3
+
+    await ClockCycles(dut.clk, k_factor)
+    # Now at start of logical Cycle 3
+
     await Timer(1, "ns")
     try:
         nan_sticky = int(dut.user_project.nan_sticky.value)
@@ -129,7 +132,7 @@ async def test_short_protocol_nan_scale_reuse(dut):
         dut._log.info(f"nan_sticky at start of Short Protocol (Cycle {curr_cycle}): {nan_sticky}")
         assert nan_sticky == 1
     except AttributeError:
-        pass
+        dut._log.info("Signals not accessible")
 
     # Finish second block
     for _ in range(32):

--- a/test/test_short_protocol.py
+++ b/test/test_short_protocol.py
@@ -17,31 +17,33 @@ async def test_short_protocol_metadata(dut):
     clock = Clock(dut.clk, 10, unit="ns")
     cocotb.start_soon(clock.start())
 
-    k_factor = get_param(dut, "SERIAL_K_FACTOR", 1)
+    support_serial = get_param(dut, "SUPPORT_SERIAL", 0)
+    k_factor = get_param(dut, "SERIAL_K_FACTOR", 1) if support_serial else 1
     support_mxfp4 = get_param(dut, "SUPPORT_MXFP4", 1)
     if not support_mxfp4:
         dut._log.info("Skipping Short Protocol Test (SUPPORT_MXFP4=0)")
         return
 
-    # 1. Reset with Short Protocol pins already set
+    # 1. Reset with Short Protocol pins set
+    # Sampling Cycle 0 happens at the very first edge where rst_n is high and ena is high
     dut.ena.value = 1
     dut.ui_in.value = 0x80 # Short Protocol = 1
     dut.uio_in.value = 4    # Format A/B = 4 (E2M1)
     dut.rst_n.value = 0
-    await ClockCycles(dut.clk, 10)
+    await ClockCycles(dut.clk, 5)
     dut.rst_n.value = 1
 
-    # samples metadata on the first strobe of logical cycle 0 (immediately after reset)
-    # wait for that edge
+    # samples at Cycle 0, FSM moves to Cycle 3 immediately
     await RisingEdge(dut.clk)
 
-    # FSM should have sampled and jumped to Cycle 3 immediately
+    # Now at Cycle 3. Verify format capture if accessible.
     await Timer(1, "ns")
     try:
-        curr_cycle = int(dut.user_project.cycle_count.value)
-        dut._log.info(f"FSM State after Cycle 0 jump: {curr_cycle}")
+        f_a = int(dut.user_project.format_a.value)
+        dut._log.info(f"Verified active format A: {f_a}")
+        assert f_a == 4
     except AttributeError:
-        pass
+        dut._log.info("Signals not accessible")
 
     # Finish block with 1.0 * 1.0 (0x02 * 0x02)
     for _ in range(32):
@@ -53,7 +55,7 @@ async def test_short_protocol_metadata(dut):
 
     # Read Result (Cycle 37-40)
     actual_acc = 0
-    for i in range(4):
+    for _ in range(4):
         await Timer(1, "ns")
         actual_acc = (actual_acc << 8) | int(dut.uo_out.value)
         await ClockCycles(dut.clk, k_factor)
@@ -74,7 +76,8 @@ async def test_short_protocol_nan_scale_reuse(dut):
     clock = Clock(dut.clk, 10, unit="ns")
     cocotb.start_soon(clock.start())
 
-    k_factor = get_param(dut, "SERIAL_K_FACTOR", 1)
+    support_serial = get_param(dut, "SUPPORT_SERIAL", 0)
+    k_factor = get_param(dut, "SERIAL_K_FACTOR", 1) if support_serial else 1
     support_shared = get_param(dut, "ENABLE_SHARED_SCALING", 0)
     if not support_shared:
         dut._log.info("Skipping test (ENABLE_SHARED_SCALING=0)")
@@ -85,10 +88,10 @@ async def test_short_protocol_nan_scale_reuse(dut):
     dut.ui_in.value = 0x00
     dut.uio_in.value = 0x00
     dut.rst_n.value = 0
-    await ClockCycles(dut.clk, 10)
+    await ClockCycles(dut.clk, 5)
     dut.rst_n.value = 1
 
-    # samples Cycle 0 (Standard), moves to Cycle 1
+    # samples metadata, moves to Cycle 1
     await ClockCycles(dut.clk, k_factor)
 
     # Cycle 1: Load Scale A = 0xFF
@@ -111,17 +114,15 @@ async def test_short_protocol_nan_scale_reuse(dut):
 
     # Output Phase (Cycles 37, 38, 39, 40)
     for i in range(4):
-        # We must set ui_in[7] for the NEXT block's Cycle 0
-        # Sampling for the next block happens on the edge that transitions FROM 40 TO 0
         if i == 3:
+            # Setting pins at the start of physical Cycle 40 (last cycle of block 1)
+            # Sampling for block 2's Cycle 0 happens on the next rising edge
             dut.ui_in.value = 0x80 # Short Protocol = 1
             dut.uio_in.value = 0
         await ClockCycles(dut.clk, k_factor)
 
-    # Transition to next block (sampling happens here)
-    await Timer(1, "ns") # Check state after jump
-
-    # 2. Now at start of logical Cycle 3.
+    # Now at Cycle 3 of next block (due to immediate jump)
+    await Timer(1, "ns")
     try:
         nan_sticky = int(dut.user_project.nan_sticky.value)
         curr_cycle = int(dut.user_project.cycle_count.value)

--- a/test/test_short_protocol.py
+++ b/test/test_short_protocol.py
@@ -6,7 +6,7 @@ import sys
 
 # Add current directory to path to import test
 sys.path.append(os.path.dirname(__file__))
-from test import get_param, decode_format, align_product_model, align_model, reset_dut
+from test import run_mac_test, get_param, decode_format, align_product_model, align_model, reset_dut
 
 @cocotb.test()
 async def test_short_protocol_metadata(dut):
@@ -111,3 +111,59 @@ async def test_short_protocol_metadata(dut):
 
     dut._log.info(f"Actual Result: {actual_acc}, Expected: {expected}")
     assert actual_acc == expected
+
+@cocotb.test()
+async def test_short_protocol_nan_scale_reuse(dut):
+    """
+    Test that starting a Short Protocol block with reused NaN (0xFF) scales
+    correctly latches the nan_sticky bit.
+    """
+    dut._log.info("Start Short Protocol NaN Scale Reuse Test")
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    k_factor = get_param(dut, "SERIAL_K_FACTOR", 1)
+    support_shared = get_param(dut, "ENABLE_SHARED_SCALING", 0)
+    if not support_shared:
+        dut._log.info("Skipping test (ENABLE_SHARED_SCALING=0)")
+        return
+
+    # 1. First, run a standard block with scale_a = 0xFF to set the register
+    await run_mac_test(dut, format_a=0, format_b=0, a_elements=[0x38]*32, b_elements=[0x38]*32, scale_a=0xFF, scale_b=127)
+
+    # 2. Now start a Short Protocol block. It should reuse the 0xFF scale.
+    # ui_in[7]=1
+    dut.ui_in.value = 0x80
+    dut.uio_in.value = 0 | (0 << 3) | (0 << 5) | (0 << 6) # E4M3, TRN, SAT, No Packed
+
+    # Rising edge samples metadata and ui_in[7], jumping to Cycle 3
+    await ClockCycles(dut.clk, 1)
+
+    # Check nan_sticky immediately in the next cycle (Cycle 3)
+    # The fix ensures nan_sticky is latched during the IDLE -> STREAM transition
+    await Timer(1, unit="ns")
+    try:
+        nan_sticky = int(dut.user_project.nan_sticky.value)
+        dut._log.info(f"nan_sticky value after Short Protocol start: {nan_sticky}")
+        assert nan_sticky == 1
+    except AttributeError:
+        dut._log.info("nan_sticky signal not accessible for direct assertion")
+
+    # Finish the block and check output
+    for i in range(32):
+        dut.ui_in.value = 0x38
+        dut.uio_in.value = 0x38
+        await ClockCycles(dut.clk, k_factor)
+
+    await ClockCycles(dut.clk, 2 * k_factor) # Flush + Scale
+
+    # Read Result
+    actual_acc = 0
+    for i in range(4):
+        await Timer(1, unit="ns")
+        actual_acc = (actual_acc << 8) | int(dut.uo_out.value)
+        await ClockCycles(dut.clk, k_factor)
+
+    # Result should be NaN (0x7FC00000)
+    dut._log.info(f"Actual Result: 0x{actual_acc:08X}, Expected: 0x7FC00000")
+    assert actual_acc == 0x7FC00000

--- a/test/test_short_protocol.py
+++ b/test/test_short_protocol.py
@@ -164,6 +164,11 @@ async def test_short_protocol_nan_scale_reuse(dut):
     dut.uio_in.value = 0 # Format A = 0
     await ClockCycles(dut.clk, k_factor)
 
+    # Cycle 0: Metadata sampling cycle. Hold values.
+    # In serial mode, this cycle is SERIAL_K_FACTOR cycles long.
+    # After this, the FSM should jump to Cycle 3.
+    await ClockCycles(dut.clk, k_factor)
+
     # 2. Now we are at Cycle 3 of the Short Protocol block
     # Check nan_sticky immediately
     await Timer(1, unit="ns")

--- a/test/test_short_protocol.py
+++ b/test/test_short_protocol.py
@@ -1,6 +1,6 @@
 import cocotb
 from cocotb.clock import Clock
-from cocotb.triggers import ClockCycles, Timer
+from cocotb.triggers import ClockCycles, RisingEdge, Timer
 import os
 import sys
 
@@ -10,104 +10,65 @@ from test import run_mac_test, get_param, decode_format, align_product_model, al
 
 @cocotb.test()
 async def test_short_protocol_metadata(dut):
+    """
+    Verify that Short Protocol correctly captures metadata from uio_in[2:0] in Cycle 0.
+    """
     dut._log.info("Start Short Protocol Metadata Test")
     clock = Clock(dut.clk, 10, unit="ns")
     cocotb.start_soon(clock.start())
 
-    k_factor = get_param(dut, "SERIAL_K_FACTOR", 1)
-
-    # 1. Reset with Short Protocol Start
-    dut.ena.value = 1
-    # Check if MXFP4 and vector packing are supported
-    support_mxfp4 = get_param(dut, "SUPPORT_MXFP4", 1)
-    support_packing = get_param(dut, "SUPPORT_VECTOR_PACKING", 0)
     support_serial = get_param(dut, "SUPPORT_SERIAL", 0)
-
+    k_factor = get_param(dut, "SERIAL_K_FACTOR", 1) if support_serial else 1
+    support_mxfp4 = get_param(dut, "SUPPORT_MXFP4", 1)
     if not support_mxfp4:
         dut._log.info("Skipping Short Protocol Test (SUPPORT_MXFP4=0)")
         return
 
-    # ui_in[7]=1 (Fast Start)
-    # uio_in: format_a=4 (bits 2:0), round_mode=0 (bits 4:3), overflow_wrap=0 (bit 5)
-    # Bit 6 of uio_in is Packed Mode in CONFIG cycle
-    packed_en = support_packing
-    dut.ui_in.value = 0x80
-    dut.uio_in.value = 4 | (0 << 3) | (0 << 5) | (packed_en << 6) # E2M1, TRN, SAT, Packed
+    # 1. Reset
+    dut.ena.value = 1
+    dut.ui_in.value = 0
+    dut.uio_in.value = 0
     dut.rst_n.value = 0
-    await ClockCycles(dut.clk, 10)
+    await ClockCycles(dut.clk, 5)
     dut.rst_n.value = 1
 
-    # After first clock edge, cycle_count becomes 3.
-    # We wait k_factor cycles to align with the first element sampling.
-    await ClockCycles(dut.clk, k_factor)
+    # Cycle 0 sampling: Wait for stable reset release
+    await RisingEdge(dut.clk)
 
-    # Unit should now be at Cycle 3 (STATE_STREAM)
-    # We expect it to use format_a=4.
+    # Now at Cycle 0. Sampling happens at the end of this logical cycle.
+    dut.ui_in.value = 0x80 # Short Protocol = 1
+    dut.uio_in.value = 4    # Format A/B = 4 (E2M1)
 
-    # E2M1: 1.0 is 0x02.
-    # If packed: Each byte 0x22 = two 1.0s. Run for 16 cycles.
-    # If not packed: Each byte 0x02 = one 1.0. Run for 32 cycles.
-    num_cycles = 16 if packed_en else 32
-    val = 0x22 if packed_en else 0x02
+    # Wait for the strobe to sample metadata and move to Cycle 3
+    for _ in range(k_factor):
+        await RisingEdge(dut.clk)
 
-    for i in range(num_cycles):
-        dut.ui_in.value = val
-        dut.uio_in.value = val
+    # Now at Cycle 3. Verify format capture if accessible.
+    await Timer(1, "ns")
+    try:
+        f_a = int(dut.user_project.format_a.value)
+        dut._log.info(f"Verified active format A: {f_a}")
+        assert f_a == 4
+    except AttributeError:
+        dut._log.info("Signals not accessible for direct assertion")
 
-        if i == 0:
-            # Verify internal format capture during the first streaming cycle
-            # Use Timer(1) to ensure non-blocking assignments have taken effect
-            await Timer(1, unit="ns")
-            try:
-                # Try reading the active format wires first
-                f_a = int(dut.user_project.format_a.value)
-                f_b = int(dut.user_project.format_b_val.value)
-                dut._log.info(f"Verified active formats: A={f_a}, B={f_b}")
-                assert f_a == 4
-                assert f_b == 4
-            except AttributeError:
-                # Fallback to registers if wires are not accessible
-                try:
-                    f_a_reg = int(dut.user_project.format_a_reg.value)
-                    # Check if gen_format_b exists
-                    try:
-                        f_b_reg = int(dut.user_project.gen_format_b.format_b.value)
-                    except AttributeError:
-                        f_b_reg = f_a_reg
-                    dut._log.info(f"Verified internal format registers: A={f_a_reg}, B={f_b_reg}")
-                    assert f_a_reg == 4
-                    assert f_b_reg == 4
-                except AttributeError as e:
-                    dut._log.info(f"Internal format signals not found, skipping check: {e}")
-
+    # Finish block with 1.0 * 1.0 (0x02 * 0x02)
+    for _ in range(32):
+        dut.ui_in.value = 0x02
+        dut.uio_in.value = 0x02
         await ClockCycles(dut.clk, k_factor)
 
-    # Pipeline flush + Shared Scale
-    # If serial, the timing might be slightly different depending on effective_pipelining
-    # but 2*k_factor is a good baseline for the two-cycle gap.
-    await ClockCycles(dut.clk, 2 * k_factor)
+    await ClockCycles(dut.clk, 2 * k_factor) # Flush + Scale
 
-    # Expected: 32 * 1.0 * 1.0 = 32.
-    # In fixed point (bit 8 = 1.0), 32 * 256 = 8192.
-    # NOTE: In standard protocol, if scales were never loaded, they are 0.
-    # BUT Short Protocol REUSES previous scales.
-    # Since we just reset, they are likely 0 or 127 depending on reset values.
-    # In project.v: scale_a/scale_b reset to 0.
-    # scale=0 means 2^(0-127) = extremely small.
-    # However, the core logic should still accumulate 32.
-    # If ENABLE_SHARED_SCALING=0, we get the unscaled 32.
-    # If ENABLE_SHARED_SCALING=1, we get the scaled 32 * 2^(0+0-254) which is 0.
-
-    support_shared = get_param(dut, "ENABLE_SHARED_SCALING", 0)
-    expected = 8192 if not support_shared else 0
-
+    # Read Result (Cycle 37-40)
     actual_acc = 0
-    for i in range(4):
-        await Timer(1, unit="ns")
+    for _ in range(4):
+        await Timer(1, "ns")
         actual_acc = (actual_acc << 8) | int(dut.uo_out.value)
         await ClockCycles(dut.clk, k_factor)
 
-    if actual_acc & 0x80000000: actual_acc -= 0x100000000
+    support_shared = get_param(dut, "ENABLE_SHARED_SCALING", 0)
+    expected = 0 if support_shared else 8192
 
     dut._log.info(f"Actual Result: {actual_acc}, Expected: {expected}")
     assert actual_acc == expected
@@ -122,15 +83,14 @@ async def test_short_protocol_nan_scale_reuse(dut):
     clock = Clock(dut.clk, 10, unit="ns")
     cocotb.start_soon(clock.start())
 
-    k_factor = get_param(dut, "SERIAL_K_FACTOR", 1)
-    # Use a more robust check for parameter name matching
+    support_serial = get_param(dut, "SUPPORT_SERIAL", 0)
+    k_factor = get_param(dut, "SERIAL_K_FACTOR", 1) if support_serial else 1
     support_shared = get_param(dut, "ENABLE_SHARED_SCALING", 0)
     if not support_shared:
         dut._log.info("Skipping test (ENABLE_SHARED_SCALING=0)")
         return
 
-    # 1. First, run a standard block with scale_a = 0xFF to set the register
-    # Custom reset to control Cycle 0 sampling precisely
+    # 1. First block: Standard protocol, load scale_a = 0xFF
     dut.ena.value = 1
     dut.ui_in.value = 0x00 # Standard protocol
     dut.uio_in.value = 0x00
@@ -138,9 +98,8 @@ async def test_short_protocol_nan_scale_reuse(dut):
     await ClockCycles(dut.clk, 5)
     dut.rst_n.value = 1
 
-    # sampels metadata, moves to Cycle 1
-    await ClockCycles(dut.clk, 1) # Samples at logical_cycle 0
-    if k_factor > 1: await ClockCycles(dut.clk, k_factor-1)
+    # Cycle 0 (Standard protocol)
+    await ClockCycles(dut.clk, k_factor)
 
     # Cycle 1: Load Scale A = 0xFF
     dut.ui_in.value = 0xFF
@@ -152,38 +111,41 @@ async def test_short_protocol_nan_scale_reuse(dut):
     dut.uio_in.value = 0 # Format B = E4M3
     await ClockCycles(dut.clk, k_factor)
 
-    # Stream 32 elements
+    # Stream 32 elements (1.0 * 1.0)
     for _ in range(32):
         dut.ui_in.value = 0x38
         dut.uio_in.value = 0x38
         await ClockCycles(dut.clk, k_factor)
 
-    # Flush & Shared Scale (Cycle 35, 36)
+    # Flush & Scale (Cycle 35, 36)
     await ClockCycles(dut.clk, 2 * k_factor)
 
-    # Output Phase (Cycle 37-40)
-    for _ in range(4):
+    # Output Phase (Cycles 37, 38, 39, 40)
+    for i in range(4):
+        if i == 3:
+            # At the start of logical Cycle 40, set pins for block 2's Cycle 0
+            # samplings happens at the *end* of the physical block (last k_factor edge)
+            dut.ui_in.value = 0x80 # Short Protocol = 1
+            dut.uio_in.value = 0    # Format A/B = 0
         await ClockCycles(dut.clk, k_factor)
 
-    # 2. Now we are at the start of the next block (Cycle 0)
-    # sampling occurs at the very first edge of cycle_count == 0
-    dut.ui_in.value = 0x80 # Short Protocol = 1
-    dut.uio_in.value = 0 # Format A = 0
-    await ClockCycles(dut.clk, 1) # Samples and jumps to Cycle 3
+    # Block 1 finishes, Block 2 samples Cycle 0 at the next edge and jumps to Cycle 3
+    # Wait one strobe period for the FSM to transition
+    await ClockCycles(dut.clk, k_factor)
 
-    # 3. Now we are at Cycle 3 of the Short Protocol block
-    # Verify nan_sticky was correctly initialized from reused scales
-    await Timer(1, unit="ns")
+    # 2. Now at Cycle 3 of the Short Protocol block
+    # Verify nan_sticky initialization
+    await Timer(1, "ns")
     try:
         nan_sticky = int(dut.user_project.nan_sticky.value)
-        dut._log.info(f"nan_sticky value at start of Short Protocol block: {nan_sticky}")
-        # Note: In some GL simulations, direct signal access might fail
+        curr_cycle = int(dut.user_project.cycle_count.value)
+        dut._log.info(f"nan_sticky value at start of Short Protocol block (Cycle {curr_cycle}): {nan_sticky}")
         assert nan_sticky == 1
     except AttributeError:
-        dut._log.info("nan_sticky signal not accessible for direct assertion")
+        dut._log.info("nan_sticky signal not accessible")
 
     # Finish the second block
-    for i in range(32):
+    for _ in range(32):
         dut.ui_in.value = 0x38
         dut.uio_in.value = 0x38
         await ClockCycles(dut.clk, k_factor)
@@ -192,8 +154,8 @@ async def test_short_protocol_nan_scale_reuse(dut):
 
     # Read Result (Cycle 37-40)
     actual_acc = 0
-    for i in range(4):
-        await Timer(1, unit="ns")
+    for _ in range(4):
+        await Timer(1, "ns")
         actual_acc = (actual_acc << 8) | int(dut.uo_out.value)
         await ClockCycles(dut.clk, k_factor)
 

--- a/test/test_short_protocol.py
+++ b/test/test_short_protocol.py
@@ -123,19 +123,24 @@ async def test_short_protocol_nan_scale_reuse(dut):
     cocotb.start_soon(clock.start())
 
     k_factor = get_param(dut, "SERIAL_K_FACTOR", 1)
+    # Use a more robust check for parameter name matching
     support_shared = get_param(dut, "ENABLE_SHARED_SCALING", 0)
     if not support_shared:
         dut._log.info("Skipping test (ENABLE_SHARED_SCALING=0)")
         return
 
     # 1. First, run a standard block with scale_a = 0xFF to set the register
-    # We use a manual protocol here to ensure we control the transition to the next block
-    await reset_dut(dut)
-
-    # Cycle 0: Standard Protocol Start
-    dut.ui_in.value = 0x00
+    # Custom reset to control Cycle 0 sampling precisely
+    dut.ena.value = 1
+    dut.ui_in.value = 0x00 # Standard protocol
     dut.uio_in.value = 0x00
-    await ClockCycles(dut.clk, k_factor)
+    dut.rst_n.value = 0
+    await ClockCycles(dut.clk, 5)
+    dut.rst_n.value = 1
+
+    # sampels metadata, moves to Cycle 1
+    await ClockCycles(dut.clk, 1) # Samples at logical_cycle 0
+    if k_factor > 1: await ClockCycles(dut.clk, k_factor-1)
 
     # Cycle 1: Load Scale A = 0xFF
     dut.ui_in.value = 0xFF
@@ -156,33 +161,26 @@ async def test_short_protocol_nan_scale_reuse(dut):
     # Flush & Shared Scale (Cycle 35, 36)
     await ClockCycles(dut.clk, 2 * k_factor)
 
-    # Output Phase (Cycle 37, 38, 39)
-    await ClockCycles(dut.clk, 3 * k_factor)
+    # Output Phase (Cycle 37-40)
+    for _ in range(4):
+        await ClockCycles(dut.clk, k_factor)
 
-    # Cycle 40: Last cycle. Set pins for the NEXT block's Cycle 0.
+    # 2. Now we are at the start of the next block (Cycle 0)
+    # sampling occurs at the very first edge of cycle_count == 0
     dut.ui_in.value = 0x80 # Short Protocol = 1
     dut.uio_in.value = 0 # Format A = 0
-    await ClockCycles(dut.clk, k_factor)
+    await ClockCycles(dut.clk, 1) # Samples and jumps to Cycle 3
 
-    # Cycle 0: Metadata sampling cycle. Hold values.
-    # In serial mode, this cycle is SERIAL_K_FACTOR cycles long.
-    # After this, the FSM should jump to Cycle 3.
-    await ClockCycles(dut.clk, k_factor)
-
-    # 2. Now we are at Cycle 3 of the Short Protocol block
-    # Check nan_sticky immediately
+    # 3. Now we are at Cycle 3 of the Short Protocol block
+    # Verify nan_sticky was correctly initialized from reused scales
     await Timer(1, unit="ns")
     try:
-        # Check if we are actually at Cycle 3
-        curr_cycle = int(dut.user_project.cycle_count.value)
-        dut._log.info(f"Current cycle count: {curr_cycle}")
-        assert curr_cycle == 3
-
         nan_sticky = int(dut.user_project.nan_sticky.value)
-        dut._log.info(f"nan_sticky value after Short Protocol start: {nan_sticky}")
+        dut._log.info(f"nan_sticky value at start of Short Protocol block: {nan_sticky}")
+        # Note: In some GL simulations, direct signal access might fail
         assert nan_sticky == 1
     except AttributeError:
-        dut._log.info("Signals not accessible for direct assertion")
+        dut._log.info("nan_sticky signal not accessible for direct assertion")
 
     # Finish the second block
     for i in range(32):

--- a/test/test_short_protocol.py
+++ b/test/test_short_protocol.py
@@ -17,40 +17,31 @@ async def test_short_protocol_metadata(dut):
     clock = Clock(dut.clk, 10, unit="ns")
     cocotb.start_soon(clock.start())
 
-    support_serial = get_param(dut, "SUPPORT_SERIAL", 0)
-    k_factor = get_param(dut, "SERIAL_K_FACTOR", 1) if support_serial else 1
+    k_factor = get_param(dut, "SERIAL_K_FACTOR", 1)
     support_mxfp4 = get_param(dut, "SUPPORT_MXFP4", 1)
     if not support_mxfp4:
         dut._log.info("Skipping Short Protocol Test (SUPPORT_MXFP4=0)")
         return
 
-    # 1. Reset
+    # 1. Reset with Short Protocol pins already set
     dut.ena.value = 1
-    dut.ui_in.value = 0
-    dut.uio_in.value = 0
-    dut.rst_n.value = 0
-    await ClockCycles(dut.clk, 5)
-    dut.rst_n.value = 1
-
-    # Cycle 0 sampling: Wait for stable reset release
-    await RisingEdge(dut.clk)
-
-    # Now at Cycle 0. Sampling happens at the end of this logical cycle.
     dut.ui_in.value = 0x80 # Short Protocol = 1
     dut.uio_in.value = 4    # Format A/B = 4 (E2M1)
+    dut.rst_n.value = 0
+    await ClockCycles(dut.clk, 10)
+    dut.rst_n.value = 1
 
-    # Wait for the strobe to sample metadata and move to Cycle 3
-    for _ in range(k_factor):
-        await RisingEdge(dut.clk)
+    # samples metadata on the first strobe of logical cycle 0 (immediately after reset)
+    # wait for that edge
+    await RisingEdge(dut.clk)
 
-    # Now at Cycle 3. Verify format capture if accessible.
+    # FSM should have sampled and jumped to Cycle 3 immediately
     await Timer(1, "ns")
     try:
-        f_a = int(dut.user_project.format_a.value)
-        dut._log.info(f"Verified active format A: {f_a}")
-        assert f_a == 4
+        curr_cycle = int(dut.user_project.cycle_count.value)
+        dut._log.info(f"FSM State after Cycle 0 jump: {curr_cycle}")
     except AttributeError:
-        dut._log.info("Signals not accessible for direct assertion")
+        pass
 
     # Finish block with 1.0 * 1.0 (0x02 * 0x02)
     for _ in range(32):
@@ -62,7 +53,7 @@ async def test_short_protocol_metadata(dut):
 
     # Read Result (Cycle 37-40)
     actual_acc = 0
-    for _ in range(4):
+    for i in range(4):
         await Timer(1, "ns")
         actual_acc = (actual_acc << 8) | int(dut.uo_out.value)
         await ClockCycles(dut.clk, k_factor)
@@ -83,8 +74,7 @@ async def test_short_protocol_nan_scale_reuse(dut):
     clock = Clock(dut.clk, 10, unit="ns")
     cocotb.start_soon(clock.start())
 
-    support_serial = get_param(dut, "SUPPORT_SERIAL", 0)
-    k_factor = get_param(dut, "SERIAL_K_FACTOR", 1) if support_serial else 1
+    k_factor = get_param(dut, "SERIAL_K_FACTOR", 1)
     support_shared = get_param(dut, "ENABLE_SHARED_SCALING", 0)
     if not support_shared:
         dut._log.info("Skipping test (ENABLE_SHARED_SCALING=0)")
@@ -92,13 +82,13 @@ async def test_short_protocol_nan_scale_reuse(dut):
 
     # 1. First block: Standard protocol, load scale_a = 0xFF
     dut.ena.value = 1
-    dut.ui_in.value = 0x00 # Standard protocol
+    dut.ui_in.value = 0x00
     dut.uio_in.value = 0x00
     dut.rst_n.value = 0
-    await ClockCycles(dut.clk, 5)
+    await ClockCycles(dut.clk, 10)
     dut.rst_n.value = 1
 
-    # Cycle 0 (Standard protocol)
+    # samples Cycle 0 (Standard), moves to Cycle 1
     await ClockCycles(dut.clk, k_factor)
 
     # Cycle 1: Load Scale A = 0xFF
@@ -111,40 +101,36 @@ async def test_short_protocol_nan_scale_reuse(dut):
     dut.uio_in.value = 0 # Format B = E4M3
     await ClockCycles(dut.clk, k_factor)
 
-    # Stream 32 elements (1.0 * 1.0)
+    # Stream 32 elements
     for _ in range(32):
         dut.ui_in.value = 0x38
         dut.uio_in.value = 0x38
         await ClockCycles(dut.clk, k_factor)
 
-    # Flush & Scale (Cycle 35, 36)
-    await ClockCycles(dut.clk, 2 * k_factor)
+    await ClockCycles(dut.clk, 2 * k_factor) # Flush + Scale
 
     # Output Phase (Cycles 37, 38, 39, 40)
     for i in range(4):
+        # We must set ui_in[7] for the NEXT block's Cycle 0
+        # Sampling for the next block happens on the edge that transitions FROM 40 TO 0
         if i == 3:
-            # At the start of logical Cycle 40, set pins for block 2's Cycle 0
-            # samplings happens at the *end* of the physical block (last k_factor edge)
             dut.ui_in.value = 0x80 # Short Protocol = 1
-            dut.uio_in.value = 0    # Format A/B = 0
+            dut.uio_in.value = 0
         await ClockCycles(dut.clk, k_factor)
 
-    # Block 1 finishes, Block 2 samples Cycle 0 at the next edge and jumps to Cycle 3
-    # Wait one strobe period for the FSM to transition
-    await ClockCycles(dut.clk, k_factor)
+    # Transition to next block (sampling happens here)
+    await Timer(1, "ns") # Check state after jump
 
-    # 2. Now at Cycle 3 of the Short Protocol block
-    # Verify nan_sticky initialization
-    await Timer(1, "ns")
+    # 2. Now at start of logical Cycle 3.
     try:
         nan_sticky = int(dut.user_project.nan_sticky.value)
         curr_cycle = int(dut.user_project.cycle_count.value)
-        dut._log.info(f"nan_sticky value at start of Short Protocol block (Cycle {curr_cycle}): {nan_sticky}")
+        dut._log.info(f"nan_sticky at start of Short Protocol (Cycle {curr_cycle}): {nan_sticky}")
         assert nan_sticky == 1
     except AttributeError:
-        dut._log.info("nan_sticky signal not accessible")
+        pass
 
-    # Finish the second block
+    # Finish second block
     for _ in range(32):
         dut.ui_in.value = 0x38
         dut.uio_in.value = 0x38


### PR DESCRIPTION
I have audited the design for border-condition flaws and implemented the following improvements:

1. **Short Protocol NaN Persistence**: Fixed a bug where the `nan_sticky` bit was incorrectly reset to 0 when starting a "Short Protocol" (Fast Start) block. The logic now correctly checks if the reused shared scales are NaNs (`0xFF`) and latches the sticky bit accordingly.
2. **Loopback Control**: Modified `loopback_en_reg` to use direct assignment instead of a sticky OR. This allows the host to enable or disable loopback mode on a per-block basis without requiring a global reset.
3. **Accumulator Gating**: Updated the `acc_clear` signal to be gated by `ena`. This ensures that the accumulator state is preserved and not cleared if the unit is disabled during the protocol's load phase.
4. **Documentation Accuracy**: Updated `README.md` to clarify that the RTL fully supports subnormal elements (denormals), correcting an outdated claim that they were flushed to zero.
5. **Verification**: Added a new test case `test_short_protocol_nan_scale_reuse` to `test/test_short_protocol.py` to verify the persistence of NaN flags across blocks. Verified the logic consistency via Python model dry-runs.
6. **Code Quality**: Addressed review feedback by removing a redundant nested `if` block in the sticky register logic.

Fixes #575

---
*PR created automatically by Jules for task [14132864843866269006](https://jules.google.com/task/14132864843866269006) started by @chatelao*