### PR TITLE
Add WaveDrom register layouts to documentation

### DIFF
--- a/docs/info.md
+++ b/docs/info.md
@@ -35,27 +35,92 @@ To maintain a minimal IO footprint (8-bit ports), the unit uses a **41-cycle str
 
 ### Register Layouts
 
-#### Cycle 0: UI_IN (Metadata 0)
+The unit captures configuration and scaling data during the first three cycles of the protocol.
+
+#### Cycle 0: Metadata 0 (`ui_in`)
 ![Metadata 0](metadata_c0_ui.svg)
 
-- **Short Protocol (`[7]`)**: Reuse previous scales/formats; jump to Cycle 3.
-- **LNS Mode (`[4:3]`)**: 0: Normal (Exact), 1: LNS (Mitchell Approximation), 2: Hybrid (Standard for Block Max elements, LNS for others).
+```json
+{ "reg": [
+  {"name": "NBM Offset A", "bits": 3},
+  {"name": "LNS Mode", "bits": 2},
+  {"name": "Loopback En", "bits": 1},
+  {"name": "Debug En", "bits": 1},
+  {"name": "Short Protocol", "bits": 1}
+], "config": {"bits": 8}}
+```
 
-#### Cycle 0: UIO_IN (Metadata 1)
+- **Short Protocol (`[7]`)**: 1: Reuse previous scales/formats; immediately jump to Cycle 3.
+- **Debug En (`[6]`)**: 1: Enable internal probing and metadata echo at the end of the block.
+- **Loopback En (`[5]`)**: 1: Direct input-to-output mapping for physical connectivity testing.
+- **LNS Mode (`[4:3]`)**:
+  - `0`: Normal (Exact IEEE-like multiplication).
+  - `1`: LNS (Logarithmic Number System using Mitchell's Approximation).
+  - `2`: Hybrid (Standard for Block Max elements, LNS for all others).
+- **NBM Offset A (`[2:0]`)**: (Standard Start only) Exponent offset for non-Block Max elements in Operand A (MX++).
+
+#### Cycle 0: Metadata 1 (`uio_in`)
 ![Metadata 1](metadata_c0_uio.svg)
 
-- **Rounding Mode (`[4:3]`)**: 0: TRN, 1: CEL, 2: FLR, 3: RNE.
-- **Packed Mode (`[6]`)**: Enable 2-elements-per-byte for FP4 formats.
+```json
+{ "reg": [
+  {"name": "NBM Offset B / Format A/B", "bits": 3},
+  {"name": "Rounding Mode", "bits": 2},
+  {"name": "Overflow Mode", "bits": 1},
+  {"name": "Packed Mode", "bits": 1},
+  {"name": "MX+ Enable", "bits": 1}
+], "config": {"bits": 8}}
+```
 
-#### Cycle 1: UIO_IN (Config A)
+- **MX+ Enable (`[7]`)**: 1: Enable OCP MX+ extensions (Repurposed exponents and Block Max tracking).
+- **Packed Mode (`[6]`)**: 1: Enable Vector Packing for 4-bit formats (2 elements per byte, Cycles 3-18).
+- **Overflow Mode (`[5]`)**: 0: SAT (Saturate to Max/Min), 1: WRAP (Modulo arithmetic).
+- **Rounding Mode (`[4:3]`)**:
+  - `0`: TRN (Truncate/Towards Zero).
+  - `1`: CEL (Ceil/Towards $+\infty$).
+  - `2`: FLR (Floor/Towards $-\infty$).
+  - `3`: RNE (Round-to-Nearest-Ties-to-Even).
+- **NBM Offset B / Format A/B (`[2:0]`)**:
+  - **Standard Start**: NBM Offset B (Exponent offset for Operand B).
+  - **Short Protocol**: Combined Format A & B selection.
+
+#### Cycle 1: Scale A (`ui_in`) & Config A (`uio_in`)
 ![Config A](ocp_mx_config.svg)
 
-- **Format A (`[2:0]`)**: 0: E4M3, 1: E5M2, 2: E3M2, 3: E2M3, 4: E2M1, 5: INT8, 6: INT8_SYM.
-- **BM Index A (`[7:3]`)**: The index (0-31) of the "Block Max" element in Operand A, used for MX+ exponent repurposing.
+**Scale A (`ui_in[7:0]`)**:
+```json
+{ "reg": [ {"name": "Scale A", "bits": 8} ], "config": {"bits": 8}}
+```
+- **Shared Scale A**: 8-bit unsigned biased exponent (UE8M0, Bias 127) applied to all elements in Operand A.
 
-#### Cycle 2: UIO_IN (Config B)
-- **Format B (`[2:0]`)**: Independent format for Operand B (Enabled if `SUPPORT_MIXED_PRECISION=1`).
+**Config A (`uio_in[7:0]`)**:
+```json
+{ "reg": [
+  {"name": "Format A", "bits": 3},
+  {"name": "BM Index A", "bits": 5}
+], "config": {"bits": 8}}
+```
+- **BM Index A (`[7:3]`)**: The index (0-31) of the "Block Max" element in Operand A (used in MX+ mode).
+- **Format A (`[2:0]`)**:
+  - `0`: E4M3, `1`: E5M2, `2`: E3M2, `3`: E2M3, `4`: E2M1, `5`: INT8, `6`: INT8_SYM.
+
+#### Cycle 2: Scale B (`ui_in`) & Config B (`uio_in`)
+
+**Scale B (`ui_in[7:0]`)**:
+```json
+{ "reg": [ {"name": "Scale B", "bits": 8} ], "config": {"bits": 8}}
+```
+- **Shared Scale B**: 8-bit unsigned biased exponent (UE8M0, Bias 127) applied to all elements in Operand B.
+
+**Config B (`uio_in[7:0]`)**:
+```json
+{ "reg": [
+  {"name": "Format B", "bits": 3},
+  {"name": "BM Index B", "bits": 5}
+], "config": {"bits": 8}}
+```
 - **BM Index B (`[7:3]`)**: The index (0-31) of the "Block Max" element in Operand B.
+- **Format B (`[2:0]`)**: Independent format for Operand B (Enabled if `SUPPORT_MIXED_PRECISION=1`).
 
 ## How to test
 


### PR DESCRIPTION
I have updated the `docs/info.md` file to include comprehensive WaveDrom bit patterns and detailed bit-level descriptions for all configuration registers used in the 41-cycle streaming protocol (Cycles 0, 1, and 2). 

This includes:
- **Cycle 0**: Detailed breakdown of Metadata 0 (`ui_in`) and Metadata 1 (`uio_in`), covering Short Protocol, Debug/Loopback modes, LNS modes, and Rounding/Overflow settings.
- **Cycle 1**: Explicit documentation for Scale A and Config A (Format and Block Max Index).
- **Cycle 2**: Explicit documentation for Scale B and Config B.

Each section now features a WaveDrom-compatible JSON block and a clear explanation of each bit's function, ensuring the documentation is both human-readable and compatible with the project's datasheet generation toolchain.

Fixes #597

---
*PR created automatically by Jules for task [15971110333688281492](https://jules.google.com/task/15971110333688281492) started by @chatelao*