### PR TITLE
Fix circuit render task by using external TeX file

### DIFF
--- a/.github/workflows/render_circuit.yml
+++ b/.github/workflows/render_circuit.yml
@@ -3,7 +3,7 @@ name: render_circuit
 on:
   push:
     paths:
-      - 'CIRCUIT.md'
+      - 'docs/diagrams/CIRCUIT.tex'
       - 'scripts/render_circuit.py'
       - '.github/workflows/render_circuit.yml'
   workflow_dispatch:

--- a/docs/diagrams/CIRCUIT.tex
+++ b/docs/diagrams/CIRCUIT.tex
@@ -1,0 +1,40 @@
+    % Module Boundary
+    \draw[thick] (0,0) rectangle (10,8);
+    \node[anchor=north] at (5,7.8) {\large \textbf{tt\_um\_chatelao\_fp8\_multiplier}};
+
+    % Input Ports (LHS)
+    \draw (-1,6.5) node[anchor=east] {ui\_in[7:0]} -- (0,6.5);
+    \draw (-1,5.5) node[anchor=east] {uio\_in[7:0]} -- (0,5.5);
+    \draw (-1,3.5) node[anchor=east] {clk} -- (0,3.5);
+    \draw (-1,2.5) node[anchor=east] {rst\_n} -- (0,2.5);
+    \draw (-1,1.5) node[anchor=east] {ena} -- (0,1.5);
+
+    % Functional Blocks
+    \draw (1,4.5) rectangle (3,7.5) node[midway, align=center] {FSM \&\\Control\\Logic};
+    \draw (4,5) rectangle (6,7) node[midway, align=center] {Dual\\Multiplier\\Lanes};
+    \draw (7,5) rectangle (9,7) node[midway, align=center] {Dual\\Aligner\\Stage};
+    \draw (7,1) rectangle (9,3) node[midway, align=center] {32-bit\\Accumulator\\\& Serializer};
+
+    % Connections
+    % Data paths
+    \draw[->, thick] (3,6) -- (4,6); % FSM to Multiplier
+    \draw[->, thick] (6,6) -- (7,6); % Multiplier to Aligner
+    \draw[->, thick] (8,5) -- (8,3); % Aligner to Accumulator
+
+    % Input to FSM/Mul
+    \draw[->] (0.5,6.5) |- (1,6);
+    \draw[->] (0.5,5.5) |- (1,5);
+
+    % Control lines from FSM
+    \draw[->, dashed] (2,4.5) |- (5,4) -- (5,5); % FSM to Multiplier control
+    \draw[->, dashed] (2,4.5) |- (8,4) -- (8,5); % FSM to Aligner control
+    \draw[->, dashed] (2,4.5) |- (7,2);           % FSM to Accumulator control
+
+    % Output Ports (RHS)
+    \draw (9,2) -- (11,2) node[anchor=west] {uo\_out[7:0]};
+
+    % Legend
+    \draw[dashed] (0.5,0.5) rectangle (4,2.5);
+    \node[anchor=west] at (0.6,2.2) {\small \textbf{Legend:}};
+    \draw[thick] (0.8,1.7) -- (1.5,1.7) node[right] {\scriptsize Data Path};
+    \draw[dashed] (0.8,1.2) -- (1.5,1.2) node[right] {\scriptsize Control Path};

--- a/scripts/render_circuit.py
+++ b/scripts/render_circuit.py
@@ -1,28 +1,19 @@
 import os
 import subprocess
-import re
 import sys
 
 def main():
-    circuit_md_path = 'CIRCUIT.md'
+    circuit_tex_path = 'docs/diagrams/CIRCUIT.tex'
     output_svg_path = 'docs/circuit.svg'
     temp_tex_path = 'circuit_temp.tex'
     temp_dvi_path = 'circuit_temp.dvi'
 
-    if not os.path.exists(circuit_md_path):
-        print(f"Error: {circuit_md_path} not found.")
+    if not os.path.exists(circuit_tex_path):
+        print(f"Error: {circuit_tex_path} not found.")
         sys.exit(1)
 
-    with open(circuit_md_path, 'r') as f:
-        content = f.read()
-
-    # Extract LaTeX block between $$ and $$
-    match = re.search(r'\$\$(.*?)\$\$', content, re.DOTALL)
-    if not match:
-        print("Error: No LaTeX block found in CIRCUIT.md")
-        sys.exit(1)
-
-    latex_code = match.group(1).strip()
+    with open(circuit_tex_path, 'r') as f:
+        latex_code = f.read().strip()
 
     # Wrap in standalone tikz document
     tex_template = r"""\documentclass[tikz]{standalone}


### PR DESCRIPTION
The circuit diagram rendering task was failing because the LaTeX TikZ block was removed from `CIRCUIT.md` but the rendering script still expected to find it there using regex. This PR restores the TikZ block from a previous commit into a dedicated external file `docs/diagrams/CIRCUIT.tex` and updates both the rendering script and the GitHub Action workflow to use this new file. This approach is more robust as it eliminates the need for regex-based extraction and simplifies the maintenance of the circuit diagram. Verified with project tests and code inspection.

Fixes #739

---
*PR created automatically by Jules for task [1002261745715223225](https://jules.google.com/task/1002261745715223225) started by @chatelao*