### PR TITLE
Add tests for Debug Mode 0x2 exception bits

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -170,3 +170,44 @@ Allows monitoring of the product from the first multiplier lane.
 | 0 | `0x40` | `0x09` | `0x00` | `0x00` | Control signals monitoring |
 | 1-2 | `0x7F` | `0x00` | `0x00` | `0xD0` | `ena=1, strobe=1, acc_clear=1` |
 | 4-34 | `0x38` | `0x38` | `0x00` | `0xE0` | `ena=1, strobe=1, acc_en=1` |
+
+### Test Sequence 8: NaN Exception (Element-triggered)
+**Description**: Streaming an E4M3 NaN element (`0x7F`) to trigger `nan_sticky` in Debug Mode 0x2.
+**Expected Result**: `uo_out[7]` becomes 1.
+
+| Cycle | `ui_in` | `uio_in` | `uio_out` | `uo_out` | Description |
+|:---:|:---:|:---:|:---:|:---:|---|
+| 0 | `0x40` | `0x02` | `0x00` | `0x10` | Debug En, Sel 0x2 (Exception Monitor) |
+| 1 | `127` | `0x00` | `0x00` | `0x10` | Scale A = 1.0 (127), Format A = E4M3 |
+| 2 | `127` | `0x00` | `0x00` | `0x10` | Scale B = 1.0 (127), Format B = E4M3 |
+| 3 | `0x7F` | `0x38` | `0x00` | `0x10` | Stream NaN (`0x7F`) |
+| 4 | `0x38` | `0x38` | `0x00` | `0x10` | Pipelining... |
+| 5 | `0x38` | `0x38` | `0x00` | `0x90` | `uo_out[7]` (nan_sticky) = 1 |
+
+---
+
+### Test Sequence 9: NaN Exception (Scale-triggered)
+**Description**: Loading Scale A = `0xFF` during Cycle 1.
+**Expected Result**: `uo_out[7]` becomes 1.
+
+| Cycle | `ui_in` | `uio_in` | `uio_out` | `uo_out` | Description |
+|:---:|:---:|:---:|:---:|:---:|---|
+| 0 | `0x40` | `0x02` | `0x00` | `0x10` | Debug En, Sel 0x2 |
+| 1 | `255` | `0x00` | `0x00` | `0x10` | Scale A = 255 (0xFF, NaN) |
+| 2 | `127` | `0x00` | `0x00` | `0x90` | `nan_sticky` set due to Cycle 1 Scale |
+
+---
+
+### Test Sequence 10: Infinity Exceptions (Positive and Negative)
+**Description**: Using E5M2 operands to trigger `inf_pos_sticky` and `inf_neg_sticky`.
+**Expected Result**: `uo_out[6]` and `uo_out[5]` go high.
+
+| Cycle | `ui_in` | `uio_in` | `uio_out` | `uo_out` | Description |
+|:---:|:---:|:---:|:---:|:---:|---|
+| 0 | `0x40` | `0x02` | `0x00` | `0x10` | Debug En, Sel 0x2 |
+| 1 | `127` | `0x00` | `0x00` | `0x10` | Scale A = 1.0 |
+| 2 | `127` | `0x01` | `0x00` | `0x10` | Scale B = 1.0, Format B = E5M2 |
+| 3 | `0x7C` | `0x3C` | `0x00` | `0x10` | +Inf (0x7C) x 1.0 (0x3C) |
+| 4 | `0xFC` | `0x3C` | `0x00` | `0x10` | -Inf (0xFC) x 1.0 (0x3C) |
+| 5 | `0x3C` | `0x3C` | `0x00` | `0x50` | `inf_pos_sticky` (uo_out[6]) = 1 |
+| 6 | `0x3C` | `0x3C` | `0x00` | `0x70` | `inf_neg_sticky` (uo_out[5]) = 1 |

--- a/test/test_debug.py
+++ b/test/test_debug.py
@@ -225,3 +225,68 @@ async def test_debug_no_packed_interference(dut):
     actual = int(dut.uo_out.value)
     dut._log.info(f"Metadata Echo: {actual:02x}")
     assert (actual >> 6) & 1 == 0 # packed_mode_reg should be 0
+
+@cocotb.test()
+async def test_debug_exceptions(dut):
+    dut._log.info("Start Debug Exceptions Test")
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    support_serial_hw = get_param(dut, "SUPPORT_SERIAL", 0)
+    k = get_param(dut, "SERIAL_K_FACTOR", 1) if support_serial_hw else 1
+    pipelined = get_param(dut, "SUPPORT_PIPELINING", 1)
+
+    # 1. Test NaN and Infinities from elements using Probe 0x2
+    # Reset and configure for Debug Mode 0x2
+    await reset_with_debug(dut, debug_en=1, probe_sel=2)
+
+    # Cycle 1: Scale A = 1.0 (127), Format A = E5M2 (1)
+    dut.ui_in.value = 127
+    dut.uio_in.value = 1
+    await ClockCycles(dut.clk, k)
+
+    # Cycle 2: Scale B = 1.0 (127), Format B = E5M2 (1)
+    dut.ui_in.value = 127
+    dut.uio_in.value = 1
+    await ClockCycles(dut.clk, k)
+
+    # Cycle 3: Element A = NaN (0x7F), B = 1.0 (0x3C)
+    dut.ui_in.value = 0x7F
+    dut.uio_in.value = 0x3C
+    await ClockCycles(dut.clk, k)
+
+    # Cycle 4: Element A = +Inf (0x7C), B = 1.0 (0x3C)
+    dut.ui_in.value = 0x7C
+    dut.uio_in.value = 0x3C
+    await ClockCycles(dut.clk, k)
+
+    # Cycle 5: Element A = -Inf (0xFC), B = 1.0 (0x3C)
+    dut.ui_in.value = 0xFC
+    dut.uio_in.value = 0x3C
+    await ClockCycles(dut.clk, k)
+
+    # Wait for the last element's result to clear the pipeline if enabled
+    if pipelined:
+        await ClockCycles(dut.clk, k)
+
+    # Now check exception bits in uo_out
+    await Timer(1, unit="ns")
+    val = int(dut.uo_out.value)
+    dut._log.info(f"Exceptions Probe (Cycle {int(dut.user_project.cycle_count.value)}): {val:02x}")
+
+    # [7] nan_sticky, [6] inf_pos_sticky, [5] inf_neg_sticky, [4] strobe
+    assert (val >> 7) & 1 == 1, "nan_sticky bit 7 should be high"
+    assert (val >> 6) & 1 == 1, "inf_pos_sticky bit 6 should be high"
+    assert (val >> 5) & 1 == 1, "inf_neg_sticky bit 5 should be high"
+    # Bit 4 is strobe. In non-serial mode, strobe is always 1.
+    if not support_serial_hw:
+        assert (val >> 4) & 1 == 1, "strobe bit 4 should be high"
+
+    # 2. Test Scale-triggered NaN sticky flag
+    await reset_with_debug(dut, debug_en=1, probe_sel=2)
+    # Cycle 1: Load Scale A = 0xFF (NaN)
+    dut.ui_in.value = 0xFF
+    await ClockCycles(dut.clk, k)
+    await Timer(1, unit="ns")
+    # In Debug Mode 0x2, uo_out[7] (nan_sticky) should reflect the Scale NaN immediately
+    assert (int(dut.uo_out.value) >> 7) & 1 == 1, "nan_sticky bit 7 should be high from Scale A NaN"


### PR DESCRIPTION
This PR adds documentation and functional tests for the Logic Analyzer's Exception Monitor (Probe 0x2). It includes cycle-by-cycle sequences in `docs/test.md` and a new Cocotb test case in `test/test_debug.py` that verifies the sticky NaN and Infinity flags, as well as the strobe signal.

Key improvements:
- Clear distinction between shared scale NaNs (0xFF) and element NaNs.
- Explicit verification of the `strobe` bit in non-serial hardware configurations.
- Cleaned up test logic by removing redundant resets and abandoned code paths.

Fixes #716

---
*PR created automatically by Jules for task [9583719687414349936](https://jules.google.com/task/9583719687414349936) started by @chatelao*