### PR TITLE
Add FSM state diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ We gratefully acknowledge these contributions to the open-source hardware and AI
 
 The MAC unit follows a **41-cycle streaming protocol** (Cycles 0–40) to process a block of 32 elements.
 
+### Protocol State Machine
+
+![Protocol State Machine Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/ihp-sg13cmos5l/docs/diagrams/PROTOCOL_STATES.PUML)
+
+*Source: [docs/diagrams/PROTOCOL_STATES.PUML](docs/diagrams/PROTOCOL_STATES.PUML)*
+
 ### Operational Sequence
 
 | Cycle | Input `ui_in[7:0]` | Input `uio_in[7:0]` | Output `uo_out[7:0]` | Description |


### PR DESCRIPTION
This change adds a visual representation of the OCP MXFP8 streaming protocol's finite state machine to the main README.md. It utilizes the project's existing PlantUML proxy integration pattern to render the diagram from `docs/diagrams/PROTOCOL_STATES.PUML`. This improves documentation clarity by providing a high-level view of the 41-cycle (standard) or 25-cycle (packed) protocol transitions.

Fixes #698

---
*PR created automatically by Jules for task [10733669522620304956](https://jules.google.com/task/10733669522620304956) started by @chatelao*