### PR TITLE
Fix GitHub Action CI/CD Workflows

### DIFF
--- a/.github/workflows/diagram.yaml
+++ b/.github/workflows/diagram.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Install Graphviz
         run: sudo apt-get update && sudo apt-get install -y graphviz

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/fpga.yaml
+++ b/.github/workflows/fpga.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -50,7 +50,7 @@ jobs:
       id-token: write # to verify the deployment originates from an appropriate source
     steps:
       - name: checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/gowin.yaml
+++ b/.github/workflows/gowin.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -27,7 +27,6 @@ jobs:
         uses: YosysHQ/setup-oss-cad-suite@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: '2026-03-13'
 
       - name: Install Apycula dependencies
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Install Verilator
         shell: bash
@@ -13,4 +13,4 @@ jobs:
 
       - name: Run Verilator Lint
         shell: bash
-        run: verilator --lint-only -Wall -Isrc/ --top-module tt_um_chatelao_fp8_multiplier src/project.v
+        run: verilator --lint-only -Wall -Isrc/ --top-module tt_um_chatelao_fp8_multiplier src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
         config: [Full, Lite, Tiny, Ultra-Tiny, Tiny-Serial]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -18,7 +18,7 @@ jobs:
 
       # Set Python up and install cocotb
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -35,9 +35,9 @@ jobs:
         if: matrix.config == 'Full'
         run: |
           # Verify compilation of all M3 modes using iverilog
-          for mode in M3_MODE_GPIO M3_MODE_APB M3_MODE_AHB; do
+          for mode in M3_MODE_GPIO M3_MODE_APB M3_MODE_AHB M3_MODE_AHB_DMA; do
             echo "Verifying $mode..."
-            iverilog -g2012 -Isrc -D$mode src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v -o m3_test
+            iverilog -g2012 -Isrc -D$mode src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v src_gowin/ahb2_mac_bridge.v -o m3_test
             rm m3_test
           done
 
@@ -51,7 +51,7 @@ jobs:
           elif [ "${{ matrix.config }}" == "Tiny" ]; then
             export COMPILE_ARGS="-P tb.ALIGNER_WIDTH=40 -P tb.ACCUMULATOR_WIDTH=32 -P tb.SUPPORT_E5M2=0 -P tb.SUPPORT_MXFP6=0 -P tb.SUPPORT_MXFP4=1 -P tb.SUPPORT_INT8=0 -P tb.SUPPORT_PIPELINING=0 -P tb.SUPPORT_ADV_ROUNDING=0 -P tb.SUPPORT_MIXED_PRECISION=0 -P tb.ENABLE_SHARED_SCALING=0 -P tb.SUPPORT_SERIAL=0 -P tb.SERIAL_K_FACTOR=1"
           elif [ "${{ matrix.config }}" == "Ultra-Tiny" ]; then
-            export COMPILE_ARGS="-P tb.SUPPORT_SERIAL=0 -P tb.SERIAL_K_FACTOR=1"
+            export COMPILE_ARGS="-P tb.ALIGNER_WIDTH=32 -P tb.ACCUMULATOR_WIDTH=24 -P tb.SUPPORT_E5M2=0 -P tb.SUPPORT_MXFP6=0 -P tb.SUPPORT_MXFP4=1 -P tb.SUPPORT_INT8=0 -P tb.SUPPORT_PIPELINING=0 -P tb.SUPPORT_ADV_ROUNDING=0 -P tb.SUPPORT_MIXED_PRECISION=0 -P tb.ENABLE_SHARED_SCALING=0 -P tb.SUPPORT_SERIAL=0 -P tb.SERIAL_K_FACTOR=1"
           elif [ "${{ matrix.config }}" == "Tiny-Serial" ]; then
             export COMPILE_ARGS="-P tb.SUPPORT_SERIAL=1 -P tb.SERIAL_K_FACTOR=8"
           fi

--- a/test/list_tests.py
+++ b/test/list_tests.py
@@ -13,7 +13,7 @@ def list_tests(module_name):
                 tests.append(name)
         return tests
     except Exception as e:
-        # print(f"Error importing {module_name}: {e}", file=sys.stderr)
+        print(f"Error importing {module_name}: {e}", file=sys.stderr)
         return []
 
 if __name__ == "__main__":

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,4 @@
 pytest==8.4.2
 cocotb==2.0.1
 cocotb-coverage>=1.2.0
+pyyaml


### PR DESCRIPTION
This PR fixes several critical issues in the CI/CD pipelines that were preventing successful builds and testing:

1. **Invalid Action Versions**: Replaced non-existent `v6` versions of standard GitHub actions with their latest stable counterparts (`v4` for checkout, `v5` for setup-python).
2. **Missing Dependencies**: Added `pyyaml` to `test/requirements.txt`, which was causing silent failures in `test/list_tests.py` and resulting in zero tests being executed.
3. **Improved Test Discovery**: Updated `test/list_tests.py` to print import errors to stderr, making future dependency issues visible in CI logs.
4. **Hardware Verification Alignment**: 
    - Updated the `Ultra-Tiny` configuration in the test matrix to use the correct 32-bit aligner and 24-bit accumulator widths.
    - Expanded the M3 integration check to include `M3_MODE_AHB_DMA` and added the necessary `ahb2_mac_bridge.v` source file to the compilation command.
5. **Comprehensive Linting**: Fixed `lint.yaml` to run Verilator against the entire set of project source files instead of just the top-level module.
6. **Tooling Fixes**: Corrected the `setup-oss-cad-suite` version in `gowin.yaml` from an invalid future date to the default latest version.

Fixes #741

---
*PR created automatically by Jules for task [437575779238708222](https://jules.google.com/task/437575779238708222) started by @chatelao*