### PR TITLE
Integrate PlantUML protocol state diagram into AHB2_INTEGRATION.md

### DIFF
--- a/AHB2_INTEGRATION.md
+++ b/AHB2_INTEGRATION.md
@@ -12,6 +12,10 @@ In diesem Modus fungiert die MAC-Einheit als passives Peripheriegerät am AHB-Bu
 
 ### Funktionsweise
 - Ein **AHB-to-MAC Bridge** Modul übersetzt AHB-Protokollphasen (`HSEL`, `HTRANS`, `HADDR`, `HWRITE`, `HWDATA`) in die Steuersignale der MAC-Einheit.
+
+![Protocol States Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/docs/diagrams/PROTOCOL_STATES.PUML)
+
+*Quelle: [docs/diagrams/PROTOCOL_STATES.PUML](docs/diagrams/PROTOCOL_STATES.PUML)*
 - **Pipeline-Unterstützung**: AHB nutzt getrennte Adress- und Datenphasen. Die Bridge muss die Adresse für einen Zyklus puffern, um sie mit der Datenphase zu korrelieren.
 - **Wait-States**: Die Bridge nutzt das `HREADY`-Signal, um den Bus-Master (M3) zu pausieren, falls die MAC-Einheit gerade das sequentielle Streaming-Protokoll abarbeitet.
 

--- a/docs/diagrams/PROTOCOL_STATES.PUML
+++ b/docs/diagrams/PROTOCOL_STATES.PUML
@@ -1,0 +1,40 @@
+@startuml PROTOCOL_STATES
+title OCP MXFP8 MAC Protocol State Machine
+
+[*] --> IDLE
+
+IDLE : Cycle 0
+IDLE : Capture Metadata
+IDLE : ui_in[7] ? Next=STREAM (C3) : Next=LOAD_SCALE (C1)
+
+IDLE --> LOAD_SCALE : Standard Start\n(ui_in[7]=0)
+IDLE --> STREAM : Short Protocol\n(ui_in[7]=1)
+
+LOAD_SCALE : Cycles 1-2
+LOAD_SCALE : C1: Scale A, Format A
+LOAD_SCALE : C2: Scale B, Format B
+LOAD_SCALE --> STREAM : Cycle 3
+
+state STREAM {
+    direction lr
+    STREAM_DATA : Cycles 3-34 (Std) / 3-18 (Pk)
+    STREAM_DATA : Element Streaming
+
+    STREAM_FLUSH : Cycle 35 (Std) / 19 (Pk)
+    STREAM_FLUSH : Pipeline Flush
+
+    STREAM_SCALE : Cycle 36 (Std) / 20 (Pk)
+    STREAM_SCALE : Shared Scaling
+
+    STREAM_DATA -> STREAM_FLUSH
+    STREAM_FLUSH -> STREAM_SCALE
+}
+
+STREAM --> OUTPUT : Cycle 37 (Std) / 21 (Pk)
+
+OUTPUT : Cycles 37-40 (Std) / 21-24 (Pk)
+OUTPUT : Serialized 32-bit Result
+OUTPUT : 8-bit per Cycle (MSB first)
+OUTPUT --> IDLE : Cycle 0
+
+@enduml


### PR DESCRIPTION
This PR adds a visual state diagram for the OCP MXFP8 MAC protocol to the AHB integration documentation.

Changes:
1. Created a new PlantUML source file `docs/diagrams/PROTOCOL_STATES.PUML` that describes the unit's FSM transitions (IDLE, LOAD_SCALE, STREAM, OUTPUT) including cycle counts for both Standard and Packed modes.
2. Modified `AHB2_INTEGRATION.md` to include this diagram, helping implementers understand the protocol timing required for the AHB-to-MAC bridge.

The diagram was verified against the actual RTL FSM logic in `src/project.v`.

Fixes #642

---
*PR created automatically by Jules for task [7070086662787271315](https://jules.google.com/task/7070086662787271315) started by @chatelao*