### PR TITLE
Refactor Verilog source organization and metadata for better toolchain compatibility

### DIFF
--- a/.github/workflows/gowin.yaml
+++ b/.github/workflows/gowin.yaml
@@ -44,7 +44,7 @@ jobs:
         run: |
           # Defaults
           echo "TOP=tt_gowin_top" >> $GITHUB_ENV
-          echo "SOURCES=src/project.v src_gowin/tt_gowin_top.v" >> $GITHUB_ENV
+          echo "SOURCES=src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src_gowin/tt_gowin_top.v" >> $GITHUB_ENV
           echo "CST=src_gowin/tangnano4k.cst" >> $GITHUB_ENV
           echo "YOSYS_FLAGS=" >> $GITHUB_ENV
 
@@ -60,7 +60,7 @@ jobs:
             echo "PARAMS=-set ALIGNER_WIDTH 32 -set ACCUMULATOR_WIDTH 24 -set SUPPORT_E4M3 0 -set SUPPORT_E5M2 0 -set SUPPORT_MXFP6 0 -set SUPPORT_MXFP4 1 -set SUPPORT_INT8 0 -set SUPPORT_PIPELINING 0 -set SUPPORT_ADV_ROUNDING 0 -set SUPPORT_MIXED_PRECISION 0 -set SUPPORT_VECTOR_PACKING 0 -set ENABLE_SHARED_SCALING 0 -set SUPPORT_MX_PLUS 0 -set SUPPORT_INPUT_BUFFERING 0 -set SUPPORT_SERIAL 1" >> $GITHUB_ENV
           elif [[ "${{ matrix.variant }}" == M3-* ]]; then
             echo "TOP=tt_gowin_top_m3" >> $GITHUB_ENV
-            echo "SOURCES=src/project.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v src_gowin/ahb2_mac_bridge.v" >> $GITHUB_ENV
+            echo "SOURCES=src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v src_gowin/ahb2_mac_bridge.v" >> $GITHUB_ENV
             echo "CST=src_gowin/tangnano4k_m3.cst" >> $GITHUB_ENV
             echo "PARAMS=-set ALIGNER_WIDTH 32 -set ACCUMULATOR_WIDTH 32 -set SUPPORT_E4M3 1 -set SUPPORT_E5M2 1" >> $GITHUB_ENV
             if [ "${{ matrix.variant }}" == "M3-GPIO" ]; then

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
           # Verify compilation of all M3 modes using iverilog
           for mode in M3_MODE_GPIO M3_MODE_APB M3_MODE_AHB; do
             echo "Verifying $mode..."
-            iverilog -g2012 -Isrc -D$mode src/project.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v -o m3_test
+            iverilog -g2012 -Isrc -D$mode src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v -o m3_test
             rm m3_test
           done
 

--- a/info.yaml
+++ b/info.yaml
@@ -20,6 +20,7 @@ project:
     - "project.v"
     - "fp8_mul.v"
     - "fp8_mul_lns.v"
+    - "fp8_mul_serial_lns.v"
     - "fp8_aligner.v"
     - "accumulator.v"
 

--- a/src/project.v
+++ b/src/project.v
@@ -1,3 +1,5 @@
+`ifndef __PROJECT_V__
+`define __PROJECT_V__
 `default_nettype none
 
 /**
@@ -12,13 +14,7 @@
  * (ui_in, uo_out, uio_in, uio_out, uio_oe, ena, clk, rst_n).
  */
 
-`include "fp8_mul.v"
-`include "fp8_mul_lns.v"
-`include "fp8_aligner.v"
-`include "accumulator.v"
-
 /* verilator lint_off DECLFILENAME */
-/* verilator lint_off MODDUP */
 module tt_um_chatelao_fp8_multiplier #(
     // Parameters allow customizing the hardware size and features during synthesis.
     parameter ALIGNER_WIDTH = 40,
@@ -974,3 +970,4 @@ module tt_um_chatelao_fp8_multiplier #(
 `endif
 
 endmodule
+`endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,7 +6,7 @@ SIM ?= icarus
 FST ?= -fst # Use more efficient FST format
 TOPLEVEL_LANG ?= verilog
 SRC_DIR = ../src
-PROJECT_SOURCES = project.v
+PROJECT_SOURCES = project.v fp8_mul.v fp8_mul_lns.v fp8_mul_serial_lns.v fp8_aligner.v accumulator.v
 
 ifeq ($(GATES),yes)
 
@@ -46,4 +46,4 @@ include $(shell cocotb-config --makefiles)/Makefile.sim
 
 # Verilator linting:
 lint:
-	cd $(SRC_DIR) && verilator --lint-only -Wall project.v --top-module tt_um_chatelao_fp8_multiplier
+	cd $(SRC_DIR) && verilator --lint-only -Wall $(PROJECT_SOURCES) --top-module tt_um_chatelao_fp8_multiplier

--- a/test/gate_analysis.py
+++ b/test/gate_analysis.py
@@ -2,7 +2,7 @@ import subprocess
 import os
 import re
 
-def get_yosys_stats(params, top_module="tt_um_chatelao_fp8_multiplier", source_file="src/project.v"):
+def get_yosys_stats(params, top_module="tt_um_chatelao_fp8_multiplier", source_file="src/*.v"):
     param_str = ""
     for k, v in params.items():
         param_str += f"chparam -set {k} {v} {top_module}; "


### PR DESCRIPTION
This PR improves the project's architectural robustness and toolchain compatibility by refactoring the Verilog source organization. It moves away from internal `include directives in the top-level module, which can cause "Multiple Definition" errors in many EDA tools (like Cocotb, Yosys, and the Tiny Tapeout GDS flow). Instead, it adopts the standard practice of defining a complete file list in the project's metadata (`info.yaml`) and build system (`test/Makefile`). Additionally, it ensures that all source files follow a consistent pattern of using `ifndef include guards and integrates the bit-serial multiplier core into the standard linter and build flow.

Fixes #662

---
*PR created automatically by Jules for task [45875044733398897](https://jules.google.com/task/45875044733398897) started by @chatelao*