### PR TITLE
Update ARM Cortex-M3 Integration Documentation

### DIFF
--- a/ARM_M3_INTEGRATION.md
+++ b/ARM_M3_INTEGRATION.md
@@ -6,38 +6,81 @@ This document consolidates the integration concepts for connecting the ARM Corte
 
 The Gowin GW1NSR-4C provides a hard-core ARM Cortex-M3 (EMCU) which can be used to drive the MAC unit. Depending on the performance requirements and available FPGA resources, several integration levels are possible. Transitioning from the current bit-banged GPIO approach to a memory-mapped interface (APB or AHB) allows for higher throughput, lower latency, and cleaner software abstraction.
 
-## 2. Current GPIO Implementation (Status Quo)
+## 2. Toolchain Setup
 
-The current implementation in `src_gowin/tt_gowin_top_m3.v` uses a **16-bit multiplexed GPIO interface**:
-- **GPIO[7:0]**: Data Bus (Multiplexed)
-- **GPIO[10:8]**: Address (Selects `ui_in`, `uio_in`, `uo_out`, etc.)
-- **GPIO[11-14]**: Control (`clk`, `rst_n`, `ena`, `WEN`)
+To build and deploy the M3-integrated MAC unit, the following tools are required:
 
-**Limitations:**
-- Software must manually toggle `GPIO[11]` (mac_clk) for every cycle.
-- Software must manage the 8-bit data bus direction (input/output) during reads.
-- High CPU overhead for bit-banging the 41-cycle protocol.
-- Max clock speed is limited by software execution (approx. 500 kHz).
+### 2.1. Arm Firmware Toolchain
+- **Compiler**: `arm-none-eabi-gcc` (Arm GNU Toolchain).
+- **Required**: `gcc`, `binutils`, `newlib`.
+- **Usage**: Compiles `src_m3/main.c` and `src_m3/startup.c` into a `.bin` file.
 
-## 3. Hybrid Integration Mode (APB-Write / GPIO-Read)
+### 2.2. RTL & FPGA Synthesis
+- **OSS Toolchain**: [OSS CAD Suite](https://github.com/YosysHQ/oss-cad-suite-build) (includes Yosys, nextpnr-gowin, and Apycula/gowin_pack).
+- **Alternative**: [Gowin EDA](https://www.gowinsemi.com/en/design/software/) (Proprietary).
+- **M3 IP**: Synthesis requires the `Gowin_EMPU_M3` primitive. In the OSS flow, this is provided by `src_gowin/gowin_empu_m3_stub.v`.
+
+### 2.3. Utilities
+- **Python 3**: Used for converting the compiled binary to a Gowin-compatible memory initialization file (`src_m3/bin2mi.py`).
+- **Serial Terminal**: `PuTTY`, `minicom`, or `screen` (115200 baud).
+
+## 3. GPIO Implementation (Status Quo)
+
+The baseline implementation in `src_gowin/tt_gowin_top_m3.v` uses a **16-bit multiplexed GPIO interface** to overcome the physical pin limitations of the EMCU.
+
+### 3.1. Technical Details
+- **GPIO[7:0]**: 8-bit Bidirectional Data Bus
+- **GPIO[10:8]**: 3-bit Address Select (0: `ui_in`, 1: `uio_in`, 2: `uo_out`, 3: `uio_out`, 4: `uio_oe`)
+- **GPIO[11]**: `mac_clk` (Manual toggle)
+- **GPIO[12]**: `mac_rst_n` (Active low)
+- **GPIO[13]**: `mac_ena`
+- **GPIO[14]**: `WEN` (Write Strobe)
+
+### 3.2. Installation & Usage
+
+**Synthesis**:
+To enable GPIO mode, define `M3_MODE_GPIO` during synthesis:
+```bash
+yosys -p "read_verilog -sv -DM3_MODE_GPIO src/project.v src_gowin/tt_gowin_top_m3.v ...; synth_gowin -top tt_gowin_top_m3"
+```
+
+**Firmware (C)**:
+```c
+#define GPIO0_DATA (*(volatile uint32_t *)0x40010000)
+#define GPIO0_DIR  (*(volatile uint32_t *)0x40010004)
+
+void write_ui_in(uint8_t val) {
+    GPIO0_DIR |= 0x00FF; // Bits 0-7 as output
+    GPIO0_DATA = (0 << 8) | val; // Addr 0, Data val
+    GPIO0_DATA |= (1 << 14);     // WEN high
+    GPIO0_DATA &= ~(1 << 14);    // WEN low
+}
+
+void clock_tick() {
+    GPIO0_DATA |= (1 << 11);     // clk high
+    GPIO0_DATA &= ~(1 << 11);    // clk low
+}
+```
+
+## 4. Hybrid Integration Mode (APB-Write / GPIO-Read)
 
 The **Hybrid mode** serves as a bridge between full software control and full hardware automation.
 - **Mechanism**: Accelerates the 32-cycle streaming phase by automating clock generation in hardware via an APB bridge for writes.
 - **Simplification**: Uses the existing GPIO path for the low-frequency read phase (Cycles 37-40), simplifying the bridge design.
 - **Benefit**: Significantly reduces CPU overhead during the data-intensive streaming phase without the complexity of a full bidirectional APB-to-MAC bridge.
 
-## 4. APB Integration (Peripheral Mode)
+## 5. APB Integration (Peripheral Mode)
 
 The APB interface acts as a Slave between the M3's Peripheral Bus and the MAC unit, replacing manual GPIO toggling with hardware-assisted register access.
 
-### Block Diagram Concept
+### 5.1. Block Diagram Concept
 ```text
 [ Cortex-M3 ] <--- APB Bus ---> [ APB-to-MAC Bridge ] <---> [ MAC Unit ]
                                    (Register Map)            (ui, uo, uio)
                                    (State Machine)           (mac_clk gen)
 ```
 
-### APB Register Map
+### 5.2. APB Register Map
 The bridge is mapped to a dedicated peripheral address space (e.g., `0x40020000`).
 
 | Offset | Name | Access | Description |
@@ -48,10 +91,36 @@ The bridge is mapped to a dedicated peripheral address space (e.g., `0x40020000`
 | `0x0C` | **STATUS** | R | Bit 0: Busy (Protocol in progress), Bit 1: Result Valid. |
 | `0x10` | **CONFIG** | RW | Clock divider settings for `mac_clk` generation. |
 
-### Automated Block Mode
+### 5.3. Installation & Usage
+
+**Synthesis**:
+The APB mode is the **default** for the `tt_gowin_top_m3` top-level if no other mode is specified.
+```bash
+yosys -p "read_verilog -sv src/project.v src_gowin/tt_gowin_top_m3.v ...; synth_gowin -top tt_gowin_top_m3"
+```
+
+**Firmware (C)**:
+```c
+#define APB_MAC_BASE 0x40020000
+#define MAC_DATA_IN  (*(volatile uint32_t *)(APB_MAC_BASE + 0x00))
+#define MAC_DATA_OUT (*(volatile uint32_t *)(APB_MAC_BASE + 0x04))
+#define MAC_CTRL     (*(volatile uint32_t *)(APB_MAC_BASE + 0x08))
+
+void mac_init() {
+    MAC_CTRL = 0x03; // ena=1, rst_n=1
+}
+
+void stream_element(uint8_t a, uint8_t b) {
+    // Write ui_in (bits 7:0) and uio_in (bits 15:8)
+    // Writing to DATA_IN automatically triggers one mac_clk pulse.
+    MAC_DATA_IN = (b << 8) | a;
+}
+```
+
+### 5.4. Automated Block Mode
 To minimize software overhead, the bridge can implement an **Automated Block Mode** where a hardware sequencer manages the entire 41-cycle streaming protocol, triggered by a single control register bit.
 
-## 5. AHB Integration (System Bus)
+## 6. AHB Integration (System Bus)
 
 For maximum performance, the MAC unit can be integrated directly onto the **Advanced High-performance Bus (AHB)**, the primary system bus of the Cortex-M3. AHB allows for burst transfers and zero-wait-state accesses.
 
@@ -62,11 +131,27 @@ In this mode, the MAC unit functions as a passive peripheral on the system bus.
 - **Operation**: An **AHB-to-MAC Bridge** module translates AHB protocol phases (`HSEL`, `HTRANS`, `HADDR`, `HWRITE`, `HWDATA`) into MAC control signals.
 - **Pipeline Support**: AHB uses separate address and data phases. The bridge buffers the address for one cycle to correlate it with the data phase.
 - **Wait-States**: The bridge uses the `HREADY` signal to pause the M3 if the MAC unit is busy with the sequential streaming protocol.
-- **Advantages**: Zero-wait-state access (where possible), higher taktraten (clock rates), and lower latency compared to APB.
+- **Advantages**: Zero-wait-state access (where possible), higher clock rates, and lower latency compared to APB.
 
 ![Protocol States Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/docs/diagrams/PROTOCOL_STATES.PUML)
 
-### 5.2. AHB_MASTER (DMA / Accelerator Mode)
+#### 6.1.1. Installation & Usage
+
+**Synthesis**:
+To enable AHB Slave mode, define `M3_MODE_AHB` during synthesis:
+```bash
+yosys -p "read_verilog -sv -DM3_MODE_AHB src/project.v src_gowin/tt_gowin_top_m3.v ...; synth_gowin -top tt_gowin_top_m3"
+```
+
+**Firmware (C)**:
+Accessing the MAC unit in AHB mode is identical to APB mode but uses the system bus for lower latency:
+```c
+#define AHB_MAC_BASE 0x40020000
+#define MAC_DATA_IN  (*(volatile uint32_t *)(AHB_MAC_BASE + 0x00))
+// Same register offsets as APB
+```
+
+### 6.2. AHB_MASTER (DMA / Accelerator Mode)
 
 In this mode, the integration includes a hardware sequencer that acts as a Bus Master.
 
@@ -78,7 +163,40 @@ In this mode, the integration includes a hardware sequencer that acts as a Bus M
 - **Interrupts**: An IRQ informs the M3 when the operation is complete.
 - **Advantages**: Minimal CPU load and maximum throughput (utilizing AHB bursts). Ideal for large-scale calculations such as LLM inference.
 
-## 6. Comparison of Integration Methods
+#### 6.2.1. AHB DMA Register Map
+
+| Offset | Name | Access | Description |
+|:---:|---|:---:|---|
+| `0x20` | **DMA_SRC** | RW | Source address in M3 SRAM (pointing to operand data). |
+| `0x24` | **DMA_DST** | RW | Destination address in M3 SRAM (for results). |
+| `0x2C` | **DMA_CTRL** | RW | Bit 0: Start DMA, Bit 1: Enable IRQ on completion. |
+| `0x0C` | **STATUS** | RW | Bit 0: Busy, Bit 1: Done (Write 1 to clear). |
+
+#### 6.2.2. Installation & Usage
+
+**Synthesis**:
+To enable AHB DMA mode, define `M3_MODE_AHB_DMA` during synthesis:
+```bash
+yosys -p "read_verilog -sv -DM3_MODE_AHB_DMA src/project.v src_gowin/tt_gowin_top_m3.v src_gowin/ahb2_mac_bridge.v ...; synth_gowin -top tt_gowin_top_m3"
+```
+
+**Firmware (C)**:
+```c
+#define AHB_DMA_BASE 0x40020000
+#define DMA_SRC      (*(volatile uint32_t *)(AHB_DMA_BASE + 0x20))
+#define DMA_DST      (*(volatile uint32_t *)(AHB_DMA_BASE + 0x24))
+#define DMA_CTRL     (*(volatile uint32_t *)(AHB_DMA_BASE + 0x2C))
+#define DMA_STATUS   (*(volatile uint32_t *)(AHB_DMA_BASE + 0x0C))
+
+void run_dma_mac(void* src, void* dst) {
+    DMA_SRC = (uint32_t)src;
+    DMA_DST = (uint32_t)dst;
+    DMA_CTRL = 0x01; // Start
+    while (DMA_STATUS & 0x01); // Wait for busy bit to clear
+}
+```
+
+## 7. Comparison of Integration Methods
 
 | Feature | GPIO (Status Quo) | Hybrid (APB/GPIO) | APB (Peripheral) | AHB_SLAVE | AHB_MASTER (DMA) |
 |:---:|:---:|:---:|:---:|:---:|:---:|
@@ -88,7 +206,7 @@ In this mode, the integration includes a hardware sequencer that acts as a Bus M
 | **Footprint** | ~150 Gates | ~350 Gates | ~500 Gates | ~800 Gates | ~2000 Gates |
 | **Design Effort**| Minimal | Low | Medium | High | Very High |
 
-## 7. Implementation Roadmap
+## 8. Implementation Roadmap
 
 1. **RTL Development**: Create `src_gowin/apb_mac_bridge.v` (or AHB equivalent).
 2. **Integration**: Update `tt_gowin_top_m3.v` to instantiate the chosen bridge instead of direct GPIO mapping.


### PR DESCRIPTION
I have updated the `ARM_M3_INTEGRATION.md` documentation to include comprehensive installation and usage instructions for all ARM Cortex-M3 integration modes (GPIO, APB, AHB, and AHB-DMA). 

Key additions include:
1.  **Toolchain Setup**: Documented the requirements for the Arm Firmware Toolchain, RTL synthesis tools (Yosys/OSS CAD Suite), and necessary utility scripts.
2.  **Synthesis Flags**: Provided the specific `-D` flags (e.g., `-DM3_MODE_GPIO`, `-DM3_MODE_AHB_DMA`) required for each mode.
3.  **Firmware Snippets**: Added C code examples for every mode, showing how to interact with the hardware via GPIO bit-banging, standard register access, or DMA configuration.
4.  **Register Maps**: Included the detailed DMA register map for the high-performance AHB-MASTER mode.
5.  **Section Cleanup**: Improved the overall structure and renumbered sections for better flow.

These changes ensure that developers have clear, actionable steps to build, synthesize, and write software for any of the M3-accelerated MAC unit configurations.

Fixes #658

---
*PR created automatically by Jules for task [16019508151416885716](https://jules.google.com/task/16019508151416885716) started by @chatelao*