### PR TITLE
Improve CI workflow robustness and failure detection

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,13 +47,24 @@ jobs:
             export COMPILE_ARGS="-P tb.SUPPORT_SERIAL=1 -P tb.SERIAL_K_FACTOR=8"
           fi
           make
-          # make will return success even if the test fails, so check for failure in the results.xml
-          ! grep failure results.xml
+          # make will return success even if the test fails, so check for results.xml
+          if [ ! -f results.xml ]; then
+            echo "Error: results.xml not found. Simulation may have failed to run."
+            exit 1
+          fi
+          if grep -q failure results.xml; then
+            echo "Test failed: $(grep failure results.xml)"
+            exit 1
+          fi
 
       - name: Convert FST to VCD
         if: always()
         run: |
-          fst2vcd -f test/tb.fst -o test/tb.vcd
+          if [ -f test/tb.fst ]; then
+            fst2vcd -f test/tb.fst -o test/tb.vcd
+          else
+            echo "Warning: test/tb.fst not found. Skipping waveform conversion."
+          fi
 
       - name: Test Summary
         uses: test-summary/action@v2.4

--- a/run_all_configs.sh
+++ b/run_all_configs.sh
@@ -13,8 +13,10 @@ for config in Full Lite Tiny Ultra-Tiny Tiny-Serial; do
   elif [ "$config" == "Tiny-Serial" ]; then
     export COMPILE_ARGS="-P tb.SUPPORT_SERIAL=1 -P tb.SERIAL_K_FACTOR=8"
   fi
-  make > /dev/null 2>&1
-  if grep -q failure results.xml; then
+  make
+  if [ ! -f results.xml ]; then
+    echo "Error: $config results.xml not found. Simulation may have failed to run."
+  elif grep -q failure results.xml; then
     echo "$config FAILED in results.xml"
     grep failure results.xml
   else


### PR DESCRIPTION
This PR improves the robustness of the CI/CD pipeline and the local configuration runner by ensuring that simulation failures (like crashes or compilation errors) are correctly detected even if a `results.xml` file is not generated. It also prevents secondary failures in the workflow during waveform conversion if the simulation did not produce a trace file.

Fixes #617

---
*PR created automatically by Jules for task [17510329726600284856](https://jules.google.com/task/17510329726600284856) started by @chatelao*