### PR TITLE
Add GH Pages Interactive Digital Twin and Predictor

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,63 @@
+name: github-pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-wasm:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Verilator
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y verilator
+
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 3.1.56
+
+      - name: Build WASM
+        run: |
+          cd wasm
+          make VARIANT=Full
+
+      - name: Prepare Website
+        run: |
+          mkdir -p public
+          cp -r docs/web/* public/
+          cp wasm/digital_twin_Full.js public/
+          cp wasm/digital_twin_Full.wasm public/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './public'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-wasm
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/web/index.html
+++ b/docs/web/index.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OCP MXFP8 MAC Digital Twin</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>OCP MXFP8 Streaming MAC Unit</h1>
+        <p>Interactive Digital Twin & Predictor</p>
+    </header>
+
+    <main>
+        <section id="config-global">
+            <h2>Global Configuration (Cycle 0)</h2>
+            <div class="grid-container">
+                <div class="control-group">
+                    <label for="rounding-mode">Rounding Mode</label>
+                    <select id="rounding-mode">
+                        <option value="0">TRN (Truncate)</option>
+                        <option value="1">CEL (Ceil)</option>
+                        <option value="2">FLR (Floor)</option>
+                        <option value="3" selected>RNE (Round-to-Nearest-Even)</option>
+                    </select>
+                </div>
+                <div class="control-group">
+                    <label for="overflow-mode">Overflow Mode</label>
+                    <select id="overflow-mode">
+                        <option value="0" selected>SAT (Saturate)</option>
+                        <option value="1">WRAP (Modulo)</option>
+                    </select>
+                </div>
+                <div class="control-group">
+                    <label for="lns-mode">Multiplier Mode</label>
+                    <select id="lns-mode">
+                        <option value="0" selected>Normal (Exact)</option>
+                        <option value="1">LNS (Mitchell's Approx)</option>
+                        <option value="2">Hybrid (BM=Exact, else LNS)</option>
+                    </select>
+                </div>
+                <div class="control-group">
+                    <label for="mx-plus-en">MX+ Extensions</label>
+                    <select id="mx-plus-en">
+                        <option value="0">Disabled</option>
+                        <option value="1">Enabled</option>
+                    </select>
+                </div>
+                <div class="control-group">
+                    <label for="packed-mode">Vector Packing (FP4)</label>
+                    <select id="packed-mode">
+                        <option value="0" selected>Disabled</option>
+                        <option value="1">Enabled</option>
+                    </select>
+                </div>
+            </div>
+        </section>
+
+        <section id="config-scales">
+            <h2>Scales & Formats (Cycles 1 & 2)</h2>
+            <div class="grid-container">
+                <div class="card">
+                    <h3>Operand A</h3>
+                    <div class="control-group">
+                        <label for="format-a">Format</label>
+                        <select id="format-a">
+                            <option value="0" selected>E4M3 (FP8)</option>
+                            <option value="1">E5M2 (FP8)</option>
+                            <option value="2">E3M2 (FP6)</option>
+                            <option value="3">E2M3 (FP6)</option>
+                            <option value="4">E2M1 (FP4)</option>
+                            <option value="5">INT8</option>
+                            <option value="6">INT8_SYM</option>
+                        </select>
+                    </div>
+                    <div class="control-group">
+                        <label for="scale-a">Shared Scale (Hex)</label>
+                        <input type="text" id="scale-a" value="7F" maxlength="2">
+                        <span id="scale-a-dec" class="dec-val">1.0</span>
+                    </div>
+                    <div class="control-group mx-plus-only hidden">
+                        <label for="bm-index-a">BM Index (0-31)</label>
+                        <input type="number" id="bm-index-a" value="0" min="0" max="31">
+                    </div>
+                    <div class="control-group mx-plus-only hidden">
+                        <label for="nbm-offset-a">NBM Offset (0-7)</label>
+                        <input type="number" id="nbm-offset-a" value="0" min="0" max="7">
+                    </div>
+                </div>
+
+                <div class="card">
+                    <h3>Operand B</h3>
+                    <div class="control-group">
+                        <label for="format-b">Format</label>
+                        <select id="format-b">
+                            <option value="0" selected>E4M3 (FP8)</option>
+                            <option value="1">E5M2 (FP8)</option>
+                            <option value="2">E3M2 (FP6)</option>
+                            <option value="3">E2M3 (FP6)</option>
+                            <option value="4">E2M1 (FP4)</option>
+                            <option value="5">INT8</option>
+                            <option value="6">INT8_SYM</option>
+                        </select>
+                    </div>
+                    <div class="control-group">
+                        <label for="scale-b">Shared Scale (Hex)</label>
+                        <input type="text" id="scale-b" value="7F" maxlength="2">
+                        <span id="scale-b-dec" class="dec-val">1.0</span>
+                    </div>
+                    <div class="control-group mx-plus-only hidden">
+                        <label for="bm-index-b">BM Index (0-31)</label>
+                        <input type="number" id="bm-index-b" value="0" min="0" max="31">
+                    </div>
+                    <div class="control-group mx-plus-only hidden">
+                        <label for="nbm-offset-b">NBM Offset (0-7)</label>
+                        <input type="number" id="nbm-offset-b" value="0" min="0" max="7">
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="streaming-data">
+            <h2>Element Streaming (Cycles 3-34)</h2>
+            <div class="table-container">
+                <table id="elements-table">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>A (Hex)</th>
+                            <th>A (Dec)</th>
+                            <th>B (Hex)</th>
+                            <th>B (Dec)</th>
+                            <th>Product</th>
+                        </tr>
+                    </thead>
+                    <tbody id="elements-body">
+                        <!-- Rows populated by JS -->
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section id="results">
+            <div class="result-card">
+                <h2>Predicted Output</h2>
+                <div class="result-grid">
+                    <div class="result-item">
+                        <span class="label">Accumulator (Hex)</span>
+                        <span id="acc-hex" class="value">0x00000000</span>
+                    </div>
+                    <div class="result-item">
+                        <span class="label">Accumulator (Dec)</span>
+                        <span id="acc-dec" class="value">0.0</span>
+                    </div>
+                    <div class="result-item">
+                        <span class="label">Status</span>
+                        <span id="status-flags" class="value">-</span>
+                    </div>
+                </div>
+                <button id="run-simulation">Run Simulation</button>
+            </div>
+        </section>
+    </main>
+
+    <footer id="console">
+        <div id="log-container">
+            <pre id="log-output">Initializing WASM Digital Twin...</pre>
+        </div>
+    </footer>
+
+    <script src="digital_twin_Full.js"></script>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/docs/web/main.js
+++ b/docs/web/main.js
@@ -1,0 +1,263 @@
+// OCP MXFP8 Digital Twin Main Controller
+
+let twin = null;
+let Module = {
+    onRuntimeInitialized: function() {
+        console.log("WASM Runtime Initialized");
+        initApp();
+    }
+};
+
+function log(msg) {
+    const output = document.getElementById('log-output');
+    output.textContent += msg + "\n";
+    document.getElementById('console').scrollTop = document.getElementById('console').scrollHeight;
+}
+
+// --- Numerical Decoders ---
+
+function decode_e2m1(bits) {
+    const s = (bits >> 3) & 1;
+    const e = (bits >> 1) & 3;
+    const m = bits & 1;
+    if (e === 0) return (s ? -1 : 1) * (m / 2.0); // Subnormal
+    return (s ? -1 : 1) * Math.pow(2, e - 1) * (1 + m / 2.0);
+}
+
+function decode_e3m2(bits) {
+    const s = (bits >> 5) & 1;
+    const e = (bits >> 2) & 7;
+    const m = bits & 3;
+    if (e === 0) return (s ? -1 : 1) * Math.pow(2, -2) * (m / 4.0);
+    return (s ? -1 : 1) * Math.pow(2, e - 3) * (1 + m / 4.0);
+}
+
+function decode_e2m3(bits) {
+    const s = (bits >> 5) & 1;
+    const e = (bits >> 3) & 3;
+    const m = bits & 7;
+    if (e === 0) return (s ? -1 : 1) * (m / 8.0);
+    return (s ? -1 : 1) * Math.pow(2, e - 1) * (1 + m / 8.0);
+}
+
+function decode_e4m3(bits) {
+    if (bits === 0x7F || bits === 0xFF) return NaN;
+    const s = (bits >> 7) & 1;
+    const e = (bits >> 3) & 0xF;
+    const m = bits & 7;
+    if (e === 0) return (s ? -1 : 1) * Math.pow(2, -6) * (m / 8.0);
+    return (s ? -1 : 1) * Math.pow(2, e - 7) * (1 + m / 8.0);
+}
+
+function decode_e5m2(bits) {
+    const s = (bits >> 7) & 1;
+    const e = (bits >> 2) & 0x1F;
+    const m = bits & 3;
+    if (e === 0x1F) return m === 0 ? (s ? -Infinity : Infinity) : NaN;
+    if (e === 0) return (s ? -1 : 1) * Math.pow(2, -14) * (m / 4.0);
+    return (s ? -1 : 1) * Math.pow(2, e - 15) * (1 + m / 4.0);
+}
+
+function decode_int8(bits) {
+    // Standard 2's complement, but OCP MX specifies it's scaled by 2^-6
+    let val = bits >= 128 ? bits - 256 : bits;
+    return val / 64.0;
+}
+
+function decode_int8_sym(bits) {
+    // Symmetric INT8: -127 to 127, 0x80 is NaN or saturated
+    if (bits === 0x80) return NaN;
+    let val = bits >= 128 ? bits - 256 : bits;
+    return val / 64.0;
+}
+
+function decode_ue8m0(bits) {
+    if (bits === 0xFF) return NaN;
+    return Math.pow(2, bits - 127);
+}
+
+function decode(bits, format) {
+    switch(parseInt(format)) {
+        case 0: return decode_e4m3(bits);
+        case 1: return decode_e5m2(bits);
+        case 2: return decode_e3m2(bits);
+        case 3: return decode_e2m3(bits);
+        case 4: return decode_e2m1(bits);
+        case 5: return decode_int8(bits);
+        case 6: return decode_int8_sym(bits);
+        default: return 0;
+    }
+}
+
+// --- UI Logic ---
+
+function initApp() {
+    log("Instantiating Digital Twin...");
+    twin = new Module.DigitalTwin();
+
+    populateTable();
+    setupEventListeners();
+    updateDecValues();
+    log("Ready.");
+}
+
+function populateTable() {
+    const body = document.getElementById('elements-body');
+    for (let i = 0; i < 32; i++) {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+            <td>${i}</td>
+            <td><input type="text" class="cell-a-hex" data-idx="${i}" value="38" maxlength="2"></td>
+            <td><span class="cell-a-dec">-</span></td>
+            <td><input type="text" class="cell-b-hex" data-idx="${i}" value="38" maxlength="2"></td>
+            <td><span class="cell-b-dec">-</span></td>
+            <td><span class="cell-prod">-</span></td>
+        `;
+        body.appendChild(row);
+    }
+}
+
+function updateDecValues() {
+    const fmtA = document.getElementById('format-a').value;
+    const fmtB = document.getElementById('format-b').value;
+    const scaleAHex = parseInt(document.getElementById('scale-a').value, 16) || 0;
+    const scaleBHex = parseInt(document.getElementById('scale-b').value, 16) || 0;
+
+    const scaleA = decode_ue8m0(scaleAHex);
+    const scaleB = decode_ue8m0(scaleBHex);
+
+    document.getElementById('scale-a-dec').textContent = isNaN(scaleA) ? "NaN" : scaleA.toExponential(2);
+    document.getElementById('scale-b-dec').textContent = isNaN(scaleB) ? "NaN" : scaleB.toExponential(2);
+
+    const rows = document.querySelectorAll('#elements-body tr');
+    rows.forEach((row, i) => {
+        const aHex = parseInt(row.querySelector('.cell-a-hex').value, 16) || 0;
+        const bHex = parseInt(row.querySelector('.cell-b-hex').value, 16) || 0;
+
+        const aDec = decode(aHex, fmtA);
+        const bDec = decode(bHex, fmtB);
+
+        row.querySelector('.cell-a-dec').textContent = isNaN(aDec) ? "NaN" : (aDec * scaleA).toExponential(2);
+        row.querySelector('.cell-b-dec').textContent = isNaN(bDec) ? "NaN" : (bDec * scaleB).toExponential(2);
+
+        const prod = (aDec * scaleA) * (bDec * scaleB);
+        row.querySelector('.cell-prod').textContent = isNaN(prod) ? "NaN" : prod.toExponential(2);
+    });
+}
+
+function setupEventListeners() {
+    document.querySelectorAll('select, input').forEach(el => {
+        el.addEventListener('change', () => {
+            if (el.id === 'mx-plus-en') {
+                document.querySelectorAll('.mx-plus-only').forEach(item => {
+                    item.classList.toggle('hidden', el.value === '0');
+                });
+            }
+            updateDecValues();
+        });
+    });
+
+    document.getElementById('run-simulation').addEventListener('click', runSimulation);
+}
+
+// --- Simulation Driver ---
+
+async function runSimulation() {
+    if (!twin) return;
+    log("Starting simulation cycle...");
+
+    // Reset
+    twin.set_rst_n(false);
+    twin.step();
+    twin.set_rst_n(true);
+    twin.set_ena(true);
+
+    const getVal = (id) => parseInt(document.getElementById(id).value);
+    const getHex = (id) => parseInt(document.getElementById(id).value, 16) || 0;
+
+    // Cycle 0: Metadata
+    const ui0 = (getVal('lns-mode') << 3) | (getVal('nbm-offset-a'));
+    const uio0 = (getVal('mx-plus-en') << 7) | (getVal('packed-mode') << 6) | (getVal('overflow-mode') << 5) | (getVal('rounding-mode') << 3) | (getVal('nbm-offset-b'));
+
+    twin.set_ui_in(ui0);
+    twin.set_uio_in(uio0);
+    twin.step();
+    log(`Cycle 0: ui=0x${ui0.toString(16)}, uio=0x${uio0.toString(16)}`);
+
+    // Cycle 1: Scale A / Config A
+    const ui1 = getHex('scale-a');
+    const uio1 = (getVal('bm-index-a') << 3) | getVal('format-a');
+    twin.set_ui_in(ui1);
+    twin.set_uio_in(uio1);
+    twin.step();
+    log(`Cycle 1: ui=0x${ui1.toString(16)}, uio=0x${uio1.toString(16)}`);
+
+    // Cycle 2: Scale B / Config B
+    const ui2 = getHex('scale-b');
+    const uio2 = (getVal('bm-index-b') << 3) | getVal('format-b');
+    twin.set_ui_in(ui2);
+    twin.set_uio_in(uio2);
+    twin.step();
+    log(`Cycle 2: ui=0x${ui2.toString(16)}, uio=0x${uio2.toString(16)}`);
+
+    // Cycle 3-34: Streaming
+    const rows = document.querySelectorAll('#elements-body tr');
+    for (let i = 0; i < 32; i++) {
+        const aHex = parseInt(rows[i].querySelector('.cell-a-hex').value, 16) || 0;
+        const bHex = parseInt(rows[i].querySelector('.cell-b-hex').value, 16) || 0;
+        twin.set_ui_in(aHex);
+        twin.set_uio_in(bHex);
+        twin.step();
+    }
+    log("Cycles 3-34: Streaming completed.");
+
+    // Cycle 35-36: Flush & Scale
+    twin.set_ui_in(0);
+    twin.set_uio_in(0);
+    twin.step(); // 35
+    twin.step(); // 36
+    log("Cycles 35-36: Flush and final scaling.");
+
+    // Cycle 37-40: Read Result
+    let result = 0n;
+    for (let i = 0; i < 4; i++) {
+        twin.step();
+        const byte = BigInt(twin.get_uo_out());
+        result = (result << 8n) | byte;
+        log(`Cycle ${37+i}: Output byte = 0x${byte.toString(16).padStart(2, '0')}`);
+    }
+
+    // Process 32-bit signed result (fixed point with 13-bit fractional part usually,
+    // but depends on ALIGNER_WIDTH/ACCUMULATOR_WIDTH.
+    // In our Full variant: ALIGNER_WIDTH=40, ACCUMULATOR_WIDTH=32.
+    // The accumulator is signed 32-bit.
+    let signedRes = result;
+    if (result & 0x80000000n) {
+        signedRes = result - 0x100000000n;
+    }
+
+    // Scaling: The hardware aligner/accumulator has a fixed-point position.
+    // Based on project.v, for E4M3 (bias 7), 1.0 * 1.0 = 2^0.
+    // The aligner output usually has some fractional bits.
+    // In the E4M3 example in README: 1.0 * 1.0 (32 times) = 0x00002000 => 32.0.
+    // This implies 0x00000100 is 1.0. So 8 bits of fraction.
+
+    const floatRes = Number(signedRes) / 256.0;
+
+    document.getElementById('acc-hex').textContent = `0x${result.toString(16).padStart(8, '0').toUpperCase()}`;
+    document.getElementById('acc-dec').textContent = floatRes.toFixed(4);
+
+    // Check for Sticky Flags (Infinities/NaNs)
+    // The RTL uses a special byte output if sticky flags are set.
+    // Cycle 37: 0x7F/0xFF if Inf/NaN
+    // Cycle 38: 0xC0/0x80 if NaN/Inf
+
+    // Let's just log if the result looks like a special value
+    if (result === 0x7FC00000n || result === 0x7F800000n || result === 0xFF800000n) {
+        document.getElementById('status-flags').textContent = "Special Value (NaN/Inf) detected";
+    } else {
+        document.getElementById('status-flags').textContent = "Normal";
+    }
+
+    log(`Final Result: ${floatRes}`);
+}

--- a/docs/web/style.css
+++ b/docs/web/style.css
@@ -1,0 +1,192 @@
+:root {
+    --primary: #2c3e50;
+    --secondary: #34495e;
+    --accent: #3498db;
+    --bg: #ecf0f1;
+    --text: #333;
+    --card-bg: #fff;
+    --border: #ddd;
+    --success: #27ae60;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--text);
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+header {
+    background: var(--primary);
+    color: #fff;
+    padding: 1.5rem;
+    text-align: center;
+}
+
+header h1 {
+    margin: 0;
+    font-size: 1.8rem;
+}
+
+main {
+    padding: 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+    flex: 1;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    gap: 1.5rem;
+}
+
+section {
+    background: var(--card-bg);
+    padding: 1.5rem;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+}
+
+h2 {
+    margin-top: 0;
+    font-size: 1.2rem;
+    border-bottom: 2px solid var(--accent);
+    padding-bottom: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.grid-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+
+.control-group {
+    margin-bottom: 0.75rem;
+}
+
+.control-group label {
+    display: block;
+    font-weight: bold;
+    font-size: 0.9rem;
+    margin-bottom: 0.25rem;
+}
+
+.control-group input, .control-group select {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+.card {
+    background: #f9f9f9;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+}
+
+.card h3 {
+    margin-top: 0;
+    font-size: 1rem;
+    color: var(--secondary);
+}
+
+.hidden {
+    display: none !important;
+}
+
+.table-container {
+    max-height: 400px;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+}
+
+th, td {
+    padding: 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid #eee;
+}
+
+th {
+    background: #f4f4f4;
+    position: sticky;
+    top: 0;
+}
+
+.result-card {
+    background: var(--secondary);
+    color: #fff;
+    padding: 1.5rem;
+    border-radius: 8px;
+    text-align: center;
+}
+
+.result-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.result-item .label {
+    display: block;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    opacity: 0.8;
+}
+
+.result-item .value {
+    font-size: 1.2rem;
+    font-weight: bold;
+    font-family: 'Courier New', Courier, monospace;
+}
+
+button {
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+button:hover {
+    background: #2980b9;
+}
+
+footer {
+    background: #000;
+    color: #0f0;
+    padding: 1rem;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 0.85rem;
+    height: 150px;
+    overflow-y: scroll;
+}
+
+pre {
+    margin: 0;
+    white-space: pre-wrap;
+}
+
+@media (max-width: 768px) {
+    main {
+        grid-template-columns: 1fr;
+    }
+    .grid-container {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
This submission adds a GitHub Pages interactive tool to the repository. The tool allows users to configure the OCP MXFP8 Streaming MAC Unit through a user-friendly web interface and predict output values using a WASM-compiled 'Digital Twin' of the hardware. 

Key features include:
- Dropdowns for all protocol metadata (Rounding, Overflow, LNS, MX+, Vector Packing).
- Input fields for Shared Scales with real-time decimal conversion.
- A 32-row interactive streaming table for element-wise input.
- A JavaScript model that accurately decodes FP8, FP6, FP4, and INT8 formats.
- An automated CI/CD workflow that builds the WASM binary and deploys the site.

The solution is non-intrusive to the core hardware design and has been verified through both existing RTL tests and new frontend verification scripts.

Fixes #671

---
*PR created automatically by Jules for task [6132830518294059056](https://jules.google.com/task/6132830518294059056) started by @chatelao*