### PR TITLE
Convert synchronous reset logic to asynchronous reset

### DIFF
--- a/src/accumulator.v
+++ b/src/accumulator.v
@@ -51,8 +51,9 @@ module accumulator #(
     // Overflow check: If the signs of the inputs are the same but the sign of the result is different.
     wire overflow = (acc_reg[WIDTH-1] == data_in[WIDTH-1]) && (sum[WIDTH-1] != acc_reg[WIDTH-1]);
 
-    // This 'always' block describes sequential logic that updates on the rising edge of the clock.
-    always @(posedge clk) begin
+    // This 'always' block describes sequential logic that updates on the rising edge of the clock
+    // or the falling edge of the asynchronous reset.
+    always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin
             // Reset: Asynchronous return to zero.
             acc_reg <= {REG_WIDTH{1'b0}};

--- a/src/fp8_mul_serial_lns.v
+++ b/src/fp8_mul_serial_lns.v
@@ -36,7 +36,7 @@ module fp8_mul_serial_lns #(
      * We need to know which bit of the 8-bit (or 16-bit internal) stream we are currently processing.
      */
     reg [3:0] cnt;
-    always @(posedge clk) begin
+    always @(posedge clk or negedge rst_n) begin
         if (!rst_n) cnt <= 4'd15;
         else if (ena) begin
             if (strobe) cnt <= 4'd0; // Reset counter on strobe.
@@ -135,7 +135,7 @@ module fp8_mul_serial_lns #(
     wire carry_s2_next = (sum_s1 & (~bit_bias)) | (carry_sub & (sum_s1 ^ (~bit_bias)));
 
     // Sequential update of carry bits.
-    always @(posedge clk) begin
+    always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin
             carry_adder <= 1'b0;
             carry_sub <= 1'b1; // Initial carry for subtraction (2's complement style).
@@ -162,7 +162,7 @@ module fp8_mul_serial_lns #(
     reg a_e_all_ones, b_e_all_ones;
     reg a_m_any_nonzero, b_m_any_nonzero;
 
-    always @(posedge clk) begin
+    always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin
             sign_a <= 1'b0; sign_b <= 1'b0;
             a_any_nonzero <= 1'b0; b_any_nonzero <= 1'b0;

--- a/src/project.v
+++ b/src/project.v
@@ -68,7 +68,7 @@ module tt_um_chatelao_fp8_multiplier #(
     generate
         if (SUPPORT_SERIAL) begin : gen_serial_ctrl
             reg [COUNTER_WIDTH-1:0] k_counter;
-            always @(posedge clk) begin
+            always @(posedge clk or negedge rst_n) begin
                 if (!rst_n) k_counter <= {COUNTER_WIDTH{1'b0}};
                 else if (ena) k_counter <= (k_counter == SERIAL_K_FACTOR[COUNTER_WIDTH-1:0] - {{ (COUNTER_WIDTH-1){1'b0} }, 1'b1}) ? {COUNTER_WIDTH{1'b0}} : k_counter + {{ (COUNTER_WIDTH-1){1'b0} }, 1'b1};
             end
@@ -114,7 +114,7 @@ module tt_um_chatelao_fp8_multiplier #(
             reg [3:0] probe_sel_reg;
             reg       loopback_en_reg;
 
-            always @(posedge clk) begin
+            always @(posedge clk or negedge rst_n) begin
                 if (!rst_n) begin
                     debug_en_reg <= 1'b0;
                     probe_sel_reg <= 4'd0;
@@ -169,7 +169,7 @@ module tt_um_chatelao_fp8_multiplier #(
             reg [2:0] nbm_offset_a;
             reg [2:0] nbm_offset_b;
             reg       mx_plus_en;
-            always @(posedge clk) begin
+            always @(posedge clk or negedge rst_n) begin
                 if (!rst_n) begin
                     bm_index_a <= 5'd0;
                     bm_index_b <= 5'd0;
@@ -226,16 +226,22 @@ module tt_um_chatelao_fp8_multiplier #(
             reg [7:0] fifo_a [0:15];
             reg [7:0] fifo_b [0:15];
             reg [3:0] write_ptr;
-            always @(posedge clk) begin
+            always @(posedge clk or negedge rst_n) begin
                 if (!rst_n) begin
                     write_ptr <= 4'd0;
                 end else if (ena && strobe) begin
                     if (state == STATE_IDLE) begin
                         write_ptr <= 4'd0;
                     end else if (state == STATE_STREAM && logical_cycle <= 6'd18) begin
+                        write_ptr <= write_ptr + 4'd1;
+                    end
+                end
+            end
+            always @(posedge clk) begin
+                if (ena && strobe) begin
+                    if (state == STATE_STREAM && logical_cycle <= 6'd18) begin
                         fifo_a[write_ptr] <= ui_in;
                         fifo_b[write_ptr] <= uio_in;
-                        write_ptr <= write_ptr + 4'd1;
                     end
                 end
             end
@@ -264,7 +270,7 @@ module tt_um_chatelao_fp8_multiplier #(
     generate
         if (ENABLE_SHARED_SCALING) begin : gen_scale_a
             reg [7:0] scale_a;
-            always @(posedge clk) begin
+            always @(posedge clk or negedge rst_n) begin
                 if (!rst_n) scale_a <= 8'd0;
                 else if (ena && strobe && logical_cycle == 6'd1) scale_a <= ui_in;
             end
@@ -275,7 +281,7 @@ module tt_um_chatelao_fp8_multiplier #(
 
         if (ENABLE_SHARED_SCALING) begin : gen_scale_b
             reg [7:0] scale_b;
-            always @(posedge clk) begin
+            always @(posedge clk or negedge rst_n) begin
                 if (!rst_n) scale_b <= 8'd0;
                 else if (ena && strobe && logical_cycle == 6'd2) scale_b <= ui_in;
             end
@@ -286,7 +292,7 @@ module tt_um_chatelao_fp8_multiplier #(
 
         if (SUPPORT_MIXED_PRECISION && !FIXED_FORMAT) begin : gen_format_b
             reg [2:0] format_b;
-            always @(posedge clk) begin
+            always @(posedge clk or negedge rst_n) begin
                 if (!rst_n) format_b <= 3'd0;
                 else if (ena && strobe) begin
                     if (logical_cycle == 6'd0 && ui_in[7])
@@ -332,7 +338,7 @@ module tt_um_chatelao_fp8_multiplier #(
      * Cycle Counter and Main FSM Controller
      * Captures configuration metadata and advances the protocol state.
      */
-    always @(posedge clk) begin
+    always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin
             cycle_count <= {COUNTER_WIDTH{1'b0}};
             format_a_reg <= 3'd0;
@@ -388,7 +394,7 @@ module tt_um_chatelao_fp8_multiplier #(
 
     // Buffer for packed elements in bit-serial modes.
     reg [3:0] packed_a_buf, packed_b_buf;
-    always @(posedge clk) begin
+    always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin
             packed_a_buf <= 4'd0;
             packed_b_buf <= 4'd0;
@@ -545,7 +551,7 @@ module tt_um_chatelao_fp8_multiplier #(
             reg mul_nan_lane0_reg, mul_inf_lane0_reg;
             reg is_bm_a_lane0_reg, is_bm_b_lane0_reg;
 
-            always @(posedge clk) begin
+            always @(posedge clk or negedge rst_n) begin
                 if (!rst_n) begin
                     mul_prod_lane0_reg <= 16'd0;
                     mul_exp_sum_lane0_reg <= {EXP_SUM_WIDTH{1'b0}};
@@ -579,7 +585,7 @@ module tt_um_chatelao_fp8_multiplier #(
                 reg mul_nan_lane1_reg, mul_inf_lane1_reg;
                 reg is_bm_a_lane1_reg, is_bm_b_lane1_reg;
 
-                always @(posedge clk) begin
+                always @(posedge clk or negedge rst_n) begin
                     if (!rst_n) begin
                         mul_prod_lane1_reg <= 16'd0;
                         mul_exp_sum_lane1_reg <= {EXP_SUM_WIDTH{1'b0}};
@@ -640,7 +646,7 @@ module tt_um_chatelao_fp8_multiplier #(
     // This avoids Cycle 1/2 (Scales) and Cycle 3 (Pipelined garbage).
     wire sticky_latch_en = (logical_cycle >= (SUPPORT_PIPELINING ? 6'd4 : 6'd3)) && (logical_cycle <= last_stream_cycle + (SUPPORT_PIPELINING ? 6'd1 : 6'd0));
 
-    always @(posedge clk) begin
+    always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin
             nan_sticky <= 1'b0;
             inf_pos_sticky <= 1'b0;
@@ -835,7 +841,7 @@ module tt_um_chatelao_fp8_multiplier #(
      */
     // 0. Formal-only capture register for serialization verification
     reg [31:0] f_scaled_acc_reg;
-    always @(posedge clk) begin
+    always @(posedge clk or negedge rst_n) begin
         if (!rst_n) f_scaled_acc_reg <= 32'd0;
         else if (ena && strobe && logical_cycle == capture_cycle) f_scaled_acc_reg <= final_scaled_result;
     end

--- a/test/test_async_reset.py
+++ b/test/test_async_reset.py
@@ -1,0 +1,79 @@
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import FallingEdge, RisingEdge, Timer
+
+@cocotb.test()
+async def test_asynchronous_reset(dut):
+    """Verify that rst_n acts as an asynchronous reset."""
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    # Initialize
+    dut.rst_n.value = 1
+    dut.ena.value = 1
+    dut.ui_in.value = 0
+    dut.uio_in.value = 0
+
+    # Wait for a few clock cycles
+    await RisingEdge(dut.clk)
+    await RisingEdge(dut.clk)
+
+    # Set some state (cycle_count)
+    # We can't directly set cycle_count because it's internal,
+    # but we can advance the protocol.
+    # In STATE_IDLE (cycle 0), if ui_in[7]=0, it goes to cycle 1.
+    dut.ui_in.value = 0x00
+    await RisingEdge(dut.clk)
+    # Now it should be cycle 1.
+    # We can check uo_out if debug is enabled, but let's just assume it advanced.
+
+    # Assert reset in the middle of the clock cycle
+    await Timer(5, units="ns")
+    dut.rst_n.value = 0
+
+    # Immediately check if reset took effect (asynchronous)
+    await Timer(1, units="ns")
+
+    # We need a way to verify internal state.
+    # tt_um_chatelao_fp8_multiplier has a debug mode.
+    # If we enable debug mode and select a probe, we can see internal state.
+    # Probe 1: {state, logical_cycle[5:0]}
+
+    # Let's restart with debug enabled.
+    dut.rst_n.value = 1
+    dut.ui_in.value = 0x40 # debug_en (ui_in[6])
+    dut.uio_in.value = 0x01 # probe_sel = 1 (uio_in[3:0])
+    await RisingEdge(dut.clk) # Samples Cycle 0
+
+    # Cycle 1
+    await RisingEdge(dut.clk)
+
+    # Verify we are not at 0
+    assert dut.uo_out.value != 0, "Should have non-zero probe data in Cycle 1"
+
+    # Assert reset asynchronously
+    await Timer(5, units="ns")
+    dut.rst_n.value = 0
+    await Timer(1, units="ns")
+
+    # In Cycle 0, probe 1 output is probe_data which is {state, cycle} = {0, 0} = 0.
+    # But wait, Cycle 0 output is:
+    # (debug_en_val && logical_cycle < capture_cycle) ? probe_data : 8'h00;
+    # logical_cycle is 0. state is IDLE (0). probe_data for probe 1 is 0.
+
+    # Let's use a different probe or just check if it's 0.
+    # Actually, if it resets to 0, it should be 0.
+    assert dut.uo_out.value == 0, f"uo_out should be 0 after async reset, got {dut.uo_out.value}"
+
+    # Verify it stays 0
+    await RisingEdge(dut.clk)
+    assert dut.uo_out.value == 0
+
+    # Release reset
+    dut.rst_n.value = 1
+    await RisingEdge(dut.clk)
+    # Should advance to Cycle 1 again (if ui_in still has debug_en)
+    # Actually Cycle 0 is sampled at posedge.
+    # If we release it after posedge, next posedge will sample Cycle 0.
+    await RisingEdge(dut.clk)
+    assert dut.uo_out.value != 0


### PR DESCRIPTION
The codebase was using synchronous resets for most of its sequential logic, which contradicts the interface documentation requirement for asynchronous resets. This PR converts all relevant `always` blocks to use asynchronous reset sensitivity (`negedge rst_n`). It also optimizes the FIFO implementation by keeping the memory arrays synchronous to avoid synthesis overhead/errors while ensuring pointers are correctly reset asynchronously.

Fixes #721

---
*PR created automatically by Jules for task [925703202542482251](https://jules.google.com/task/925703202542482251) started by @chatelao*