### PR TITLE
Link GitHub Pages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to proces
 - `uio_in[7:3]`: **BM Index B** (MX+)
 
 - [Silicon Online Viewer](https://gds-viewer.tinytapeout.com/?pdk=ihp-sg13g2&model=https%3A%2F%2Fchatelao.github.io%2Fttihp-fp8-mul%2F%2Ftinytapeout.oas)
+- [Interactive Digital Twin (WASM Demo)](https://chatelao.github.io/ttihp-fp8-mul/)
 
 ### MicroPython Example (TT DevKit)
 


### PR DESCRIPTION
Added a link to the project's GitHub Pages (Interactive Digital Twin) in the README.md file. Verified the change by reading the file and ensured no regressions by running the comprehensive regression test suite.

Fixes #675

---
*PR created automatically by Jules for task [8985930745831975425](https://jules.google.com/task/8985930745831975425) started by @chatelao*