### PR TITLE
Style internal datapath diagram with green boxes and black arrows

### DIFF
--- a/docs/diagrams/DATAPATH_DIAGRAM.PUML
+++ b/docs/diagrams/DATAPATH_DIAGRAM.PUML
@@ -6,33 +6,33 @@ LAYOUT_WITH_LEGEND()
 ' Green Theme Overrides
 skinparam backgroundColor white
 skinparam component {
-    BackgroundColor #E8F5E9
-    BorderColor #2E7D32
-    FontColor #1B5E20
+    BackgroundColor #90EE90
+    BorderColor #006400
+    FontColor #000000
 }
 skinparam rectangle<<container>> {
-    BackgroundColor #F1F8E9
-    BorderColor #33691E
-    FontColor #1B5E20
+    BackgroundColor #90EE90
+    BorderColor #006400
+    FontColor #000000
 }
 skinparam rectangle<<boundary>> {
     FontSize 20
-    BorderColor #2E7D32
-    FontColor #1B5E20
+    BorderColor #006400
+    FontColor #000000
 }
 skinparam rectangle<<container_boundary>> {
     FontSize 20
-    BorderColor #2E7D32
-    FontColor #1B5E20
+    BorderColor #006400
+    FontColor #000000
 }
 skinparam rectangle<<system_boundary>> {
     FontSize 20
-    BorderColor #2E7D32
-    FontColor #1B5E20
+    BorderColor #006400
+    FontColor #000000
 }
 skinparam Arrow {
-    Color #2E7D32
-    FontColor #1B5E20
+    Color black
+    FontColor black
 }
 skinparam legend {
     BackgroundColor #E8F5E9


### PR DESCRIPTION
This change updates the PlantUML styling for the internal datapath diagram. 

Specifically:
- Updated `component` and `rectangle` background colors to `#90EE90` (Light Green).
- Updated `component` and `rectangle` border colors to `#006400` (Dark Green).
- Set `Arrow` color and font color to `black`.
- Set component and rectangle font colors to `black` for better contrast against the green background.

These changes ensure the diagram matches the user's requested color scheme while improving overall readability. Verification was performed by running the project's test suite to ensure no regressions in documentation build or verification workflows.

Fixes #744

---
*PR created automatically by Jules for task [17112230227627530435](https://jules.google.com/task/17112230227627530435) started by @chatelao*