### PR TITLE
Switch M3 Integration to Compile-Time Flags and Enhance CI Coverage

### DIFF
--- a/.github/workflows/gowin.yaml
+++ b/.github/workflows/gowin.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        variant: [Full, Lite, Tiny, Ultra-Tiny, Tiny-Serial]
+        variant: [Full, Lite, Tiny, Ultra-Tiny, Tiny-Serial, M3-GPIO, M3-APB, M3-AHB]
 
     permissions:
       contents: write
@@ -42,6 +42,12 @@ jobs:
 
       - name: Set parameters
         run: |
+          # Defaults
+          echo "TOP=tt_gowin_top" >> $GITHUB_ENV
+          echo "SOURCES=src/project.v src_gowin/tt_gowin_top.v" >> $GITHUB_ENV
+          echo "CST=src_gowin/tangnano4k.cst" >> $GITHUB_ENV
+          echo "YOSYS_FLAGS=" >> $GITHUB_ENV
+
           if [ "${{ matrix.variant }}" == "Full" ]; then
             echo "PARAMS=-set ALIGNER_WIDTH 40 -set ACCUMULATOR_WIDTH 32 -set SUPPORT_E4M3 1 -set SUPPORT_E5M2 1 -set SUPPORT_MXFP6 1 -set SUPPORT_MXFP4 1 -set SUPPORT_INT8 1 -set SUPPORT_PIPELINING 1 -set SUPPORT_ADV_ROUNDING 1 -set SUPPORT_MIXED_PRECISION 1 -set SUPPORT_VECTOR_PACKING 1 -set ENABLE_SHARED_SCALING 1 -set SUPPORT_MX_PLUS 1 -set SUPPORT_INPUT_BUFFERING 1 -set SUPPORT_SERIAL 0" >> $GITHUB_ENV
           elif [ "${{ matrix.variant }}" == "Lite" ]; then
@@ -52,14 +58,26 @@ jobs:
             echo "PARAMS=-set ALIGNER_WIDTH 32 -set ACCUMULATOR_WIDTH 24 -set SUPPORT_E4M3 1 -set SUPPORT_E5M2 0 -set SUPPORT_MXFP6 0 -set SUPPORT_MXFP4 0 -set SUPPORT_INT8 0 -set SUPPORT_PIPELINING 0 -set SUPPORT_ADV_ROUNDING 0 -set SUPPORT_MIXED_PRECISION 0 -set SUPPORT_VECTOR_PACKING 0 -set ENABLE_SHARED_SCALING 0 -set SUPPORT_MX_PLUS 0 -set SUPPORT_INPUT_BUFFERING 0 -set SUPPORT_SERIAL 0" >> $GITHUB_ENV
           elif [ "${{ matrix.variant }}" == "Tiny-Serial" ]; then
             echo "PARAMS=-set ALIGNER_WIDTH 32 -set ACCUMULATOR_WIDTH 24 -set SUPPORT_E4M3 0 -set SUPPORT_E5M2 0 -set SUPPORT_MXFP6 0 -set SUPPORT_MXFP4 1 -set SUPPORT_INT8 0 -set SUPPORT_PIPELINING 0 -set SUPPORT_ADV_ROUNDING 0 -set SUPPORT_MIXED_PRECISION 0 -set SUPPORT_VECTOR_PACKING 0 -set ENABLE_SHARED_SCALING 0 -set SUPPORT_MX_PLUS 0 -set SUPPORT_INPUT_BUFFERING 0 -set SUPPORT_SERIAL 1" >> $GITHUB_ENV
+          elif [[ "${{ matrix.variant }}" == M3-* ]]; then
+            echo "TOP=tt_gowin_top_m3" >> $GITHUB_ENV
+            echo "SOURCES=src/project.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v" >> $GITHUB_ENV
+            echo "CST=src_gowin/tangnano4k_m3.cst" >> $GITHUB_ENV
+            echo "PARAMS=-set ALIGNER_WIDTH 32 -set ACCUMULATOR_WIDTH 32 -set SUPPORT_E4M3 1 -set SUPPORT_E5M2 1" >> $GITHUB_ENV
+            if [ "${{ matrix.variant }}" == "M3-GPIO" ]; then
+              echo "YOSYS_FLAGS=-DM3_MODE_GPIO" >> $GITHUB_ENV
+            elif [ "${{ matrix.variant }}" == "M3-AHB" ]; then
+              echo "YOSYS_FLAGS=-DM3_MODE_AHB" >> $GITHUB_ENV
+            else
+              echo "YOSYS_FLAGS=-DM3_MODE_APB" >> $GITHUB_ENV
+            fi
           fi
 
       - name: Synthesis
         run: |
           if [ -n "${PARAMS}" ]; then
-            yosys -p "read_verilog -Isrc -sv src/project.v src_gowin/tt_gowin_top.v; chparam ${PARAMS} tt_gowin_top; synth_gowin -top tt_gowin_top; write_json build/gowin.json"
+            yosys -p "read_verilog -Isrc -sv ${YOSYS_FLAGS} ${SOURCES}; chparam ${PARAMS} ${TOP}; synth_gowin -top ${TOP}; write_json build/gowin.json"
           else
-            yosys -p "read_verilog -Isrc -sv src/project.v src_gowin/tt_gowin_top.v; synth_gowin -top tt_gowin_top; write_json build/gowin.json"
+            yosys -p "read_verilog -Isrc -sv ${YOSYS_FLAGS} ${SOURCES}; synth_gowin -top ${TOP}; write_json build/gowin.json"
           fi
 
       - name: Place and Route
@@ -70,16 +88,16 @@ jobs:
                           --write build/gowin_pnr.json \
                           --device GW1NSR-LV4CQN48PC6/I5 \
                           --family GW1NS-4 \
-                          --top tt_gowin_top \
+                          --top ${TOP} \
                           --freq 20 \
-                          --cst src_gowin/tangnano4k.cst
+                          --cst ${CST}
           elif command -v nextpnr-himbaechel >/dev/null 2>&1; then
             nextpnr-himbaechel --json build/gowin.json \
                                --write build/gowin_pnr.json \
                                --device GW1NSR-LV4CQN48PC6/I5 \
                                --vopt family=GW1NS-4 \
-                               --vopt cst=src_gowin/tangnano4k.cst \
-                               --top tt_gowin_top \
+                               --vopt cst=${CST} \
+                               --top ${TOP} \
                                --freq 20
           else
             echo "Error: No nextpnr binary found for Gowin"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,16 @@ jobs:
         run: |
           python3 test/gate_analysis.py
 
+      - name: Verify M3 Integration Compilation
+        if: matrix.config == 'Full'
+        run: |
+          # Verify compilation of all M3 modes using iverilog
+          for mode in M3_MODE_GPIO M3_MODE_APB M3_MODE_AHB; do
+            echo "Verifying $mode..."
+            iverilog -g2012 -Isrc -D$mode src/project.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v -o m3_test
+            rm m3_test
+          done
+
       - name: Run tests
         run: |
           cd test

--- a/src_gowin/gowin_empu_m3_stub.v
+++ b/src_gowin/gowin_empu_m3_stub.v
@@ -1,0 +1,51 @@
+`default_nettype none
+
+/* Stub for Gowin EMPU (Cortex-M3) IP Core
+   This allows open-source tools to process the design without the proprietary IP.
+*/
+
+module Gowin_EMPU_M3 (
+    input  wire        CLK,
+    input  wire        RESETN,
+    output wire        UART0_TXD,
+    input  wire        UART0_RXD,
+    inout  wire [15:0] GPIO0_IO,
+    input  wire [15:0] GPIO0_I,
+    output wire [15:0] GPIO0_O,
+    output wire [15:0] GPIO0_OE,
+    // Extension Bus (APB-like)
+    output wire [15:0] ADDR,
+    output wire [31:0] DATAOUT,
+    output wire        WRITE,
+    output wire        READ,
+    input  wire [31:0] DATAIN,
+    // AHB-Lite Master
+    output wire [31:0] M_AHB_HADDR,
+    output wire [1:0]  M_AHB_HTRANS,
+    output wire        M_AHB_HWRITE,
+    output wire [2:0]  M_AHB_HSIZE,
+    output wire [31:0] M_AHB_HWDATA,
+    output wire        M_AHB_HSEL,
+    output wire        M_AHB_HREADY,
+    input  wire [31:0] M_AHB_HRDATA,
+    input  wire        M_AHB_HREADYOUT,
+    input  wire        M_AHB_HRESP
+);
+
+    // This stub is for synthesis/linting and does not implement M3 logic.
+    assign UART0_TXD = 1'b1;
+    assign GPIO0_O   = 16'h0;
+    assign GPIO0_OE  = 16'h0;
+    assign ADDR      = 16'h0;
+    assign DATAOUT   = 32'h0;
+    assign WRITE     = 1'b0;
+    assign READ      = 1'b0;
+    assign M_AHB_HADDR  = 32'h0;
+    assign M_AHB_HTRANS = 2'b0;
+    assign M_AHB_HWRITE = 1'b0;
+    assign M_AHB_HSIZE  = 3'b0;
+    assign M_AHB_HWDATA = 32'h0;
+    assign M_AHB_HSEL   = 1'b0;
+    assign M_AHB_HREADY = 1'b0;
+
+endmodule

--- a/src_gowin/tt_gowin_top_m3.v
+++ b/src_gowin/tt_gowin_top_m3.v
@@ -20,7 +20,13 @@ module tt_gowin_top_m3 #(
     parameter ENABLE_SHARED_SCALING = 1,
     parameter USE_LNS_MUL = 0,
     parameter USE_LNS_MUL_PRECISE = 0,
-    parameter INTEGRATION_MODE = 0, // 0: GPIO, 1: APB, 2: AHB
+`ifdef M3_MODE_GPIO
+    parameter INTEGRATION_MODE = 0,
+`elsif M3_MODE_AHB
+    parameter INTEGRATION_MODE = 2,
+`else
+    parameter INTEGRATION_MODE = 1, // Default: APB
+`endif
     parameter APB_BASE_ADDR = 32'h40020000,
     parameter AHB_BASE_ADDR = 32'h40020000
 )(

--- a/test/verify_rtl_m3.py
+++ b/test/verify_rtl_m3.py
@@ -24,6 +24,21 @@ def verify_gowin_m3_top():
             print(f"Error: {error_msg} in {filepath}")
             return False
 
+    # Verify compile-time flags for INTEGRATION_MODE
+    ifdef_patterns = [
+        (r"`ifdef\s+M3_MODE_GPIO", "Missing `ifdef M3_MODE_GPIO"),
+        (r"parameter\s+INTEGRATION_MODE\s*=\s*0", "Missing INTEGRATION_MODE = 0 in GPIO branch"),
+        (r"`elsif\s+M3_MODE_AHB", "Missing `elsif M3_MODE_AHB"),
+        (r"parameter\s+INTEGRATION_MODE\s*=\s*2", "Missing INTEGRATION_MODE = 2 in AHB branch"),
+        (r"`else", "Missing `else for default APB mode"),
+        (r"parameter\s+INTEGRATION_MODE\s*=\s*1", "Missing INTEGRATION_MODE = 1 in default branch")
+    ]
+
+    for pattern, error_msg in ifdef_patterns:
+        if not re.search(pattern, content):
+            print(f"Error: {error_msg} in {filepath}")
+            return False
+
     # Verify parameter propagation (reusing from verify_rtl.py logic)
     expected_params = [
         "parameter ALIGNER_WIDTH",


### PR DESCRIPTION
This change refactors the Cortex-M3 integration to use compile-time flags for mode selection instead of runtime parameters, improving synthesis flexibility. It also expands the CI pipeline to automatically build and verify all three integration variants (GPIO, APB, AHB) and provides a stub for the proprietary M3 IP to facilitate open-source linting and compilation checks.

Fixes #654

---
*PR created automatically by Jules for task [14349488947235778199](https://jules.google.com/task/14349488947235778199) started by @chatelao*