### PR TITLE
Fix M3 integration for Tang Nano 4K (16-bit GPIO Mux)

### DIFF
--- a/src_gowin/gowin_empu_m3_stub.v
+++ b/src_gowin/gowin_empu_m3_stub.v
@@ -1,0 +1,60 @@
+`default_nettype none
+
+// Gowin EMPU (Cortex-M3) Hard IP Primitive
+module EMCU (
+    input  wire [15:0] ADDR,
+    input  wire [31:0] DATAIN,
+    output wire [31:0] DATAOUT,
+    input  wire        WRITE,
+    input  wire        READ,
+    input  wire        CLK,
+    input  wire        RESETN,
+    output wire        UART0_TXD,
+    input  wire        UART0_RXD,
+    inout  wire [15:0] GPIO
+);
+endmodule
+
+// Wrapper to match the expected interface in tt_gowin_top_m3.v
+module Gowin_EMPU_M3 (
+    input  wire        CLK,
+    input  wire        RESETN,
+    output wire        UART0_TXD,
+    input  wire        UART0_RXD,
+    inout  wire [31:0] GPIO0_IO,
+    input  wire [31:0] GPIO0_I,
+    output wire [31:0] GPIO0_O,
+    input  wire [31:0] GPIO0_OE
+);
+
+    wire [15:0] m3_gpio_bus;
+
+    // Instantiate the hard-core primitive
+    EMCU emcu_inst (
+        .ADDR(16'b0),      // Unused AHB/APB expansion
+        .DATAIN(32'b0),
+        .DATAOUT(),
+        .WRITE(1'b0),
+        .READ(1'b0),
+        .CLK(CLK),
+        .RESETN(RESETN),
+        .UART0_TXD(UART0_TXD),
+        .UART0_RXD(UART0_RXD),
+        .GPIO(m3_gpio_bus)
+    );
+
+    // Map the 16-bit inout GPIO to the 32-bit split interface
+    genvar i;
+    generate
+        for (i = 0; i < 16; i = i + 1) begin : gpio_gen
+            assign m3_gpio_bus[i] = GPIO0_OE[i] ? GPIO0_O[i] : 1'bz;
+            // The split input GPIO0_I is what the M3 "sees"
+            // Since we don't have a real model here, we just loop back for the stub's sake
+            // but tt_gowin_top_m3.v will drive GPIO0_I from the fabric.
+        end
+    endgenerate
+
+    // For the remaining 16-31 bits, they are physically absent in the 4C's EMCU
+    // We leave them disconnected in the stub.
+
+endmodule

--- a/src_gowin/tt_gowin_top_m3.v
+++ b/src_gowin/tt_gowin_top_m3.v
@@ -34,27 +34,52 @@ module tt_gowin_top_m3 #(
     wire [31:0] m3_gpio_oe;
 
     // MAC Unit Signals (Internal)
-    wire [7:0] ui_in;
+    reg  [7:0] ui_in;
+    reg  [7:0] uio_in;
     wire [7:0] uo_out_mac;
-    wire [7:0] uio_in;
     wire [7:0] uio_out;
     wire [7:0] uio_oe;
     wire       mac_clk;
     wire       mac_rst_n;
     wire       mac_ena;
 
-    // GPIO Mapping from M3 to MAC
-    // Output from M3 (GPIO[18:0])
-    assign ui_in     = m3_gpio_o[7:0];
-    assign uio_in    = m3_gpio_o[15:8];
-    assign mac_clk   = m3_gpio_o[16];
-    assign mac_rst_n = m3_gpio_o[17];
-    assign mac_ena   = m3_gpio_o[18];
+    // Multiplexed Control Signals (Bits [15:8])
+    assign mac_clk   = m3_gpio_o[8];
+    assign mac_rst_n = m3_gpio_o[9];
+    assign mac_ena   = m3_gpio_o[10];
+    wire ui_latch    = m3_gpio_o[11];
+    wire uio_latch   = m3_gpio_o[12];
+    wire read_en     = m3_gpio_o[13];
+    wire [1:0] read_sel = m3_gpio_o[15:14];
 
-    // Input to M3 (GPIO[26:19])
-    assign m3_gpio_i[26:19] = uo_out_mac;
-    assign m3_gpio_i[18:0]  = 19'b0; // Inputs for M3 outputs are tied to 0
-    assign m3_gpio_i[31:27] = 5'b0;
+    // Latch Logic for ui_in and uio_in
+    always @(posedge ui_latch or negedge mac_rst_n) begin
+        if (!mac_rst_n) ui_in <= 8'b0;
+        else ui_in <= m3_gpio_o[7:0];
+    end
+
+    always @(posedge uio_latch or negedge mac_rst_n) begin
+        if (!mac_rst_n) uio_in <= 8'b0;
+        else uio_in <= m3_gpio_o[7:0];
+    end
+
+    // Read-back Multiplexer (Shared Bus Bits [7:0])
+    reg [7:0] read_data;
+    always @(*) begin
+        case (read_sel)
+            2'b00: read_data = uo_out_mac;
+            2'b01: read_data = uio_out;
+            2'b10: read_data = uio_oe;
+            2'b11: read_data = ui_in; // Echo for verification
+        endcase
+    end
+
+    // Input to M3 (GPIO[15:0])
+    // The first 8 bits are the read-back data if enabled
+    assign m3_gpio_i[7:0]   = read_en ? read_data : 8'b0;
+    // The rest of the signals are echoed back for debug
+    assign m3_gpio_i[15:8]  = m3_gpio_o[15:8];
+    assign m3_gpio_i[31:16] = 16'b0;
 
     // Output to physical pins for monitoring
     assign uo_out = uo_out_mac;

--- a/src_m3/TANG_NANO_M3_TESTBENCH.md
+++ b/src_m3/TANG_NANO_M3_TESTBENCH.md
@@ -47,17 +47,19 @@ To use the M3, you must instantiate the **Gowin_EMPU_M3** IP core in your projec
    - Enable `GPIO0` (at least 20 bits: 8 for `ui_in`, 8 for `uio_in`, and control signals).
 3. **Memory**: Configure internal SRAM for instruction/data storage (typically 16KB+).
 
-### Fabric Connections
-Map the M3 signals to the MAC Unit top-level (`tt_um_chatelao_fp8_multiplier`):
+### Fabric Connections (Multiplexed 16-bit Interface)
+Map the M3 signals (GPIO[15:0]) to the MAC Unit through the `tt_gowin_top_m3.v` wrapper:
 
-| M3 Signal | MAC Unit Signal | Description |
-|-----------|-----------------|-------------|
-| `GPIO[7:0]` | `ui_in[7:0]` | Data / Scale A |
-| `GPIO[15:8]` | `uio_in[7:0]` | Data / Scale B |
-| `GPIO[16]` | `clk` | System Clock (Driven by M3) |
-| `GPIO[17]` | `rst_n` | Reset (Active Low) |
-| `GPIO[18]` | `ena` | Enable |
-| `uo_out[7:0]` | `GPIO[26:19]` | Result (Read by M3) |
+| M3 GPIO Bit | Signal Name | Direction (M3) | Description |
+|:---:|---|:---:|---|
+| **[7:0]** | `DATA_BUS` | Bidirectional | Multiplexed data for `ui_in`, `uio_in`, and read-back |
+| **8** | `mac_clk` | Output | MAC System Clock |
+| **9** | `mac_rst_n` | Output | Reset (Active Low) |
+| **10** | `mac_ena` | Output | Enable |
+| **11** | `ui_latch` | Output | Pulse to latch `ui_in` from `DATA_BUS` |
+| **12** | `uio_latch` | Output | Pulse to latch `uio_in` from `DATA_BUS` |
+| **13** | `read_en` | Output | Enable Fabric to drive `DATA_BUS` |
+| **[15:14]** | `read_sel` | Output | 0: `uo_out`, 1: `uio_out`, 2: `uio_oe`, 3: `ui_in` echo |
 
 ---
 

--- a/src_m3/main.c
+++ b/src_m3/main.c
@@ -13,12 +13,14 @@
 #define GPIO0_DIR   (*(volatile uint32_t *)(GPIO0_BASE + 0x04))
 
 // GPIO Bit Offsets (Fabric Mapping)
-#define BIT_UI_IN   0    // GPIO[7:0]   -> ui_in[7:0]
-#define BIT_UIO_IN  8    // GPIO[15:8]  -> uio_in[7:0]
-#define BIT_CLK     16   // GPIO[16]    -> clk
-#define BIT_RST     17   // GPIO[17]    -> rst_n (active low)
-#define BIT_ENA     18   // GPIO[18]    -> ena
-#define BIT_UO_OUT  19   // GPIO[26:19] <- uo_out[7:0] (Input to M3)
+#define BIT_DATA_BUS  0    // GPIO[7:0]   (Multiplexed Data/Scale)
+#define BIT_CLK       8    // GPIO[8]     -> clk
+#define BIT_RST       9    // GPIO[9]     -> rst_n (active low)
+#define BIT_ENA       10   // GPIO[10]    -> ena
+#define BIT_UI_LATCH  11   // GPIO[11]    -> Latch ui_in
+#define BIT_UIO_LATCH 12   // GPIO[12]    -> Latch uio_in
+#define BIT_READ_EN   13   // GPIO[13]    -> Enable Fabric Read-back
+#define BIT_READ_SEL  14   // GPIO[15:14] -> Read-back Selector
 
 void uart_putc(char c) {
     while (UART0_STATE & 0x01); // Wait if TX full
@@ -61,6 +63,47 @@ void clock_tick() {
     GPIO0_DATA &= ~(1 << BIT_CLK);
 }
 
+// MAC Protocol Helpers
+void mac_write_ui(uint8_t val) {
+    // Set data on bus
+    GPIO0_DATA = (GPIO0_DATA & ~0xFF) | val;
+    // Pulse latch
+    GPIO0_DATA |= (1 << BIT_UI_LATCH);
+    delay(2);
+    GPIO0_DATA &= ~(1 << BIT_UI_LATCH);
+}
+
+void mac_write_uio(uint8_t val) {
+    // Set data on bus
+    GPIO0_DATA = (GPIO0_DATA & ~0xFF) | val;
+    // Pulse latch
+    GPIO0_DATA |= (1 << BIT_UIO_LATCH);
+    delay(2);
+    GPIO0_DATA &= ~(1 << BIT_UIO_LATCH);
+}
+
+uint8_t mac_read_bus(uint8_t sel) {
+    uint8_t val;
+    // 1. Set Selector and Enable Read
+    uint32_t ctrl = GPIO0_DATA & ~(0x3 << BIT_READ_SEL);
+    ctrl |= (sel & 0x3) << BIT_READ_SEL;
+    ctrl |= (1 << BIT_READ_EN);
+    GPIO0_DATA = ctrl;
+
+    // 2. Switch Data Bus to Input
+    GPIO0_DIR &= ~0xFF;
+    delay(5);
+
+    // 3. Sample
+    val = GPIO0_DATA & 0xFF;
+
+    // 4. Restore Data Bus to Output
+    GPIO0_DATA &= ~(1 << BIT_READ_EN);
+    GPIO0_DIR |= 0xFF;
+
+    return val;
+}
+
 /**
  * Enhanced MAC Test Driver
  * @param meta_ui_base: ui_in[7:0] for Cycle 0 (excluding nbm_offset_a)
@@ -86,36 +129,41 @@ uint32_t run_mac_test_ext(uint8_t meta_ui_base, uint8_t meta_uio_base,
     clock_tick();
 
     // Cycle 0: IDLE / Metadata
-    GPIO0_DATA = (GPIO0_DATA & ~(0xFFFF << BIT_UI_IN)) | (cycle0_ui << BIT_UI_IN) | (cycle0_uio << BIT_UIO_IN);
+    mac_write_ui(cycle0_ui);
+    mac_write_uio(cycle0_uio);
     clock_tick();
 
     if (!(cycle0_ui & 0x80)) { // Standard Protocol
         // Cycle 1: Scale A, Format A, BM Index A
         uint8_t cycle1_uio = (bm_index_a << 3) | (format_a & 0x07);
-        GPIO0_DATA = (GPIO0_DATA & ~(0xFFFF << BIT_UI_IN)) | (scale_a << BIT_UI_IN) | (cycle1_uio << BIT_UIO_IN);
+        mac_write_ui(scale_a);
+        mac_write_uio(cycle1_uio);
         clock_tick();
 
         // Cycle 2: Scale B, Format B, BM Index B
         uint8_t cycle2_uio = (bm_index_b << 3) | (format_b & 0x07);
-        GPIO0_DATA = (GPIO0_DATA & ~(0xFFFF << BIT_UI_IN)) | (scale_b << BIT_UI_IN) | (cycle2_uio << BIT_UIO_IN);
+        mac_write_ui(scale_b);
+        mac_write_uio(cycle2_uio);
         clock_tick();
     }
 
     // Cycles 3-34: Stream elements
     // In Packed mode, we only stream 16 cycles, but the driver can send 32 without harm (FSM handles it)
     for (int i = 0; i < 32; i++) {
-        GPIO0_DATA = (GPIO0_DATA & ~(0xFFFF << BIT_UI_IN)) | (element_a << BIT_UI_IN) | (element_b << BIT_UIO_IN);
+        mac_write_ui(element_a);
+        mac_write_uio(element_b);
         clock_tick();
     }
 
     // Flush
-    GPIO0_DATA &= ~(0xFFFF << BIT_UI_IN);
+    mac_write_ui(0x00);
+    mac_write_uio(0x00);
     clock_tick();
     clock_tick();
 
-    // Read Result
+    // Read Result (4 bytes, MSB first)
     for (int i = 0; i < 4; i++) {
-        uint8_t byte = (GPIO0_DATA >> BIT_UO_OUT) & 0xFF;
+        uint8_t byte = mac_read_bus(0); // Select uo_out
         result = (result << 8) | byte;
         clock_tick();
     }
@@ -126,9 +174,10 @@ uint32_t run_mac_test_ext(uint8_t meta_ui_base, uint8_t meta_uio_base,
 int main() {
     UART0_BAUD = 174; // 20MHz / 115200
     UART0_CTRL = 0x03;
-    GPIO0_DIR = 0x0007FFFF;
+    // Bits [15:8] Output, [7:0] Output (Initial state)
+    GPIO0_DIR = 0x0000FF00 | 0x000000FF;
 
-    uart_puts("\r\n--- OCP MXFP8 MAC M3 Testbench (v1.3.0) ---\r\n");
+    uart_puts("\r\n--- OCP MXFP8 MAC M3 Testbench (v1.4.0-MUX) ---\r\n");
     uart_puts("Commands: [t] E4M3, [e] E5M2, [i] INT8, [y] INT8_SYM, [p] Packed, [m] MX+, [s] Short, [l] LNS, [v] Version\r\n");
 
     uint8_t current_lns_mode = 0;
@@ -182,7 +231,7 @@ int main() {
                 uart_puts("\r\n");
                 break;
             case 'v':
-                uart_puts("Firmware Version: 1.3.0-M3-MXFP8\r\n");
+                uart_puts("Firmware Version: 1.4.0-M3-MXFP8-MUX\r\n");
                 break;
             default:
                 uart_puts("Unknown CMD: "); uart_putc(cmd); uart_puts("\r\n");

--- a/test/verify_rtl_m3.py
+++ b/test/verify_rtl_m3.py
@@ -1,0 +1,69 @@
+import sys
+import os
+
+def verify_gowin_top_m3():
+    filepath = "src_gowin/tt_gowin_top_m3.v"
+    if not os.path.exists(filepath):
+        print(f"Error: {filepath} not found")
+        return False
+
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    expected_params = [
+        "parameter ALIGNER_WIDTH",
+        "parameter ACCUMULATOR_WIDTH",
+        "parameter SUPPORT_E5M2",
+        "parameter SUPPORT_MXFP6",
+        "parameter SUPPORT_MXFP4",
+        "parameter SUPPORT_INT8",
+        "parameter SUPPORT_PIPELINING",
+        "parameter SUPPORT_ADV_ROUNDING",
+        "parameter SUPPORT_MIXED_PRECISION",
+        "parameter SUPPORT_VECTOR_PACKING",
+        "parameter SUPPORT_PACKED_SERIAL",
+        "parameter SUPPORT_INPUT_BUFFERING",
+        "parameter SUPPORT_MX_PLUS",
+        "parameter SUPPORT_SERIAL",
+        "parameter SERIAL_K_FACTOR",
+        "parameter ENABLE_SHARED_SCALING",
+        "parameter USE_LNS_MUL",
+        "parameter USE_LNS_MUL_PRECISE"
+    ]
+
+    missing_params = []
+    for param in expected_params:
+        if param not in content:
+            missing_params.append(param)
+
+    if missing_params:
+        print(f"Error: Missing parameters in {filepath}: {', '.join(missing_params)}")
+        return False
+
+    if "tt_um_chatelao_fp8_multiplier #(" not in content:
+        print(f"Error: tt_um_chatelao_fp8_multiplier not instantiated with parameters in {filepath}")
+        return False
+
+    for param in expected_params:
+        param_name = param.split()[-1]
+        if f".{param_name}({param_name})" not in content:
+            print(f"Error: Parameter {param_name} not passed to instance in {filepath}")
+            return False
+
+    # Check for M3 instantiation and GPIO mapping
+    if "Gowin_EMPU_M3 m3_inst" not in content:
+        print(f"Error: Gowin_EMPU_M3 not instantiated in {filepath}")
+        return False
+
+    if "assign mac_clk   = m3_gpio_o[8];" not in content:
+        print(f"Error: M3 GPIO mapping for mac_clk is missing or incorrect in {filepath}")
+        return False
+
+    print(f"Verification of {filepath} successful: All parameters present and M3 integration verified.")
+    return True
+
+if __name__ == "__main__":
+    if verify_gowin_top_m3():
+        sys.exit(0)
+    else:
+        sys.exit(1)


### PR DESCRIPTION
The Tang Nano 4K (GW1NSR-4C) has a hardware limitation where only 16 GPIO wires are connected between the Cortex-M3 (EMCU) and the FPGA fabric. The original code tried to use more pins than available.

I implemented a multiplexed 16-bit interface that uses a shared 8-bit data bus with latch strobes for inputs (ui_in, uio_in) and a selector for read-back (uo_out, etc.). Both the Verilog top-level and the C firmware were updated to support this new protocol. I also provided an `EMCU` primitive stub to allow the design to be processed by open-source tools like Yosys.

Fixes #627

---
*PR created automatically by Jules for task [4497747610412155842](https://jules.google.com/task/4497747610412155842) started by @chatelao*