### PR TITLE
Add Verilator linting to GitHub Actions CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,16 @@
+name: lint
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Install Verilator
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y verilator
+
+      - name: Run Verilator Lint
+        shell: bash
+        run: verilator --lint-only -Wall -Isrc/ --top-module tt_um_chatelao_fp8_multiplier src/project.v

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -28,7 +28,9 @@ module fp8_mul #(
     input  wire [2:0] format_b,              // Format selection for B.
     input  wire       is_bm_a,               // 1 = Operand A is a "Block Max" (MX+ extension).
     input  wire       is_bm_b,               // 1 = Operand B is a "Block Max" (MX+ extension).
+    /* verilator lint_off UNUSED */
     input  wire [1:0] lns_mode,              // Unused in this standard parallel multiplier.
+    /* verilator lint_on UNUSED */
     output wire [15:0] prod,                 // The product of the mantissas.
     output wire signed [EXP_SUM_WIDTH-1:0] exp_sum, // The combined and biased output exponent.
     output wire       sign,                  // The sign of the result (XOR of signs).

--- a/src/project.v
+++ b/src/project.v
@@ -148,8 +148,10 @@ module tt_um_chatelao_fp8_multiplier #(
     wire       packed_mode   = CAN_PACK ? packed_mode_reg : 1'b0;
 
     // --- MX+ Extension Registers ---
+    /* verilator lint_off UNUSED */
     wire [4:0] bm_index_a_val;
     wire [4:0] bm_index_b_val;
+    /* verilator lint_on UNUSED */
     wire [2:0] nbm_offset_a_val;
     wire [2:0] nbm_offset_b_val;
     wire       mx_plus_en_val;


### PR DESCRIPTION
This change adds a new GitHub Actions workflow to perform Verilator linting on every push and pull request. It also includes the necessary Verilator lint waivers in the source code to ensure a clean build for the top-level module 'tt_um_chatelao_fp8_multiplier'. All existing tests (28/28) passed across all configurations.

Fixes #599

---
*PR created automatically by Jules for task [11366728323378646197](https://jules.google.com/task/11366728323378646197) started by @chatelao*