### PR TITLE
Swap UART RX/TX pins 18 and 19

### DIFF
--- a/src_gowin/tangnano4k_m3.cst
+++ b/src_gowin/tangnano4k_m3.cst
@@ -4,9 +4,9 @@ IO_LOC "ext_rst_n" 15;
 IO_PORT "ext_rst_n" PULL_MODE=UP;
 
 // UART0 Mapped through fabric to on-board BL616/CH552 bridge
-IO_LOC "uart_tx" 18;
+IO_LOC "uart_tx" 19;
 IO_PORT "uart_tx" PULL_MODE=UP IO_TYPE=LVCMOS33;
-IO_LOC "uart_rx" 19;
+IO_LOC "uart_rx" 18;
 IO_PORT "uart_rx" PULL_MODE=UP IO_TYPE=LVCMOS33;
 
 // MAC output monitoring pins (optional, for logic analyzer)

--- a/src_gowin/tt_gowin_top_m3.v
+++ b/src_gowin/tt_gowin_top_m3.v
@@ -24,8 +24,8 @@ module tt_gowin_top_m3 #(
     input  wire       ext_clk,   // External 20MHz crystal
     input  wire       ext_rst_n, // S1 button
     output wire [7:0] uo_out,    // Physical pins for logic analyzer
-    output wire       uart_tx,   // Pin 18
-    input  wire       uart_rx    // Pin 19
+    output wire       uart_tx,   // Pin 19
+    input  wire       uart_rx    // Pin 18
 );
 
     // M3 Peripheral Buses

--- a/src_m3/TANG_NANO_M3_TESTBENCH.md
+++ b/src_m3/TANG_NANO_M3_TESTBENCH.md
@@ -28,8 +28,8 @@ If you prefer to use an external serial adapter (e.g., FT232R, CP2102), connect 
 
 | Tang Nano 4K Pin | Signal | External Adapter Pin |
 |:---:|:---:|:---:|
-| **18** | `uart_tx` | RXD |
-| **19** | `uart_rx` | TXD |
+| **18** | `uart_rx` | TXD |
+| **19** | `uart_tx` | RXD |
 | **GND** | Ground | GND |
 
 *Note: Ensure your adapter is set to **3.3V logic levels**. Connecting a 5V adapter may damage the FPGA.*


### PR DESCRIPTION
I have swapped the UART RX and TX pins (18 and 19) for the Tang Nano 4K M3 testbench. The change includes updating the physical constraints file, the top-level Verilog comments, and the documentation to ensure consistency across the project.

Fixes #615

---
*PR created automatically by Jules for task [9654884761876297060](https://jules.google.com/task/9654884761876297060) started by @chatelao*