### PR TITLE
Add estimated footprint comparison to APB integration docs

### DIFF
--- a/APB_INTEGRATION.md
+++ b/APB_INTEGRATION.md
@@ -64,6 +64,7 @@ The APB Slave logic handles the handshake between the fast M3 bus clock and the 
 | **Max Clock Speed** | ~500 kHz (Software Ltd) | ~10 MHz (Hardware Ltd) | ~10 MHz (Write Path Ltd) |
 | **Code Size** | Large (Driver functions) | Small (Direct pointers) | Medium (Mixed access) |
 | **Bus Integrity** | Manual direction switching | Hardware-managed | Partial (Read bit-bang) |
+| **Footprint (Bridge)** | ~150 Gates (Mux/GPIO) | ~500 Gates (Full APB) | ~350 Gates (Write-only) |
 
 ## 7. Implementation Roadmap
 


### PR DESCRIPTION
Added a new row 'Footprint (Bridge)' to the comparison table in APB_INTEGRATION.md to provide estimated gate counts for GPIO, APB, and Hybrid integration methods based on architectural data from docs/hardware/DIE_SIZE_ANALYSIS.md.

Fixes #643

---
*PR created automatically by Jules for task [10644099476435196007](https://jules.google.com/task/10644099476435196007) started by @chatelao*