### PR TITLE
Correct M3 GPIO Bus Width to 16 Bits

### DIFF
--- a/src_gowin/tt_gowin_top_m3.v
+++ b/src_gowin/tt_gowin_top_m3.v
@@ -29,9 +29,9 @@ module tt_gowin_top_m3 #(
 );
 
     // M3 Peripheral Buses
-    wire [31:0] m3_gpio_o;
-    wire [31:0] m3_gpio_i;
-    wire [31:0] m3_gpio_oe;
+    wire [15:0] m3_gpio_o;
+    wire [15:0] m3_gpio_i;
+    wire [15:0] m3_gpio_oe;
 
     // MAC Unit Signals (Internal)
     wire [7:0] ui_in;
@@ -86,7 +86,7 @@ module tt_gowin_top_m3 #(
     end
 
     assign m3_gpio_i[7:0]   = m3_gpio_i_data;
-    assign m3_gpio_i[31:8]  = 24'b0;
+    assign m3_gpio_i[15:8]  = 8'b0;
 
     // Output to physical pins for monitoring
     assign uo_out = uo_out_mac;

--- a/src_m3/TANG_M3_ROADMAP.md
+++ b/src_m3/TANG_M3_ROADMAP.md
@@ -2,9 +2,9 @@
 
 1. [x] **Hardware Setup (Gowin EDA)**
     - [x] Instantiate `Gowin_EMPU_M3` IP core in the project (Implemented in `../src_gowin/tt_gowin_top_m3.v`).
-    - [x] Configure IP: Enable AHB/APB buses, UART0, and at least 20 bits for GPIO0 (Configured in Verilog mapping).
+    - [x] Configure IP: Enable AHB/APB buses, UART0, and 16 bits for GPIO0 (Configured in Verilog mapping).
     - [x] Allocate 16KB+ internal SRAM for instruction/data memory (Defined in `link.ld`).
-    - [x] Connect fabric signals: Map M3 GPIO[7:0] to `ui_in[7:0]`, GPIO[15:8] to `uio_in[7:0]`, GPIO[16] to `clk`, GPIO[17] to `rst_n`, GPIO[18] to `ena`, and MAC `uo_out[7:0]` to M3 GPIO[26:19].
+    - [x] Connect fabric signals: 16-bit multiplexed interface (GPIO[7:0] Data, GPIO[10:8] Addr, GPIO[11] Clk, GPIO[12] Rst, GPIO[13] Ena, GPIO[14] WEN).
 2. [x] **M3 Software Implementation**
     - [x] Define base addresses: UART0 (0x40000000) and GPIO0 (0x40010000) (Implemented in `main.c`).
     - [x] Implement low-level UART drivers (`uart_putc`, `uart_puts`, `uart_getc`).

--- a/test/verify_rtl_m3.py
+++ b/test/verify_rtl_m3.py
@@ -1,0 +1,76 @@
+import sys
+import os
+import re
+
+def verify_gowin_m3_top():
+    filepath = "src_gowin/tt_gowin_top_m3.v"
+    if not os.path.exists(filepath):
+        print(f"Error: {filepath} not found")
+        return False
+
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    # Verify bus widths
+    bus_patterns = [
+        (r"wire\s+\[15:0\]\s+m3_gpio_o;", "m3_gpio_o width should be [15:0]"),
+        (r"wire\s+\[15:0\]\s+m3_gpio_i;", "m3_gpio_i width should be [15:0]"),
+        (r"wire\s+\[15:0\]\s+m3_gpio_oe;", "m3_gpio_oe width should be [15:0]"),
+        (r"assign\s+m3_gpio_i\[15:8\]\s*=\s*8'b0;", "m3_gpio_i upper bits should be tied to 0")
+    ]
+
+    for pattern, error_msg in bus_patterns:
+        if not re.search(pattern, content):
+            print(f"Error: {error_msg} in {filepath}")
+            return False
+
+    # Verify parameter propagation (reusing from verify_rtl.py logic)
+    expected_params = [
+        "parameter ALIGNER_WIDTH",
+        "parameter ACCUMULATOR_WIDTH",
+        "parameter SUPPORT_E4M3",
+        "parameter SUPPORT_E5M2",
+        "parameter SUPPORT_MXFP6",
+        "parameter SUPPORT_MXFP4",
+        "parameter SUPPORT_INT8",
+        "parameter SUPPORT_PIPELINING",
+        "parameter SUPPORT_ADV_ROUNDING",
+        "parameter SUPPORT_MIXED_PRECISION",
+        "parameter SUPPORT_VECTOR_PACKING",
+        "parameter SUPPORT_PACKED_SERIAL",
+        "parameter SUPPORT_INPUT_BUFFERING",
+        "parameter SUPPORT_MX_PLUS",
+        "parameter SUPPORT_SERIAL",
+        "parameter SERIAL_K_FACTOR",
+        "parameter ENABLE_SHARED_SCALING",
+        "parameter USE_LNS_MUL",
+        "parameter USE_LNS_MUL_PRECISE"
+    ]
+
+    missing_params = []
+    for param in expected_params:
+        if param not in content:
+            missing_params.append(param)
+
+    if missing_params:
+        print(f"Error: Missing parameters in {filepath}: {', '.join(missing_params)}")
+        return False
+
+    if "tt_um_chatelao_fp8_multiplier #(" not in content:
+        print(f"Error: tt_um_chatelao_fp8_multiplier not instantiated with parameters in {filepath}")
+        return False
+
+    for param in expected_params:
+        param_name = param.split()[-1]
+        if f".{param_name}({param_name})" not in content:
+            print(f"Error: Parameter {param_name} not passed to instance in {filepath}")
+            return False
+
+    print(f"Verification of {filepath} successful: 16-bit buses and parameters verified.")
+    return True
+
+if __name__ == "__main__":
+    if verify_gowin_m3_top():
+        sys.exit(0)
+    else:
+        sys.exit(1)


### PR DESCRIPTION
This change corrects the M3 peripheral GPIO bus width in the Gowin top-level wrapper from 32 bits to 16 bits. This alignment is necessary because the physical Cortex-M3 (EMCU) primitive on the Gowin GW1NSR-4C only supports 16 GPIO pins. The previous 32-bit declaration was inconsistent with the 16-bit multiplexed protocol described in the documentation and implemented in the firmware. Corresponding documentation and verification scripts have been updated to ensure future consistency.

Fixes #634

---
*PR created automatically by Jules for task [12960180757983243085](https://jules.google.com/task/12960180757983243085) started by @chatelao*