### PR TITLE
Upgrade GitHub Actions to Node.js compatible versions

### DIFF
--- a/.github/workflows/diagram.yaml
+++ b/.github/workflows/diagram.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Graphviz
         run: sudo apt-get update && sudo apt-get install -y graphviz
@@ -64,7 +64,7 @@ jobs:
           fi
 
       - name: Upload Diagram Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logic-diagram
           path: |

--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -51,7 +51,7 @@ jobs:
       id-token: write # to verify the deployment originates from an appropriate source
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -68,7 +68,7 @@ jobs:
           xvfb-run python3 scripts/gds_colorizer.py
 
       - name: Upload Colored Visualization
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gds_colored_zones
           path: gds_colored_zones.png

--- a/.github/workflows/gowin.yaml
+++ b/.github/workflows/gowin.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -104,7 +104,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload bitstream
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gowin_bitstream_${{ matrix.variant }}
           path: build/tangnano4k_${{ matrix.variant }}.fs


### PR DESCRIPTION
I upgraded the GitHub Actions in the workflow files to their latest versions (@v6 for checkout and @v7 for upload-artifact). These versions were already being used in some of the workflows (like `test.yaml`), so I standardized the rest of the repository to match. This ensures that the CI/CD pipelines use modern Node.js runtimes and avoid deprecation warnings or failures. I verified the changes by reading the updated YAML files and checking for any remaining `@v4` instances of these common actions.

Fixes #584

---
*PR created automatically by Jules for task [16555043604111655590](https://jules.google.com/task/16555043604111655590) started by @chatelao*