### PR TITLE
Exclude problematic nand2b_1 cell from synthesis

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -29,6 +29,7 @@
   "//": "AREA 3 focuses on minimizing the number of gates.",
   "SYNTH_STRATEGY": "AREA 3",
   "SYNTH_SIZING": 1,
+  "SYNTH_EXCLUDED_CELLS": ["sg13g2_nand2b_1"],
 
   "//": "--- Physical Layout Parameters ---",
   "RUN_KLAYOUT_XOR": 0,


### PR DESCRIPTION
Excluded the `sg13g2_nand2b_1` cell from synthesis in `src/config.json` to resolve a reported DRC issue where polysilicon layers were touching. Confirmed the cell name from the PDK source.

Fixes #660

---
*PR created automatically by Jules for task [16451069301363707672](https://jules.google.com/task/16451069301363707672) started by @chatelao*