### PR TITLE
Add LNS explanation to documentation

### DIFF
--- a/docs/info.md
+++ b/docs/info.md
@@ -17,6 +17,7 @@ The unit is configured in its "Full" edition (2x2 tiles), featuring:
 - **Shared Scaling (UE8M0)**: Automatic application of 8-bit exponents ($2^{E-127}$) to element blocks.
 - **Flexible Rounding**: Support for Truncate (TRN), Ceil (CEL), Floor (FLR), and Round-to-Nearest-Even (RNE).
 - **Mixed Precision**: Independent format control for Operand A and Operand B within a single MAC block.
+- **Logarithmic Multiplier (LNS)**: Optional area-optimized path using Mitchell's Approximation to reduce multiplier area by >50%.
 
 ### Streaming Protocol
 To maintain a minimal IO footprint (8-bit ports), the unit uses a **41-cycle streaming protocol** to process a block of 32 elements ($k=32$).
@@ -38,7 +39,7 @@ To maintain a minimal IO footprint (8-bit ports), the unit uses a **41-cycle str
 ![Metadata 0](metadata_c0_ui.svg)
 
 - **Short Protocol (`[7]`)**: Reuse previous scales/formats; jump to Cycle 3.
-- **LNS Mode (`[4:3]`)**: 0: Normal, 1: LNS, 2: Hybrid.
+- **LNS Mode (`[4:3]`)**: 0: Normal (Exact), 1: LNS (Mitchell Approximation), 2: Hybrid (Standard for Block Max elements, LNS for others).
 
 #### Cycle 0: UIO_IN (Metadata 1)
 ![Metadata 1](metadata_c0_uio.svg)
@@ -49,7 +50,7 @@ To maintain a minimal IO footprint (8-bit ports), the unit uses a **41-cycle str
 #### Cycle 1: UIO_IN (Config A)
 ![Config A](ocp_mx_config.svg)
 
-- **Format A (`[2:0]`)**: 0: E4M3, 1: E5M2, 2: E3M2, 3: E2M3, 4: E2M1, 5: INT8, 6: INT8_SYM.
+- **Format A (`[2:0]`)**: 0: E4M3, 1: E5M2, 2: E3M2, 3: E2M3, 4: E2M1, 5: INT8, 6: INT8_SYM. *(Note: All formats support LNS optimization)*
 
 ## How to test
 


### PR DESCRIPTION
This change adds a brief explanation of the Logarithmic Number System (LNS) optimization to the project datasheet (`docs/info.md`). It covers the use of Mitchell's Approximation for area reduction, details the three LNS configuration modes (Normal, LNS, Hybrid) in the metadata registers, and clarifies that LNS is compatible with all supported OCP MX formats.

Fixes #588

---
*PR created automatically by Jules for task [11613959749600431318](https://jules.google.com/task/11613959749600431318) started by @chatelao*