### PR TITLE
Add switch for GPIO/APB M3 integration and implement APB bridge

### DIFF
--- a/src_gowin/tt_gowin_top_m3.v
+++ b/src_gowin/tt_gowin_top_m3.v
@@ -19,7 +19,9 @@ module tt_gowin_top_m3 #(
     parameter SERIAL_K_FACTOR = 8,
     parameter ENABLE_SHARED_SCALING = 1,
     parameter USE_LNS_MUL = 0,
-    parameter USE_LNS_MUL_PRECISE = 0
+    parameter USE_LNS_MUL_PRECISE = 0,
+    parameter INTEGRATION_MODE = 0, // 0: GPIO, 1: APB
+    parameter APB_BASE_ADDR = 32'h40020000
 )(
     input  wire       ext_clk,   // External 20MHz crystal
     input  wire       ext_rst_n, // S1 button
@@ -32,6 +34,13 @@ module tt_gowin_top_m3 #(
     wire [15:0] m3_gpio_o;
     wire [15:0] m3_gpio_i;
     wire [15:0] m3_gpio_oe;
+
+    // M3 APB-like Peripheral Bus (EMCU specific)
+    wire [15:0] m3_addr;
+    wire [31:0] m3_data_out;
+    wire        m3_write;
+    wire        m3_read;
+    wire [31:0] m3_data_in;
 
     // MAC Unit Signals (Internal)
     wire [7:0] ui_in;
@@ -53,40 +62,112 @@ module tt_gowin_top_m3 #(
     // [14]   - write_strobe (WEN)
     // [15]   - Reserved
 
-    reg [7:0] ui_in_reg;
-    reg [7:0] uio_in_reg;
+    generate
+        if (INTEGRATION_MODE == 0) begin : gen_gpio_integration
+            // GPIO Mapping from M3 to MAC (16-bit Multiplexed Interface)
+            // M3 Output GPIO[15:0]:
+            // [7:0]  - Data
+            // [10:8] - Address (0:ui_in, 1:uio_in, 2:uo_out, 3:uio_out, 4:uio_oe)
+            // [11]   - mac_clk
+            // [12]   - mac_rst_n
+            // [13]   - mac_ena
+            // [14]   - write_strobe (WEN)
+            // [15]   - Reserved
 
-    always @(posedge ext_clk or negedge ext_rst_n) begin
-        if (!ext_rst_n) begin
-            ui_in_reg  <= 8'b0;
-            uio_in_reg <= 8'b0;
-        end else if (m3_gpio_o[14]) begin // write_strobe
-            case (m3_gpio_o[10:8])
-                3'd0: ui_in_reg  <= m3_gpio_o[7:0];
-                3'd1: uio_in_reg <= m3_gpio_o[7:0];
-            endcase
+            reg [7:0] ui_in_reg;
+            reg [7:0] uio_in_reg;
+
+            always @(posedge ext_clk or negedge ext_rst_n) begin
+                if (!ext_rst_n) begin
+                    ui_in_reg  <= 8'b0;
+                    uio_in_reg <= 8'b0;
+                end else if (m3_gpio_o[14]) begin // write_strobe
+                    case (m3_gpio_o[10:8])
+                        3'd0: ui_in_reg  <= m3_gpio_o[7:0];
+                        3'd1: uio_in_reg <= m3_gpio_o[7:0];
+                    endcase
+                end
+            end
+
+            assign ui_in     = ui_in_reg;
+            assign uio_in    = uio_in_reg;
+            assign mac_clk   = m3_gpio_o[11];
+            assign mac_rst_n = m3_gpio_o[12];
+            assign mac_ena   = m3_gpio_o[13];
+
+            // M3 Input GPIO[7:0]: Read data from MAC
+            reg [7:0] m3_gpio_i_data;
+            always @(*) begin
+                case (m3_gpio_o[10:8])
+                    3'd2:    m3_gpio_i_data = uo_out_mac;
+                    3'd3:    m3_gpio_i_data = uio_out;
+                    3'd4:    m3_gpio_i_data = uio_oe;
+                    default: m3_gpio_i_data = 8'h0;
+                endcase
+            end
+
+            assign m3_gpio_i[7:0]   = m3_gpio_i_data;
+            assign m3_gpio_i[15:8]  = 8'b0;
+            assign m3_data_in       = 32'h0;
+        end else begin : gen_apb_integration
+            // APB-to-MAC Bridge
+            // Register Map (Offset from APB_BASE_ADDR):
+            // 0x00: DATA_IN (W: [7:0] ui_in, [15:8] uio_in, triggers mac_clk pulse)
+            // 0x04: DATA_OUT (R: [7:0] uo_out_mac, [15:8] uio_out)
+            // 0x08: CTRL (RW: [0] mac_ena, [1] mac_rst_n)
+
+            reg [7:0] ui_in_reg;
+            reg [7:0] uio_in_reg;
+            reg       mac_ena_reg;
+            reg       mac_rst_n_reg;
+            reg       apb_mac_clk_reg;
+
+            always @(posedge ext_clk or negedge ext_rst_n) begin
+                if (!ext_rst_n) begin
+                    ui_in_reg       <= 8'b0;
+                    uio_in_reg      <= 8'b0;
+                    mac_ena_reg     <= 1'b0;
+                    mac_rst_n_reg   <= 1'b0;
+                    apb_mac_clk_reg <= 1'b0;
+                end else begin
+                    apb_mac_clk_reg <= 1'b0; // Default to 0, single pulse on write to DATA_IN
+                    if (m3_write) begin
+                        case (m3_addr[7:0])
+                            8'h00: begin
+                                ui_in_reg       <= m3_data_out[7:0];
+                                uio_in_reg      <= m3_data_out[15:8];
+                                apb_mac_clk_reg <= 1'b1;
+                            end
+                            8'h08: begin
+                                mac_ena_reg     <= m3_data_out[0];
+                                mac_rst_n_reg   <= m3_data_out[1];
+                            end
+                        endcase
+                    end
+                end
+            end
+
+            assign ui_in     = ui_in_reg;
+            assign uio_in    = uio_in_reg;
+            assign mac_clk   = apb_mac_clk_reg;
+            assign mac_rst_n = mac_rst_n_reg;
+            assign mac_ena   = mac_ena_reg;
+
+            reg [31:0] prdata_reg;
+            always @(*) begin
+                case (m3_addr[7:0])
+                    8'h00:   prdata_reg = {16'h0, uio_in_reg, ui_in_reg};
+                    8'h04:   prdata_reg = {16'h0, uio_out, uo_out_mac};
+                    8'h08:   prdata_reg = {30'h0, mac_rst_n_reg, mac_ena_reg};
+                    default: prdata_reg = 32'h0;
+                endcase
+            end
+            assign m3_data_in = prdata_reg;
+
+            // In APB mode, GPIOs are unused
+            assign m3_gpio_i = 16'h0;
         end
-    end
-
-    assign ui_in     = ui_in_reg;
-    assign uio_in    = uio_in_reg;
-    assign mac_clk   = m3_gpio_o[11];
-    assign mac_rst_n = m3_gpio_o[12];
-    assign mac_ena   = m3_gpio_o[13];
-
-    // M3 Input GPIO[7:0]: Read data from MAC
-    reg [7:0] m3_gpio_i_data;
-    always @(*) begin
-        case (m3_gpio_o[10:8])
-            3'd2:    m3_gpio_i_data = uo_out_mac;
-            3'd3:    m3_gpio_i_data = uio_out;
-            3'd4:    m3_gpio_i_data = uio_oe;
-            default: m3_gpio_i_data = 8'h0;
-        endcase
-    end
-
-    assign m3_gpio_i[7:0]   = m3_gpio_i_data;
-    assign m3_gpio_i[15:8]  = 8'b0;
+    endgenerate
 
     // Output to physical pins for monitoring
     assign uo_out = uo_out_mac;
@@ -101,7 +182,13 @@ module tt_gowin_top_m3 #(
         .GPIO0_IO      (), // Not using inout directly
         .GPIO0_I       (m3_gpio_i),
         .GPIO0_O       (m3_gpio_o),
-        .GPIO0_OE      (m3_gpio_oe)
+        .GPIO0_OE      (m3_gpio_oe),
+        // Peripheral Bus (EMCU specific)
+        .ADDR          (m3_addr),
+        .DATAOUT       (m3_data_out),
+        .WRITE         (m3_write),
+        .READ          (m3_read),
+        .DATAIN        (m3_data_in)
     );
 
     // Instantiate MAC Unit

--- a/test/verify_rtl_m3.py
+++ b/test/verify_rtl_m3.py
@@ -44,7 +44,9 @@ def verify_gowin_m3_top():
         "parameter SERIAL_K_FACTOR",
         "parameter ENABLE_SHARED_SCALING",
         "parameter USE_LNS_MUL",
-        "parameter USE_LNS_MUL_PRECISE"
+        "parameter USE_LNS_MUL_PRECISE",
+        "parameter INTEGRATION_MODE",
+        "parameter APB_BASE_ADDR"
     ]
 
     missing_params = []
@@ -56,11 +58,31 @@ def verify_gowin_m3_top():
         print(f"Error: Missing parameters in {filepath}: {', '.join(missing_params)}")
         return False
 
+    # Verify integration logic blocks
+    integration_patterns = [
+        (r"generate", "Missing generate block"),
+        (r"if\s*\(INTEGRATION_MODE\s*==\s*0\)\s*begin\s*:\s*gen_gpio_integration", "Missing gen_gpio_integration"),
+        (r"else\s*begin\s*:\s*gen_apb_integration", "Missing gen_apb_integration"),
+        (r"Gowin_EMPU_M3\s+m3_inst", "Gowin_EMPU_M3 instance not found"),
+        (r"\.ADDR\s*\(m3_addr\)", "ADDR port not connected in M3 instance"),
+        (r"\.DATAOUT\s*\(m3_data_out\)", "DATAOUT port not connected in M3 instance"),
+        (r"\.WRITE\s*\(m3_write\)", "WRITE port not connected in M3 instance"),
+        (r"\.READ\s*\(m3_read\)", "READ port not connected in M3 instance"),
+        (r"\.DATAIN\s*\(m3_data_in\)", "DATAIN port not connected in M3 instance")
+    ]
+
+    for pattern, error_msg in integration_patterns:
+        if not re.search(pattern, content):
+            print(f"Error: {error_msg} in {filepath}")
+            return False
+
     if "tt_um_chatelao_fp8_multiplier #(" not in content:
         print(f"Error: tt_um_chatelao_fp8_multiplier not instantiated with parameters in {filepath}")
         return False
 
-    for param in expected_params:
+    # Check for original parameters only (some are internal to tt_gowin_top_m3)
+    original_params = [p for p in expected_params if p not in ["parameter INTEGRATION_MODE", "parameter APB_BASE_ADDR"]]
+    for param in original_params:
         param_name = param.split()[-1]
         if f".{param_name}({param_name})" not in content:
             print(f"Error: Parameter {param_name} not passed to instance in {filepath}")


### PR DESCRIPTION
This change introduces a parameter-driven switch (INTEGRATION_MODE) in the tt_gowin_top_m3 module to toggle between the existing GPIO-based integration and a new memory-mapped APB-to-MAC bridge. The APB bridge is implemented using the Gowin EMCU primitive's specific peripheral bus ports and supports a register map for data transfer and control. The GPIO mode remains the default. Structural RTL verification has been updated and passed.

Fixes #648

---
*PR created automatically by Jules for task [6708777457837751577](https://jules.google.com/task/6708777457837751577) started by @chatelao*