### PR TITLE
Refactor FP8 MAC units for improved readability and maintainability

### DIFF
--- a/.github/workflows/gowin.yaml
+++ b/.github/workflows/gowin.yaml
@@ -57,9 +57,9 @@ jobs:
       - name: Synthesis
         run: |
           if [ -n "${PARAMS}" ]; then
-            yosys -p "read_verilog -Isrc -sv src/project.v src_gowin/tt_gowin_top.v; chparam ${PARAMS} tt_gowin_top; synth_gowin -top tt_gowin_top; write_json build/gowin.json"
+            yosys -p "read_verilog -Isrc -sv src/*.v src_gowin/tt_gowin_top.v; chparam ${PARAMS} tt_gowin_top; synth_gowin -top tt_gowin_top; write_json build/gowin.json"
           else
-            yosys -p "read_verilog -Isrc -sv src/project.v src_gowin/tt_gowin_top.v; synth_gowin -top tt_gowin_top; write_json build/gowin.json"
+            yosys -p "read_verilog -Isrc -sv src/*.v src_gowin/tt_gowin_top.v; synth_gowin -top tt_gowin_top; write_json build/gowin.json"
           fi
 
       - name: Place and Route

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,4 +13,4 @@ jobs:
 
       - name: Run Verilator Lint
         shell: bash
-        run: verilator --lint-only -Wall -Isrc/ --top-module tt_um_chatelao_fp8_multiplier src/project.v
+        run: verilator --lint-only -Wall -Isrc/ --top-module tt_um_chatelao_fp8_multiplier src/*.v

--- a/info.yaml
+++ b/info.yaml
@@ -18,11 +18,6 @@ project:
   # Don't forget to also update `PROJECT_SOURCES` in test/Makefile.
   source_files:
     - "project.v"
-    - "fp8_mul.v"
-    - "fp8_mul_lns.v"
-    - "fp8_decoder.v"
-    - "fp8_aligner.v"
-    - "accumulator.v"
 
 # The pinout of your project. Leave unused pins blank. DO NOT delete or add any pins.
 # This section is for the datasheet/website. Use descriptive names (e.g., RX, TX, MOSI, SCL, SEG_A, etc.).  

--- a/info.yaml
+++ b/info.yaml
@@ -20,6 +20,7 @@ project:
     - "project.v"
     - "fp8_mul.v"
     - "fp8_mul_lns.v"
+    - "fp8_decoder.v"
     - "fp8_aligner.v"
     - "accumulator.v"
 

--- a/info.yaml
+++ b/info.yaml
@@ -18,6 +18,11 @@ project:
   # Don't forget to also update `PROJECT_SOURCES` in test/Makefile.
   source_files:
     - "project.v"
+    - "fp8_mul.v"
+    - "fp8_mul_lns.v"
+    - "fp8_decoder.v"
+    - "fp8_aligner.v"
+    - "accumulator.v"
 
 # The pinout of your project. Leave unused pins blank. DO NOT delete or add any pins.
 # This section is for the datasheet/website. Use descriptive names (e.g., RX, TX, MOSI, SCL, SEG_A, etc.).  

--- a/src/fp8_decoder.v
+++ b/src/fp8_decoder.v
@@ -2,6 +2,7 @@
 `define __FP8_DECODER_V__
 `default_nettype none
 
+`include "fp8_defs.vh"
 
 /**
  * FP8 Operand Decoder Module

--- a/src/fp8_decoder.v
+++ b/src/fp8_decoder.v
@@ -2,7 +2,6 @@
 `define __FP8_DECODER_V__
 `default_nettype none
 
-`include "fp8_defs.vh"
 
 /**
  * FP8 Operand Decoder Module

--- a/src/fp8_decoder.v
+++ b/src/fp8_decoder.v
@@ -1,0 +1,156 @@
+`ifndef __FP8_DECODER_V__
+`define __FP8_DECODER_V__
+`default_nettype none
+
+`include "fp8_defs.vh"
+
+/**
+ * FP8 Operand Decoder Module
+ *
+ * This module breaks down an 8-bit input into its constituent parts:
+ * sign, exponent, and mantissa, while handling special values (NaN, Infinity, Zero)
+ * and MX+ extensions.
+ */
+module fp8_decoder #(
+    parameter SUPPORT_E4M3  = 1,
+    parameter SUPPORT_E5M2  = 1,
+    parameter SUPPORT_MXFP6 = 1,
+    parameter SUPPORT_MXFP4 = 1,
+    parameter SUPPORT_INT8  = 1,
+    parameter SUPPORT_MX_PLUS = 0,
+    parameter INTERNAL_EXP_WIDTH = 5,
+    parameter INTERNAL_BIAS_WIDTH = 6
+)(
+    input  wire [7:0] data,
+    input  wire [2:0] fmt,
+    input  wire       is_bm,
+    output reg        sign_out,
+    output reg  [INTERNAL_EXP_WIDTH-1:0] exp_out,
+    output reg  [7:0] mant_out,
+    output reg  signed [INTERNAL_BIAS_WIDTH-1:0] bias_out,
+    output reg        zero_out,
+    output reg        nan_out,
+    output reg        inf_out,
+    output reg        is_int_out
+);
+
+    /* verilator lint_off UNUSEDSIGNAL */
+    reg [7:0] tmp_exp;
+    /* verilator lint_on UNUSEDSIGNAL */
+
+    always @(*) begin
+        // Set default values.
+        sign_out = 1'b0;
+        tmp_exp = 8'd0;
+        mant_out = 8'd0;
+        bias_out = {INTERNAL_BIAS_WIDTH{1'b0}};
+        zero_out = 1'b1;
+        nan_out = 1'b0;
+        inf_out = 1'b0;
+        is_int_out = 1'b0;
+
+        case (fmt)
+            `FMT_E4M3: if (SUPPORT_E4M3) begin
+                sign_out = data[7];
+                bias_out = 7;
+                if (is_bm && SUPPORT_MX_PLUS) begin
+                    // MX+ Extension: Block Max treatment for E4M3.
+                    tmp_exp = 11; // 15 - 4 (mantissa shift compensation)
+                    mant_out = {1'b1, data[6:0]};
+                    zero_out = 1'b0;
+                end else begin
+                    // Standard E4M3: [S][EEEE][MMM]
+                    tmp_exp = (data[6:3] == 4'd0) ? 1 : {4'd0, data[6:3]};
+                    mant_out = {4'b0, (data[6:3] != 4'd0), data[2:0]};
+                    zero_out = (data[6:0] == 7'd0);
+                    if (data[6:0] == 7'b1111111) nan_out = 1'b1;
+                end
+            end
+            `FMT_E5M2: if (SUPPORT_E5M2) begin
+                sign_out = data[7];
+                bias_out = 15;
+                if (is_bm && SUPPORT_MX_PLUS) begin
+                    tmp_exp = 26; // 30 - 4 (mantissa shift compensation)
+                    mant_out = {1'b1, data[6:0]};
+                    zero_out = 1'b0;
+                end else begin
+                    // Standard E5M2: [S][EEEEE][MM]
+                    tmp_exp = (data[6:2] == 5'd0) ? 1 : {3'd0, data[6:2]};
+                    mant_out = {4'b0, (data[6:2] != 5'd0), data[1:0], 1'b0};
+                    zero_out = (data[6:0] == 7'd0);
+                    if (data[6:2] == 5'b11111) begin
+                        if (data[1:0] == 2'b00) inf_out = 1'b1;
+                        else                   nan_out = 1'b1;
+                    end
+                end
+            end
+            `FMT_E3M2: if (SUPPORT_MXFP6) begin
+                sign_out = data[5];
+                bias_out = 3;
+                if (is_bm && SUPPORT_MX_PLUS) begin
+                    tmp_exp = 5; // 7 - 2 (mantissa shift compensation)
+                    mant_out = {2'b0, 1'b1, data[4:0]};
+                    zero_out = 1'b0;
+                end else begin
+                    tmp_exp = (data[4:2] == 3'd0) ? 1 : {5'd0, data[4:2]};
+                    mant_out = {4'b0, (data[4:2] != 3'd0), data[1:0], 1'b0};
+                    zero_out = (data[4:0] == 5'd0);
+                end
+            end
+            `FMT_E2M3: if (SUPPORT_MXFP6) begin
+                sign_out = data[5];
+                bias_out = 1;
+                if (is_bm && SUPPORT_MX_PLUS) begin
+                    tmp_exp = 1; // 3 - 2 (mantissa shift compensation)
+                    mant_out = {2'b0, 1'b1, data[4:0]};
+                    zero_out = 1'b0;
+                end else begin
+                    tmp_exp = (data[4:3] == 2'd0) ? 1 : {6'd0, data[4:3]};
+                    mant_out = {4'b0, (data[4:3] != 2'd0), data[2:0]};
+                    zero_out = (data[4:0] == 5'd0);
+                end
+            end
+            `FMT_E2M1: if (SUPPORT_MXFP4) begin
+                sign_out = data[3];
+                bias_out = 1;
+                if (is_bm && SUPPORT_MX_PLUS) begin
+                    tmp_exp = 3; // No compensation needed (shift 0)
+                    mant_out = {4'b0, 1'b1, data[2:0]};
+                    zero_out = 1'b0;
+                end else begin
+                    tmp_exp = (data[2:1] == 2'd0) ? 1 : {6'd0, data[2:1]};
+                    mant_out = {4'b0, (data[2:1] != 2'd0), data[0], 2'b0};
+                    zero_out = (data[2:0] == 3'd0);
+                end
+            end
+            `FMT_INT8: if (SUPPORT_INT8) begin
+                // 8-bit Integer treatment.
+                sign_out = data[7];
+                mant_out = data[7] ? -data : data;
+                tmp_exp = 0;
+                bias_out = 3;
+                zero_out = (data == 8'd0);
+                is_int_out = 1'b1;
+            end
+            `FMT_INT8_SYM: if (SUPPORT_INT8) begin
+                sign_out = data[7];
+                mant_out = (data == 8'h80) ? 8'd127 : (data[7] ? -data : data);
+                tmp_exp = 0;
+                bias_out = 3;
+                zero_out = (data == 8'd0);
+                is_int_out = 1'b1;
+            end
+            default: begin
+                // Default to E4M3-like structure for unknown formats.
+                sign_out = data[7];
+                tmp_exp = (data[6:3] == 4'd0) ? 1 : {4'd0, data[6:3]};
+                mant_out = {4'b0, (data[6:3] != 4'd0), data[2:0]};
+                bias_out = 7;
+                zero_out = (data[6:0] == 7'd0);
+            end
+        endcase
+        exp_out = tmp_exp[INTERNAL_EXP_WIDTH-1:0];
+    end
+
+endmodule
+`endif

--- a/src/fp8_defs.vh
+++ b/src/fp8_defs.vh
@@ -1,0 +1,13 @@
+`ifndef __FP8_DEFS_VH__
+`define __FP8_DEFS_VH__
+
+// OCP MX Format Selection Indices
+`define FMT_E4M3      3'b000
+`define FMT_E5M2      3'b001
+`define FMT_E3M2      3'b010
+`define FMT_E2M3      3'b011
+`define FMT_E2M1      3'b100
+`define FMT_INT8      3'b101
+`define FMT_INT8_SYM  3'b110
+
+`endif

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -52,10 +52,6 @@ module fp8_mul #(
     wire signed [INTERNAL_BIAS_WIDTH-1:0] bias_a, bias_b;
     wire zero_a, zero_b;
     wire nan_a, nan_b, inf_a, inf_b;
-    /* verilator lint_off UNUSED */
-    wire is_inta, is_intb;
-    /* verilator lint_on UNUSED */
-
     reg [15:0] p_res;
     reg signed [EXP_SUM_WIDTH-1:0] exp_sum_res;
     reg sign_res;
@@ -94,6 +90,10 @@ module fp8_mul #(
             end
         end else begin : gen_multi_format
             // Standard path for multiple formats.
+            /* verilator lint_off UNUSED */
+            wire is_inta, is_intb;
+            /* verilator lint_on UNUSED */
+
             fp8_decoder #(
                 .SUPPORT_E4M3(SUPPORT_E4M3),
                 .SUPPORT_E5M2(SUPPORT_E5M2),

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -111,8 +111,7 @@ module fp8_mul #(
                 .bias_out(bias_a),
                 .zero_out(zero_a),
                 .nan_out(nan_a),
-                .inf_out(inf_a),
-                .is_int_out()
+                .inf_out(inf_a)
             );
 
             fp8_decoder #(
@@ -134,8 +133,7 @@ module fp8_mul #(
                 .bias_out(bias_b),
                 .zero_out(zero_b),
                 .nan_out(nan_b),
-                .inf_out(inf_b),
-                .is_int_out()
+                .inf_out(inf_b)
             );
 
             always @(*) begin

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -3,6 +3,8 @@
 `default_nettype none
 
 // This file contains logic derived from fp8_mul by Clive Chan (https://github.com/cchan/fp8_mul)
+`include "fp8_defs.vh"
+`include "fp8_decoder.v"
 
 /**
  * FP8 Multiplier Module

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -3,6 +3,9 @@
 `default_nettype none
 
 // This file contains logic derived from fp8_mul by Clive Chan (https://github.com/cchan/fp8_mul)
+`include "fp8_defs.vh"
+`include "fp8_decoder.v"
+
 /**
  * FP8 Multiplier Module
  *
@@ -37,28 +40,19 @@ module fp8_mul #(
     output wire       nan,                   // 1 = Result is Not a Number (NaN).
     output wire       inf                    // 1 = Result is Infinity.
 );
-    // Beginner Note: 'localparam' defines constants for different formats.
-    localparam FMT_E4M3 = 3'b000;
-    localparam FMT_E5M2 = 3'b001;
-    localparam FMT_E3M2 = 3'b010;
-    localparam FMT_E2M3 = 3'b011;
-    localparam FMT_E2M1 = 3'b100;
-    localparam FMT_INT8 = 3'b101;
-    localparam FMT_INT8_SYM = 3'b110;
-
     // Calculate the internal exponent width needed based on enabled formats.
     localparam INTERNAL_EXP_WIDTH = (SUPPORT_E5M2) ? 5 :
                                     (SUPPORT_E4M3 || SUPPORT_INT8 || SUPPORT_MX_PLUS) ? 4 :
                                     (SUPPORT_MXFP6) ? 3 : 2;
     localparam INTERNAL_BIAS_WIDTH = INTERNAL_EXP_WIDTH + 1;
 
-    // Internal registers to hold decoded components of the operands.
-    reg sign_a, sign_b;
-    reg [INTERNAL_EXP_WIDTH-1:0] ea, eb;
-    reg [7:0] ma, mb;
-    reg signed [INTERNAL_BIAS_WIDTH-1:0] bias_a, bias_b;
-    reg zero_a, zero_b;
-    reg nan_a, nan_b, inf_a, inf_b;
+    // Internal wires to hold decoded components of the operands.
+    wire sign_a, sign_b;
+    wire [INTERNAL_EXP_WIDTH-1:0] ea, eb;
+    wire [7:0] ma, mb;
+    wire signed [INTERNAL_BIAS_WIDTH-1:0] bias_a, bias_b;
+    wire zero_a, zero_b;
+    wire nan_a, nan_b, inf_a, inf_b;
 
     reg [15:0] p_res;
     reg signed [EXP_SUM_WIDTH-1:0] exp_sum_res;
@@ -69,154 +63,26 @@ module fp8_mul #(
     localparam IS_FP4_ONLY = (SUPPORT_MXFP4 == 1) && (SUPPORT_E4M3 == 0) && (SUPPORT_E5M2 == 0) &&
                              (SUPPORT_MXFP6 == 0) && (SUPPORT_INT8 == 0) && (SUPPORT_MX_PLUS == 0);
 
-    /**
-     * Decoding Task
-     * A 'task' in Verilog is like a procedure or function that can be reused.
-     * It breaks down the 8-bit input 'data' into its sign, exponent, and mantissa.
-     */
-    task automatic decode_operand(
-        input [7:0] data,
-        input [2:0] fmt,
-        input is_bm,
-        output reg sign_out,
-        output reg [INTERNAL_EXP_WIDTH-1:0] exp_out,
-        output reg [7:0] mant_out,
-        output reg signed [INTERNAL_BIAS_WIDTH-1:0] bias_out,
-        output reg zero_out,
-        output reg nan_out,
-        output reg inf_out
-    );
-        /* verilator lint_off UNUSEDSIGNAL */
-        reg [7:0] tmp_exp;
-        /* verilator lint_on UNUSEDSIGNAL */
-        begin
-            // Set default values.
-            sign_out = 1'b0;
-            tmp_exp = 8'd0;
-            mant_out = 8'd0;
-            bias_out = {INTERNAL_BIAS_WIDTH{1'b0}};
-            zero_out = 1'b1;
-            nan_out = 1'b0;
-            inf_out = 1'b0;
-
-            case (fmt)
-                FMT_E4M3: if (SUPPORT_E4M3) begin
-                    sign_out = data[7];
-                    bias_out = 7;
-                    if (is_bm && SUPPORT_MX_PLUS) begin
-                        // MX+ Extension: Block Max treatment for E4M3.
-                        tmp_exp = 11; // 15 - 4 (mantissa shift compensation)
-                        mant_out = {1'b1, data[6:0]};
-                        zero_out = 1'b0;
-                    end else begin
-                        // Standard E4M3: [S][EEEE][MMM]
-                        tmp_exp = (data[6:3] == 4'd0) ? 1 : {4'd0, data[6:3]};
-                        mant_out = {4'b0, (data[6:3] != 4'd0), data[2:0]};
-                        zero_out = (data[6:0] == 7'd0);
-                        if (data[6:0] == 7'b1111111) nan_out = 1'b1;
-                    end
-                end
-                FMT_E5M2: if (SUPPORT_E5M2) begin
-                    sign_out = data[7];
-                    bias_out = 15;
-                    if (is_bm && SUPPORT_MX_PLUS) begin
-                        tmp_exp = 26; // 30 - 4 (mantissa shift compensation)
-                        mant_out = {1'b1, data[6:0]};
-                        zero_out = 1'b0;
-                    end else begin
-                        // Standard E5M2: [S][EEEEE][MM]
-                        tmp_exp = (data[6:2] == 5'd0) ? 1 : {3'd0, data[6:2]};
-                        mant_out = {4'b0, (data[6:2] != 5'd0), data[1:0], 1'b0};
-                        zero_out = (data[6:0] == 7'd0);
-                        if (data[6:2] == 5'b11111) begin
-                            if (data[1:0] == 2'b00) inf_out = 1'b1;
-                            else                   nan_out = 1'b1;
-                        end
-                    end
-                end
-                FMT_E3M2: if (SUPPORT_MXFP6) begin
-                    sign_out = data[5];
-                    bias_out = 3;
-                    if (is_bm && SUPPORT_MX_PLUS) begin
-                        tmp_exp = 5; // 7 - 2 (mantissa shift compensation)
-                        mant_out = {2'b0, 1'b1, data[4:0]};
-                        zero_out = 1'b0;
-                    end else begin
-                        tmp_exp = (data[4:2] == 3'd0) ? 1 : {5'd0, data[4:2]};
-                        mant_out = {4'b0, (data[4:2] != 3'd0), data[1:0], 1'b0};
-                        zero_out = (data[4:0] == 5'd0);
-                    end
-                end
-                FMT_E2M3: if (SUPPORT_MXFP6) begin
-                    sign_out = data[5];
-                    bias_out = 1;
-                    if (is_bm && SUPPORT_MX_PLUS) begin
-                        tmp_exp = 1; // 3 - 2 (mantissa shift compensation)
-                        mant_out = {2'b0, 1'b1, data[4:0]};
-                        zero_out = 1'b0;
-                    end else begin
-                        tmp_exp = (data[4:3] == 2'd0) ? 1 : {6'd0, data[4:3]};
-                        mant_out = {4'b0, (data[4:3] != 2'd0), data[2:0]};
-                        zero_out = (data[4:0] == 5'd0);
-                    end
-                end
-                FMT_E2M1: if (SUPPORT_MXFP4) begin
-                    sign_out = data[3];
-                    bias_out = 1;
-                    if (is_bm && SUPPORT_MX_PLUS) begin
-                        tmp_exp = 3; // No compensation needed (shift 0)
-                        mant_out = {4'b0, 1'b1, data[2:0]};
-                        zero_out = 1'b0;
-                    end else begin
-                        tmp_exp = (data[2:1] == 2'd0) ? 1 : {6'd0, data[2:1]};
-                        mant_out = {4'b0, (data[2:1] != 2'd0), data[0], 2'b0};
-                        zero_out = (data[2:0] == 3'd0);
-                    end
-                end
-                FMT_INT8: if (SUPPORT_INT8) begin
-                    // 8-bit Integer treatment.
-                    sign_out = data[7];
-                    mant_out = data[7] ? -data : data;
-                    tmp_exp = 0;
-                    bias_out = 3;
-                    zero_out = (data == 8'd0);
-                end
-                FMT_INT8_SYM: if (SUPPORT_INT8) begin
-                    sign_out = data[7];
-                    mant_out = (data == 8'h80) ? 8'd127 : (data[7] ? -data : data);
-                    tmp_exp = 0;
-                    bias_out = 3;
-                    zero_out = (data == 8'd0);
-                end
-                default: begin
-                    // Default to E4M3-like structure for unknown formats.
-                    sign_out = data[7];
-                    tmp_exp = (data[6:3] == 4'd0) ? 1 : {4'd0, data[6:3]};
-                    mant_out = {4'b0, (data[6:3] != 4'd0), data[2:0]};
-                    bias_out = 7;
-                    zero_out = (data[6:0] == 7'd0);
-                end
-            endcase
-            exp_out = tmp_exp[INTERNAL_EXP_WIDTH-1:0];
-        end
-    endtask
-
     generate
         if (IS_FP4_ONLY) begin : gen_fp4_only
             // Ultra-optimized path for FP4 only.
+            assign sign_a = a[3];
+            assign ea = (a[2:1] == 2'd0) ? 2'd1 : a[2:1];
+            assign ma = {4'b0, (a[2:1] != 2'd0), a[0], 2'b0};
+            assign bias_a = 3'sd1;
+            assign zero_a = (a[2:0] == 3'd0);
+            assign nan_a = 1'b0;
+            assign inf_a = 1'b0;
+
+            assign sign_b = b[3];
+            assign eb = (b[2:1] == 2'd0) ? 2'd1 : b[2:1];
+            assign mb = {4'b0, (b[2:1] != 2'd0), b[0], 2'b0};
+            assign bias_b = 3'sd1;
+            assign zero_b = (b[2:0] == 3'd0);
+            assign nan_b = 1'b0;
+            assign inf_b = 1'b0;
+
             always @(*) begin
-                sign_a = a[3];
-                ea = (a[2:1] == 2'd0) ? 2'd1 : a[2:1];
-                ma = {4'b0, (a[2:1] != 2'd0), a[0], 2'b0};
-                bias_a = 3'sd1;
-                zero_a = (a[2:0] == 3'd0);
-
-                sign_b = b[3];
-                eb = (b[2:1] == 2'd0) ? 2'd1 : b[2:1];
-                mb = {4'b0, (b[2:1] != 2'd0), b[0], 2'b0};
-                bias_b = 3'sd1;
-                zero_b = (b[2:0] == 3'd0);
-
                 p_res = (zero_a || zero_b) ? 16'd0 : ({{14{1'b0}}, ma[3:2]} * {{14{1'b0}}, mb[3:2]}) << 4;
 
                 sign_res = sign_a ^ sign_b;
@@ -226,18 +92,53 @@ module fp8_mul #(
             end
         end else begin : gen_multi_format
             // Standard path for multiple formats.
+            fp8_decoder #(
+                .SUPPORT_E4M3(SUPPORT_E4M3),
+                .SUPPORT_E5M2(SUPPORT_E5M2),
+                .SUPPORT_MXFP6(SUPPORT_MXFP6),
+                .SUPPORT_MXFP4(SUPPORT_MXFP4),
+                .SUPPORT_INT8(SUPPORT_INT8),
+                .SUPPORT_MX_PLUS(SUPPORT_MX_PLUS),
+                .INTERNAL_EXP_WIDTH(INTERNAL_EXP_WIDTH),
+                .INTERNAL_BIAS_WIDTH(INTERNAL_BIAS_WIDTH)
+            ) decoder_a (
+                .data(a),
+                .fmt(format_a),
+                .is_bm(is_bm_a),
+                .sign_out(sign_a),
+                .exp_out(ea),
+                .mant_out(ma),
+                .bias_out(bias_a),
+                .zero_out(zero_a),
+                .nan_out(nan_a),
+                .inf_out(inf_a),
+                .is_int_out()
+            );
+
+            fp8_decoder #(
+                .SUPPORT_E4M3(SUPPORT_E4M3),
+                .SUPPORT_E5M2(SUPPORT_E5M2),
+                .SUPPORT_MXFP6(SUPPORT_MXFP6),
+                .SUPPORT_MXFP4(SUPPORT_MXFP4),
+                .SUPPORT_INT8(SUPPORT_INT8),
+                .SUPPORT_MX_PLUS(SUPPORT_MX_PLUS),
+                .INTERNAL_EXP_WIDTH(INTERNAL_EXP_WIDTH),
+                .INTERNAL_BIAS_WIDTH(INTERNAL_BIAS_WIDTH)
+            ) decoder_b (
+                .data(b),
+                .fmt(SUPPORT_MIXED_PRECISION ? format_b : format_a),
+                .is_bm(is_bm_b),
+                .sign_out(sign_b),
+                .exp_out(eb),
+                .mant_out(mb),
+                .bias_out(bias_b),
+                .zero_out(zero_b),
+                .nan_out(nan_b),
+                .inf_out(inf_b),
+                .is_int_out()
+            );
+
             always @(*) begin
-                // 1. Decode operands A and B.
-                decode_operand(a, format_a, is_bm_a, sign_a, ea, ma, bias_a, zero_a, nan_a, inf_a);
-
-                // Operand B Decoding
-                if (SUPPORT_MIXED_PRECISION) begin
-                    decode_operand(b, format_b, is_bm_b, sign_b, eb, mb, bias_b, zero_b, nan_b, inf_b);
-                end else begin
-                    // Use format_a for both operands to allow hardware sharing
-                    decode_operand(b, format_a, is_bm_b, sign_b, eb, mb, bias_b, zero_b, nan_b, inf_b);
-                end
-
                 // 2. Perform Multiplication of mantissas (8x8, 4x4 or 2x2 Multiplier).
                 if (SUPPORT_INT8 || SUPPORT_MX_PLUS)
                     p_res = (zero_a || zero_b) ? 16'd0 : (ma * mb);

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -3,8 +3,6 @@
 `default_nettype none
 
 // This file contains logic derived from fp8_mul by Clive Chan (https://github.com/cchan/fp8_mul)
-`include "fp8_defs.vh"
-`include "fp8_decoder.v"
 
 /**
  * FP8 Multiplier Module
@@ -53,6 +51,9 @@ module fp8_mul #(
     wire signed [INTERNAL_BIAS_WIDTH-1:0] bias_a, bias_b;
     wire zero_a, zero_b;
     wire nan_a, nan_b, inf_a, inf_b;
+    /* verilator lint_off UNUSED */
+    wire is_inta, is_intb;
+    /* verilator lint_on UNUSED */
 
     reg [15:0] p_res;
     reg signed [EXP_SUM_WIDTH-1:0] exp_sum_res;
@@ -111,7 +112,8 @@ module fp8_mul #(
                 .bias_out(bias_a),
                 .zero_out(zero_a),
                 .nan_out(nan_a),
-                .inf_out(inf_a)
+                .inf_out(inf_a),
+                .is_int_out(is_inta)
             );
 
             fp8_decoder #(
@@ -133,7 +135,8 @@ module fp8_mul #(
                 .bias_out(bias_b),
                 .zero_out(zero_b),
                 .nan_out(nan_b),
-                .inf_out(inf_b)
+                .inf_out(inf_b),
+                .is_int_out(is_intb)
             );
 
             always @(*) begin

--- a/src/fp8_mul.v
+++ b/src/fp8_mul.v
@@ -4,7 +4,6 @@
 
 // This file contains logic derived from fp8_mul by Clive Chan (https://github.com/cchan/fp8_mul)
 `include "fp8_defs.vh"
-`include "fp8_decoder.v"
 
 /**
  * FP8 Multiplier Module

--- a/src/fp8_mul_lns.v
+++ b/src/fp8_mul_lns.v
@@ -4,6 +4,9 @@
 
 // This file implements an FP8 multiplier using Logarithmic Number System (LNS).
 // It replaces the 4x4/8x8 multiplier with a simple adder or LUT.
+`include "fp8_defs.vh"
+`include "fp8_decoder.v"
+
 /**
  * FP8 Multiplier Module (Logarithmic Number System - LNS)
  *
@@ -38,27 +41,18 @@ module fp8_mul_lns #(
     output wire       nan,
     output wire       inf
 );
-    // Format selection constants.
-    localparam FMT_E4M3 = 3'b000;
-    localparam FMT_E5M2 = 3'b001;
-    localparam FMT_E3M2 = 3'b010;
-    localparam FMT_E2M3 = 3'b011;
-    localparam FMT_E2M1 = 3'b100;
-    localparam FMT_INT8 = 3'b101;
-    localparam FMT_INT8_SYM = 3'b110;
-
     localparam INTERNAL_EXP_WIDTH = (SUPPORT_E5M2) ? 5 :
                                     (SUPPORT_E4M3 || SUPPORT_INT8 || SUPPORT_MX_PLUS) ? 4 :
                                     (SUPPORT_MXFP6) ? 3 : 2;
     localparam INTERNAL_BIAS_WIDTH = INTERNAL_EXP_WIDTH + 1;
 
-    reg sign_a, sign_b;
-    reg [INTERNAL_EXP_WIDTH-1:0] ea, eb;
-    reg [7:0] ma, mb;
-    reg signed [INTERNAL_BIAS_WIDTH-1:0] bias_a, bias_b;
-    reg zero_a, zero_b;
-    reg nan_a, nan_b, inf_a, inf_b;
-    reg is_inta, is_intb;
+    wire sign_a, sign_b;
+    wire [INTERNAL_EXP_WIDTH-1:0] ea, eb;
+    wire [7:0] ma, mb;
+    wire signed [INTERNAL_BIAS_WIDTH-1:0] bias_a, bias_b;
+    wire zero_a, zero_b;
+    wire nan_a, nan_b, inf_a, inf_b;
+    wire is_inta, is_intb;
 
     reg [15:0] p_res;
     reg signed [EXP_SUM_WIDTH-1:0] exp_sum_res;
@@ -84,141 +78,51 @@ module fp8_mul_lns #(
         lns_lut[56] = 4'h7; lns_lut[57] = 4'h8; lns_lut[58] = 4'h9; lns_lut[59] = 4'ha; lns_lut[60] = 4'hb; lns_lut[61] = 4'hc; lns_lut[62] = 4'hd; lns_lut[63] = 4'he;
     end
 
-    /**
-     * Decoding Task
-     * A 'task' in Verilog is like a procedure or function that can be reused.
-     * It breaks down the 8-bit input 'data' into its sign, exponent, and mantissa.
-     */
-    task automatic decode_operand(
-        input [7:0] data,
-        input [2:0] fmt,
-        input is_bm,
-        output reg sign_out,
-        output reg [INTERNAL_EXP_WIDTH-1:0] exp_out,
-        output reg [7:0] mant_out,
-        output reg signed [INTERNAL_BIAS_WIDTH-1:0] bias_out,
-        output reg zero_out,
-        output reg nan_out,
-        output reg inf_out,
-        output reg is_int_out
+    fp8_decoder #(
+        .SUPPORT_E4M3(SUPPORT_E4M3),
+        .SUPPORT_E5M2(SUPPORT_E5M2),
+        .SUPPORT_MXFP6(SUPPORT_MXFP6),
+        .SUPPORT_MXFP4(SUPPORT_MXFP4),
+        .SUPPORT_INT8(SUPPORT_INT8),
+        .SUPPORT_MX_PLUS(SUPPORT_MX_PLUS),
+        .INTERNAL_EXP_WIDTH(INTERNAL_EXP_WIDTH),
+        .INTERNAL_BIAS_WIDTH(INTERNAL_BIAS_WIDTH)
+    ) decoder_a (
+        .data(a),
+        .fmt(format_a),
+        .is_bm(is_bm_a),
+        .sign_out(sign_a),
+        .exp_out(ea),
+        .mant_out(ma),
+        .bias_out(bias_a),
+        .zero_out(zero_a),
+        .nan_out(nan_a),
+        .inf_out(inf_a),
+        .is_int_out(is_inta)
     );
-        /* verilator lint_off UNUSEDSIGNAL */
-        reg [7:0] tmp_exp;
-        /* verilator lint_on UNUSEDSIGNAL */
-        begin
-            // Set default values.
-            sign_out = 1'b0;
-            tmp_exp = 8'd0;
-            mant_out = 8'd0;
-            bias_out = {INTERNAL_BIAS_WIDTH{1'b0}};
-            zero_out = 1'b1;
-            nan_out = 1'b0;
-            inf_out = 1'b0;
-            is_int_out = 1'b0;
 
-            case (fmt)
-                FMT_E4M3: if (SUPPORT_E4M3) begin
-                    sign_out = data[7];
-                    bias_out = 7;
-                    if (is_bm && SUPPORT_MX_PLUS) begin
-                        // MX+ Extension: Block Max treatment for E4M3.
-                        tmp_exp = 11; // 15 - 4 (mantissa shift compensation)
-                        mant_out = {1'b1, data[6:0]};
-                        zero_out = 1'b0;
-                    end else begin
-                        // Standard E4M3: [S][EEEE][MMM]
-                        tmp_exp = (data[6:3] == 4'd0) ? 1 : {4'd0, data[6:3]};
-                        mant_out = {4'b0, (data[6:3] != 4'd0), data[2:0]};
-                        zero_out = (data[6:0] == 7'd0);
-                        if (data[6:0] == 7'b1111111) nan_out = 1'b1;
-                    end
-                end
-                FMT_E5M2: if (SUPPORT_E5M2) begin
-                    sign_out = data[7];
-                    bias_out = 15;
-                    if (is_bm && SUPPORT_MX_PLUS) begin
-                        tmp_exp = 26; // 30 - 4 (mantissa shift compensation)
-                        mant_out = {1'b1, data[6:0]};
-                        zero_out = 1'b0;
-                    end else begin
-                        // Standard E5M2: [S][EEEEE][MM]
-                        tmp_exp = (data[6:2] == 5'd0) ? 1 : {3'd0, data[6:2]};
-                        mant_out = {4'b0, (data[6:2] != 5'd0), data[1:0], 1'b0};
-                        zero_out = (data[6:0] == 7'd0);
-                        if (data[6:2] == 5'b11111) begin
-                            if (data[1:0] == 2'b00) inf_out = 1'b1;
-                            else                   nan_out = 1'b1;
-                        end
-                    end
-                end
-                FMT_E3M2: if (SUPPORT_MXFP6) begin
-                    sign_out = data[5];
-                    bias_out = 3;
-                    if (is_bm && SUPPORT_MX_PLUS) begin
-                        tmp_exp = 5; // 7 - 2 (mantissa shift compensation)
-                        mant_out = {2'b0, 1'b1, data[4:0]};
-                        zero_out = 1'b0;
-                    end else begin
-                        tmp_exp = (data[4:2] == 3'd0) ? 1 : {5'd0, data[4:2]};
-                        mant_out = {4'b0, (data[4:2] != 3'd0), data[1:0], 1'b0};
-                        zero_out = (data[4:0] == 5'd0);
-                    end
-                end
-                FMT_E2M3: if (SUPPORT_MXFP6) begin
-                    sign_out = data[5];
-                    bias_out = 1;
-                    if (is_bm && SUPPORT_MX_PLUS) begin
-                        tmp_exp = 1; // 3 - 2 (mantissa shift compensation)
-                        mant_out = {2'b0, 1'b1, data[4:0]};
-                        zero_out = 1'b0;
-                    end else begin
-                        tmp_exp = (data[4:3] == 2'd0) ? 1 : {6'd0, data[4:3]};
-                        mant_out = {4'b0, (data[4:3] != 2'd0), data[2:0]};
-                        zero_out = (data[4:0] == 5'd0);
-                    end
-                end
-                FMT_E2M1: if (SUPPORT_MXFP4) begin
-                    sign_out = data[3];
-                    bias_out = 1;
-                    if (is_bm && SUPPORT_MX_PLUS) begin
-                        tmp_exp = 3; // No compensation needed (shift 0)
-                        mant_out = {4'b0, 1'b1, data[2:0]};
-                        zero_out = 1'b0;
-                    end else begin
-                        tmp_exp = (data[2:1] == 2'd0) ? 1 : {6'd0, data[2:1]};
-                        mant_out = {4'b0, (data[2:1] != 2'd0), data[0], 2'b0};
-                        zero_out = (data[2:0] == 3'd0);
-                    end
-                end
-                FMT_INT8: if (SUPPORT_INT8) begin
-                    // 8-bit Integer treatment.
-                    sign_out = data[7];
-                    mant_out = data[7] ? -data : data;
-                    tmp_exp = 0;
-                    bias_out = 3;
-                    zero_out = (data == 8'd0);
-                    is_int_out = 1'b1;
-                end
-                FMT_INT8_SYM: if (SUPPORT_INT8) begin
-                    sign_out = data[7];
-                    mant_out = (data == 8'h80) ? 8'd127 : (data[7] ? -data : data);
-                    tmp_exp = 0;
-                    bias_out = 3;
-                    zero_out = (data == 8'd0);
-                    is_int_out = 1'b1;
-                end
-                default: begin
-                    // Default to E4M3-like structure for unknown formats.
-                    sign_out = data[7];
-                    tmp_exp = (data[6:3] == 4'd0) ? 1 : {4'd0, data[6:3]};
-                    mant_out = {4'b0, (data[6:3] != 4'd0), data[2:0]};
-                    bias_out = 7;
-                    zero_out = (data[6:0] == 7'd0);
-                end
-            endcase
-            exp_out = tmp_exp[INTERNAL_EXP_WIDTH-1:0];
-        end
-    endtask
+    fp8_decoder #(
+        .SUPPORT_E4M3(SUPPORT_E4M3),
+        .SUPPORT_E5M2(SUPPORT_E5M2),
+        .SUPPORT_MXFP6(SUPPORT_MXFP6),
+        .SUPPORT_MXFP4(SUPPORT_MXFP4),
+        .SUPPORT_INT8(SUPPORT_INT8),
+        .SUPPORT_MX_PLUS(SUPPORT_MX_PLUS),
+        .INTERNAL_EXP_WIDTH(INTERNAL_EXP_WIDTH),
+        .INTERNAL_BIAS_WIDTH(INTERNAL_BIAS_WIDTH)
+    ) decoder_b (
+        .data(b),
+        .fmt(SUPPORT_MIXED_PRECISION ? format_b : format_a),
+        .is_bm(is_bm_b),
+        .sign_out(sign_b),
+        .exp_out(eb),
+        .mant_out(mb),
+        .bias_out(bias_b),
+        .zero_out(zero_b),
+        .nan_out(nan_b),
+        .inf_out(inf_b),
+        .is_int_out(is_intb)
+    );
 
     always @(*) begin
         // Initialize to avoid hardware latches.
@@ -228,17 +132,6 @@ module fp8_mul_lns #(
         nan_res = 1'b0;
         inf_res = 1'b0;
         m_sum = 4'd0;
-
-        // Decode operands.
-        decode_operand(a, format_a, is_bm_a, sign_a, ea, ma, bias_a, zero_a, nan_a, inf_a, is_inta);
-
-        // Operand B Decoding
-        if (SUPPORT_MIXED_PRECISION) begin
-            decode_operand(b, format_b, is_bm_b, sign_b, eb, mb, bias_b, zero_b, nan_b, inf_b, is_intb);
-        end else begin
-            // Use format_a for both operands to allow hardware sharing
-            decode_operand(b, format_a, is_bm_b, sign_b, eb, mb, bias_b, zero_b, nan_b, inf_b, is_intb);
-        end
 
         // Multiplication Logic Selection.
         if (lns_mode == 2'b00) begin

--- a/src/fp8_mul_lns.v
+++ b/src/fp8_mul_lns.v
@@ -4,8 +4,6 @@
 
 // This file implements an FP8 multiplier using Logarithmic Number System (LNS).
 // It replaces the 4x4/8x8 multiplier with a simple adder or LUT.
-`include "fp8_defs.vh"
-`include "fp8_decoder.v"
 
 /**
  * FP8 Multiplier Module (Logarithmic Number System - LNS)

--- a/src/fp8_mul_lns.v
+++ b/src/fp8_mul_lns.v
@@ -4,6 +4,8 @@
 
 // This file implements an FP8 multiplier using Logarithmic Number System (LNS).
 // It replaces the 4x4/8x8 multiplier with a simple adder or LUT.
+`include "fp8_defs.vh"
+`include "fp8_decoder.v"
 
 /**
  * FP8 Multiplier Module (Logarithmic Number System - LNS)

--- a/src/fp8_mul_lns.v
+++ b/src/fp8_mul_lns.v
@@ -5,7 +5,6 @@
 // This file implements an FP8 multiplier using Logarithmic Number System (LNS).
 // It replaces the 4x4/8x8 multiplier with a simple adder or LUT.
 `include "fp8_defs.vh"
-`include "fp8_decoder.v"
 
 /**
  * FP8 Multiplier Module (Logarithmic Number System - LNS)

--- a/src/fp8_mul_serial_lns.v
+++ b/src/fp8_mul_serial_lns.v
@@ -1,3 +1,5 @@
+`ifndef __FP8_MUL_SERIAL_LNS_V__
+`define __FP8_MUL_SERIAL_LNS_V__
 `default_nettype none
 `include "fp8_defs.vh"
 
@@ -215,3 +217,4 @@ module fp8_mul_serial_lns #(
                          (b_is_nan_inf && format_b == `FMT_E5M2 && !b_m_any_nonzero);
 
 endmodule
+`endif

--- a/src/fp8_mul_serial_lns.v
+++ b/src/fp8_mul_serial_lns.v
@@ -1,4 +1,5 @@
 `default_nettype none
+`include "fp8_defs.vh"
 
 // Bit-Serial LNS Multiplier Core (Mitchell Approximation)
 // Processes Log(A) + Log(B) - Bias bit-by-bit.
@@ -48,11 +49,11 @@ module fp8_mul_serial_lns #(
     function automatic [3:0] get_m_width(input [2:0] fmt);
         begin
             case (fmt)
-                3'b000: get_m_width = 4'd3; // E4M3
-                3'b001: get_m_width = 4'd2; // E5M2
-                3'b010: get_m_width = 4'd2; // E3M2
-                3'b011: get_m_width = 4'd3; // E2M3
-                3'b100: get_m_width = 4'd1; // E2M1
+                `FMT_E4M3: get_m_width = 4'd3; // E4M3
+                `FMT_E5M2: get_m_width = 4'd2; // E5M2
+                `FMT_E3M2: get_m_width = 4'd2; // E3M2
+                `FMT_E2M3: get_m_width = 4'd3; // E2M3
+                `FMT_E2M1: get_m_width = 4'd1; // E2M1
                 default: get_m_width = 4'd3;
             endcase
         end
@@ -61,9 +62,9 @@ module fp8_mul_serial_lns #(
     function automatic [3:0] get_sign_pos(input [2:0] fmt);
         begin
             case (fmt)
-                3'b000, 3'b001: get_sign_pos = 4'd7;
-                3'b010, 3'b011: get_sign_pos = 4'd5;
-                3'b100:         get_sign_pos = 4'd3;
+                `FMT_E4M3, `FMT_E5M2: get_sign_pos = 4'd7;
+                `FMT_E3M2, `FMT_E2M3: get_sign_pos = 4'd5;
+                `FMT_E2M1:         get_sign_pos = 4'd3;
                 default:        get_sign_pos = 4'd7;
             endcase
         end
@@ -72,11 +73,11 @@ module fp8_mul_serial_lns #(
     function automatic [7:0] get_bias(input [2:0] fmt);
         begin
             case (fmt)
-                3'b000: get_bias = 8'd7;
-                3'b001: get_bias = 8'd15;
-                3'b010: get_bias = 8'd3;
-                3'b011: get_bias = 8'd1;
-                3'b100: get_bias = 8'd1;
+                `FMT_E4M3: get_bias = 8'd7;
+                `FMT_E5M2: get_bias = 8'd15;
+                `FMT_E3M2: get_bias = 8'd3;
+                `FMT_E2M3: get_bias = 8'd1;
+                `FMT_E2M1: get_bias = 8'd1;
                 default: get_bias = 8'd7;
             endcase
         end
@@ -205,12 +206,12 @@ module fp8_mul_serial_lns #(
     assign special_zero = !a_any_nonzero || !b_any_nonzero;
 
     // Detect if operands are special values (NaN or Infinity).
-    wire a_is_nan_inf = ( (format_a == 3'b001 && a_e_all_ones) || (format_a == 3'b000 && a_e_all_ones && a_m_any_nonzero) );
-    wire b_is_nan_inf = ( (format_b == 3'b001 && b_e_all_ones) || (format_b == 3'b000 && b_e_all_ones && b_m_any_nonzero) );
+    wire a_is_nan_inf = ( (format_a == `FMT_E5M2 && a_e_all_ones) || (format_a == `FMT_E4M3 && a_e_all_ones && a_m_any_nonzero) );
+    wire b_is_nan_inf = ( (format_b == `FMT_E5M2 && b_e_all_ones) || (format_b == `FMT_E4M3 && b_e_all_ones && b_m_any_nonzero) );
 
-    assign special_nan = (a_is_nan_inf && (format_a != 3'b001 || a_m_any_nonzero)) ||
-                         (b_is_nan_inf && (format_b != 3'b001 || b_m_any_nonzero));
-    assign special_inf = (a_is_nan_inf && format_a == 3'b001 && !a_m_any_nonzero) ||
-                         (b_is_nan_inf && format_b == 3'b001 && !b_m_any_nonzero);
+    assign special_nan = (a_is_nan_inf && (format_a != `FMT_E5M2 || a_m_any_nonzero)) ||
+                         (b_is_nan_inf && (format_b != `FMT_E5M2 || b_m_any_nonzero));
+    assign special_inf = (a_is_nan_inf && format_a == `FMT_E5M2 && !a_m_any_nonzero) ||
+                         (b_is_nan_inf && format_b == `FMT_E5M2 && !b_m_any_nonzero);
 
 endmodule

--- a/src/project.v
+++ b/src/project.v
@@ -13,11 +13,6 @@
  */
 
 `include "fp8_defs.vh"
-`include "fp8_decoder.v"
-`include "fp8_mul.v"
-`include "fp8_mul_lns.v"
-`include "fp8_aligner.v"
-`include "accumulator.v"
 
 /* verilator lint_off DECLFILENAME */
 /* verilator lint_off MODDUP */

--- a/src/project.v
+++ b/src/project.v
@@ -1,3 +1,5 @@
+`ifndef __PROJECT_V__
+`define __PROJECT_V__
 `default_nettype none
 
 /**
@@ -971,3 +973,4 @@ module tt_um_chatelao_fp8_multiplier #(
 `endif
 
 endmodule
+`endif

--- a/src/project.v
+++ b/src/project.v
@@ -12,6 +12,8 @@
  * (ui_in, uo_out, uio_in, uio_out, uio_oe, ena, clk, rst_n).
  */
 
+`include "fp8_defs.vh"
+`include "fp8_decoder.v"
 `include "fp8_mul.v"
 `include "fp8_mul_lns.v"
 `include "fp8_aligner.v"

--- a/test/Makefile
+++ b/test/Makefile
@@ -46,4 +46,4 @@ include $(shell cocotb-config --makefiles)/Makefile.sim
 
 # Verilator linting:
 lint:
-	cd $(SRC_DIR) && verilator --lint-only -Wall project.v --top-module tt_um_chatelao_fp8_multiplier
+	cd $(SRC_DIR) && verilator --lint-only -Wall *.v --top-module tt_um_chatelao_fp8_multiplier

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,7 +6,7 @@ SIM ?= icarus
 FST ?= -fst # Use more efficient FST format
 TOPLEVEL_LANG ?= verilog
 SRC_DIR = ../src
-PROJECT_SOURCES = project.v
+PROJECT_SOURCES = project.v fp8_decoder.v
 
 ifeq ($(GATES),yes)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,7 +6,7 @@ SIM ?= icarus
 FST ?= -fst # Use more efficient FST format
 TOPLEVEL_LANG ?= verilog
 SRC_DIR = ../src
-PROJECT_SOURCES = project.v
+PROJECT_SOURCES = project.v fp8_mul.v fp8_mul_lns.v fp8_decoder.v fp8_aligner.v accumulator.v
 
 ifeq ($(GATES),yes)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,7 +6,7 @@ SIM ?= icarus
 FST ?= -fst # Use more efficient FST format
 TOPLEVEL_LANG ?= verilog
 SRC_DIR = ../src
-PROJECT_SOURCES = project.v fp8_decoder.v
+PROJECT_SOURCES = project.v
 
 ifeq ($(GATES),yes)
 

--- a/test/gate_analysis.py
+++ b/test/gate_analysis.py
@@ -7,14 +7,8 @@ def get_yosys_stats(params, top_module="tt_um_chatelao_fp8_multiplier", source_f
     for k, v in params.items():
         param_str += f"chparam -set {k} {v} {top_module}; "
 
-    # For modular analysis, we need to read the dependencies first
-    # However, since we list all files in info.yaml, we should probably read them all here too
-    # or at least the ones required by the module being analyzed.
-    if top_module == "tt_um_chatelao_fp8_multiplier":
-        read_cmd = "read_verilog -Isrc src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_decoder.v src/fp8_aligner.v src/accumulator.v;"
-    else:
-        # Assume module-level analysis needs the decoder
-        read_cmd = f"read_verilog -Isrc src/fp8_decoder.v {source_file};"
+    # Read all source files to ensure sub-modules are found during synthesis.
+    read_cmd = "read_verilog -Isrc src/*.v;"
 
     cmd = f"yosys -p \"{read_cmd} {param_str} synth -top {top_module}; stat\""
     result = subprocess.run(cmd, shell=True, capture_output=True, text=True)

--- a/test/gate_analysis.py
+++ b/test/gate_analysis.py
@@ -140,11 +140,17 @@ def main():
     mul_params = {f: 1 for f in mul_features}
     mul_params["SUPPORT_MX_PLUS"] = 0
     mul_baseline_gates = get_yosys_stats(mul_params, top_module="fp8_mul", source_file="src/fp8_mul.v")
-    print(f"{'fp8_mul (Baseline)':<30} | {mul_baseline_gates:<10} | 0")
+    if mul_baseline_gates is not None:
+        print(f"{'fp8_mul (Baseline)':<30} | {mul_baseline_gates:<10} | 0")
+    else:
+        print(f"{'fp8_mul (Baseline)':<30} | {'FAILED':<10} | N/A")
 
     mul_params["SUPPORT_MX_PLUS"] = 1
     mul_mx_plus_gates = get_yosys_stats(mul_params, top_module="fp8_mul", source_file="src/fp8_mul.v")
-    print(f"{'fp8_mul (With MX+)':<30} | {mul_mx_plus_gates:<10} | {mul_mx_plus_gates - mul_baseline_gates}")
+    if mul_mx_plus_gates is not None and mul_baseline_gates is not None:
+        print(f"{'fp8_mul (With MX+)':<30} | {mul_mx_plus_gates:<10} | {mul_mx_plus_gates - mul_baseline_gates}")
+    else:
+        print(f"{'fp8_mul (With MX+)':<30} | {'FAILED':<10} | N/A")
 
 if __name__ == "__main__":
     main()

--- a/test/gate_analysis.py
+++ b/test/gate_analysis.py
@@ -7,7 +7,16 @@ def get_yosys_stats(params, top_module="tt_um_chatelao_fp8_multiplier", source_f
     for k, v in params.items():
         param_str += f"chparam -set {k} {v} {top_module}; "
 
-    cmd = f"yosys -p \"read_verilog -Isrc {source_file}; {param_str} synth -top {top_module}; stat\""
+    # For modular analysis, we need to read the dependencies first
+    # However, since we list all files in info.yaml, we should probably read them all here too
+    # or at least the ones required by the module being analyzed.
+    if top_module == "tt_um_chatelao_fp8_multiplier":
+        read_cmd = "read_verilog -Isrc src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_decoder.v src/fp8_aligner.v src/accumulator.v;"
+    else:
+        # Assume module-level analysis needs the decoder
+        read_cmd = f"read_verilog -Isrc src/fp8_decoder.v {source_file};"
+
+    cmd = f"yosys -p \"{read_cmd} {param_str} synth -top {top_module}; stat\""
     result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
 
     # Extract total number of cells from the last "design hierarchy" section


### PR DESCRIPTION
- Centralized OCP MX format selection indices in `src/fp8_defs.vh`.
- Extracted operand decoding logic into a new reusable module `src/fp8_decoder.v`.
- Refactored `fp8_mul.v` and `fp8_mul_lns.v` to instantiate `fp8_decoder`, reducing code duplication and improving consistency.
- Updated `fp8_mul_serial_lns.v` to use centralized format definitions.
- Updated `info.yaml` and `test/Makefile` to include the new source files.
- Improved code documentation and organization.

Fixes #606

---
*PR created automatically by Jules for task [15549733663173983367](https://jules.google.com/task/15549733663173983367) started by @chatelao*