### PR TITLE
Implement Snitch Accelerator Interface Components

### DIFF
--- a/snitch-core/accelerator/SOURCES.txt
+++ b/snitch-core/accelerator/SOURCES.txt
@@ -1,0 +1,15 @@
+# PULP Snitch Accelerator Interface Implementations - Source URLs
+
+snitch_fp_ss.sv: https://raw.githubusercontent.com/pulp-platform/snitch/master/hw/ip/snitch_cluster/src/snitch_fp_ss.sv
+snitch_fpu.sv: https://raw.githubusercontent.com/pulp-platform/snitch/master/hw/ip/snitch_cluster/src/snitch_fpu.sv
+snitch_sequencer.sv: https://raw.githubusercontent.com/pulp-platform/snitch/master/hw/ip/snitch_cluster/src/snitch_sequencer.sv
+snitch_shared_muldiv.sv: https://raw.githubusercontent.com/pulp-platform/snitch/master/hw/ip/snitch_cluster/src/snitch_shared_muldiv.sv
+snitch_int_ss.sv: https://raw.githubusercontent.com/pulp-platform/snitch/master/hw/ip/snitch_ipu/src/snitch_int_ss.sv
+snitch_ipu_alu.sv: https://raw.githubusercontent.com/pulp-platform/snitch/master/hw/ip/snitch_ipu/src/snitch_ipu_alu.sv
+snitch_ipu_pkg.sv: https://raw.githubusercontent.com/pulp-platform/snitch/master/hw/ip/snitch_ipu/src/snitch_ipu_pkg.sv
+axi_dma_tc_snitch_fe.sv: https://raw.githubusercontent.com/pulp-platform/snitch/master/hw/ip/snitch_dma/src/axi_dma_tc_snitch_fe.sv
+axi_dma_pkg.sv: https://raw.githubusercontent.com/pulp-platform/snitch/master/hw/ip/snitch_dma/src/axi_dma_pkg.sv
+snitch_ssr.sv: https://raw.githubusercontent.com/pulp-platform/snitch/master/hw/ip/snitch_ssr/src/snitch_ssr.sv
+snitch_ssr_pkg.sv: https://raw.githubusercontent.com/pulp-platform/snitch/master/hw/ip/snitch_ssr/src/snitch_ssr_pkg.sv
+
+Note: These files were downloaded from the main 'snitch' repository. The 'snitch_cluster' repository is also a valid source but follows a slightly different directory structure.

--- a/snitch-core/accelerator/axi_dma_pkg.sv
+++ b/snitch-core/accelerator/axi_dma_pkg.sv
@@ -1,0 +1,25 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Thomas Benz <tbenz@ethz.ch>
+
+`include "axi/typedef.svh"
+
+// for now this is an extended copy of the axi_pkg
+// eventually the DMA specific parts should be moved in axi_pkg aswell
+package axi_dma_pkg;
+
+  typedef struct packed {
+      logic [63:0] aw_stall_cnt, ar_stall_cnt, r_stall_cnt, w_stall_cnt,
+                   buf_w_stall_cnt, buf_r_stall_cnt;
+      logic [63:0] aw_valid_cnt, aw_ready_cnt, aw_done_cnt, aw_bw;
+      logic [63:0] ar_valid_cnt, ar_ready_cnt, ar_done_cnt, ar_bw;
+      logic [63:0]  r_valid_cnt,  r_ready_cnt,  r_done_cnt,  r_bw;
+      logic [63:0]  w_valid_cnt,  w_ready_cnt,  w_done_cnt,  w_bw;
+      logic [63:0]  b_valid_cnt,  b_ready_cnt,  b_done_cnt;
+      logic [63:0] next_id,       completed_id;
+      logic [63:0] dma_busy_cnt;
+  } dma_perf_t;
+
+endpackage

--- a/snitch-core/accelerator/axi_dma_tc_snitch_fe.sv
+++ b/snitch-core/accelerator/axi_dma_tc_snitch_fe.sv
@@ -1,0 +1,363 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Thomas Benz <tbenz@ethz.ch>
+
+// Implements the tightly-coupled frontend. This module can directly be connected
+// to an accelerator bus in the snitch system
+
+`include "common_cells/registers.svh"
+
+module axi_dma_tc_snitch_fe #(
+    parameter int unsigned AddrWidth     = 0,
+    parameter int unsigned DataWidth     = 0,
+    parameter int unsigned DMADataWidth  = 0,
+    parameter int unsigned IdWidth       = 0,
+    parameter int unsigned DMAAxiReqFifoDepth = 3,
+    parameter int unsigned DMAReqFifoDepth    = 3,
+    parameter type         axi_req_t     = logic,
+    parameter type         axi_res_t     = logic,
+    parameter type         acc_resp_t    = logic,
+    parameter type         dma_events_t  = logic,
+    /// Derived parameter *Do not override*
+    parameter type addr_t = logic [AddrWidth-1:0],
+    parameter type data_t = logic [DataWidth-1:0]
+) (
+    input  logic           clk_i,
+    input  logic           rst_ni,
+    // AXI4 bus
+    output axi_req_t       axi_dma_req_o,
+    input  axi_res_t       axi_dma_res_i,
+    // debug output
+    output logic           dma_busy_o,
+    // accelerator interface
+    input  logic [31:0]    acc_qaddr_i,
+    input  logic [ 4:0]    acc_qid_i,
+    input  logic [31:0]    acc_qdata_op_i,
+    input  data_t          acc_qdata_arga_i,
+    input  data_t          acc_qdata_argb_i,
+    input  addr_t          acc_qdata_argc_i,
+    input  logic           acc_qvalid_i,
+    output logic           acc_qready_o,
+
+    output data_t          acc_pdata_o,
+    output logic [ 4:0]    acc_pid_o,
+    output logic           acc_perror_o,
+    output logic           acc_pvalid_o,
+    input  logic           acc_pready_i,
+
+    // hart id of the frankensnitch
+    input  logic [31:0]       hart_id_i,
+
+    // performance output
+    output axi_dma_pkg::dma_perf_t dma_perf_o,
+    output dma_events_t dma_events_o
+);
+
+    typedef logic [IdWidth-1:0] id_t;
+
+    typedef struct packed {
+        id_t              id;
+        addr_t            src, dst, num_bytes;
+        axi_pkg::cache_t  cache_src, cache_dst;
+        axi_pkg::burst_t  burst_src, burst_dst;
+        logic             decouple_rw;
+        logic             deburst;
+        logic             serialize;
+    } burst_req_t;
+
+    typedef struct packed {
+        id_t              id;
+        addr_t            src, dst, num_bytes;
+        axi_pkg::cache_t  cache_src, cache_dst;
+        addr_t            stride_src, stride_dst, num_repetitions;
+        axi_pkg::burst_t  burst_src, burst_dst;
+        logic             decouple_rw;
+        logic             deburst;
+        logic             is_twod;
+    } twod_req_t;
+
+    //--------------------------------------
+    // Backend Instanciation
+    //--------------------------------------
+    logic backend_idle;
+    burst_req_t burst_req;
+    logic burst_req_valid;
+    logic burst_req_ready;
+    logic oned_trans_complete;
+
+    axi_dma_backend #(
+        .DataWidth       ( DMADataWidth ),
+        .AddrWidth       ( AddrWidth ),
+        .IdWidth         ( IdWidth ),
+        .AxReqFifoDepth  ( DMAAxiReqFifoDepth ),
+        .TransFifoDepth  ( DMAReqFifoDepth ),
+        .BufferDepth     ( 3 ),
+        .axi_req_t       ( axi_req_t ),
+        .axi_res_t       ( axi_res_t ),
+        .burst_req_t     ( burst_req_t ),
+        .DmaIdWidth      ( 32 ),
+        .DmaTracing      ( 1 )
+    ) i_axi_dma_backend (
+        .clk_i            ( clk_i               ),
+        .rst_ni           ( rst_ni              ),
+        .axi_dma_req_o    ( axi_dma_req_o       ),
+        .axi_dma_res_i    ( axi_dma_res_i       ),
+        .burst_req_i      ( burst_req           ),
+        .valid_i          ( burst_req_valid     ),
+        .ready_o          ( burst_req_ready     ),
+        .backend_idle_o   ( backend_idle        ),
+        .trans_complete_o ( oned_trans_complete ),
+        .dma_id_i         ( hart_id_i           )
+    );
+
+    //--------------------------------------
+    // 2D Extension
+    //--------------------------------------
+    twod_req_t twod_req_d, twod_req_q;
+    logic      twod_req_valid;
+    logic      twod_req_ready;
+    logic      twod_req_last;
+
+    axi_dma_twod_ext #(
+        .ADDR_WIDTH       ( AddrWidth   ),
+        .REQ_FIFO_DEPTH   ( DMAReqFifoDepth ),
+        .burst_req_t      ( burst_req_t ),
+        .twod_req_t       ( twod_req_t )
+    ) i_axi_dma_twod_ext (
+        .clk_i                ( clk_i           ),
+        .rst_ni               ( rst_ni          ),
+        .twod_req_i           ( twod_req_d      ),
+        .twod_req_valid_i     ( twod_req_valid  ),
+        .twod_req_ready_o     ( twod_req_ready  ),
+        .burst_req_o          ( burst_req       ),
+        .burst_req_valid_o    ( burst_req_valid ),
+        .burst_req_ready_i    ( burst_req_ready ),
+        .twod_req_last_o      ( twod_req_last   )
+    );
+
+    //--------------------------------------
+    // Buffer twod last
+    //--------------------------------------
+    localparam int unsigned TwodBufferDepth = 2 * (DMAReqFifoDepth +
+        DMAAxiReqFifoDepth) + 3 + 1;
+    logic twod_req_last_realigned;
+    fifo_v3 # (
+        .DATA_WIDTH  (  1                 ),
+        .DEPTH       ( TwodBufferDepth  )
+    ) i_fifo_v3_last_twod_buffer (
+        .clk_i       ( clk_i                             ),
+        .rst_ni      ( rst_ni                            ),
+        .flush_i     ( 1'b0                              ),
+        .testmode_i  ( 1'b0                              ),
+        .full_o      ( ),
+        .empty_o     ( ),
+        .usage_o     ( ),
+        .data_i      ( twod_req_last                     ),
+        .push_i      ( burst_req_valid & burst_req_ready ),
+        .data_o      ( twod_req_last_realigned           ),
+        .pop_i       ( oned_trans_complete               )
+    );
+
+    //--------------------------------------
+    // ID gen
+    //--------------------------------------
+    logic [31:0] next_id;
+    logic [31:0] completed_id;
+
+    `FFL(next_id, next_id + 'h1, twod_req_valid & twod_req_ready, 0)
+    `FFL(completed_id, completed_id + 'h1, oned_trans_complete & twod_req_last_realigned, 0)
+
+    // dma is busy when it is not idle
+    assign dma_busy_o = next_id != completed_id;
+
+    //--------------------------------------
+    // Performance counters
+    //--------------------------------------
+    axi_dma_perf_counters #(
+        .TRANSFER_ID_WIDTH  ( 32           ),
+        .DATA_WIDTH         ( DMADataWidth ),
+        .axi_req_t          ( axi_req_t    ),
+        .axi_res_t          ( axi_res_t    ),
+        .dma_events_t       ( dma_events_t )
+    ) i_axi_dma_perf_counters (
+        .clk_i           ( clk_i               ),
+        .rst_ni          ( rst_ni              ),
+        .axi_dma_req_i   ( axi_dma_req_o       ),
+        .axi_dma_res_i   ( axi_dma_res_i       ),
+        .next_id_i       ( next_id             ),
+        .completed_id_i  ( completed_id        ),
+        .dma_busy_i      ( dma_busy_o          ),
+        .dma_perf_o      ( dma_perf_o          ),
+        .dma_events_o    ( dma_events_o        )
+    );
+
+    //--------------------------------------
+    // Spill register for response channel
+    //--------------------------------------
+    acc_resp_t acc_pdata_spill, acc_pdata;
+    logic acc_pvalid_spill;
+    logic acc_pready_spill;
+
+    // the response path needs to be decoupled
+    spill_register #(
+        .T            ( acc_resp_t )
+    ) i_spill_register_dma_resp (
+        .clk_i        ( clk_i            ),
+        .rst_ni       ( rst_ni           ),
+        .valid_i      ( acc_pvalid_spill ),
+        .ready_o      ( acc_pready_spill ),
+        .data_i       ( acc_pdata_spill   ),
+        .valid_o      ( acc_pvalid_o     ),
+        .ready_i      ( acc_pready_i     ),
+        .data_o       ( acc_pdata         )
+    );
+
+    assign acc_pdata_o  = acc_pdata.data;
+    assign acc_pid_o    = acc_pdata.id;
+    assign acc_perror_o = acc_pdata.error;
+
+    //--------------------------------------
+    // Instruction decode
+    //--------------------------------------
+    logic            is_dma_op;
+    logic [12*8-1:0] dma_op_name;
+
+    always_comb begin : proc_fe_inst_decode
+        twod_req_d            = twod_req_q;
+        twod_req_d.burst_src  = axi_pkg::BURST_INCR;
+        twod_req_d.burst_dst  = axi_pkg::BURST_INCR;
+        twod_req_d.cache_src  = axi_pkg::CACHE_MODIFIABLE;
+        twod_req_d.cache_dst  = axi_pkg::CACHE_MODIFIABLE;
+        twod_req_valid        = 1'b0;
+        acc_qready_o          = 1'b0;
+        acc_pdata_spill       = '0;
+        acc_pdata_spill.error = 1'b1;
+        acc_pvalid_spill      = 1'b0;
+
+        // debug signal
+        is_dma_op        = 1'b0;
+        dma_op_name      = "Invalid";
+
+        // decode
+        if (acc_qvalid_i == 1'b1) begin
+          unique casez (acc_qdata_op_i)
+
+              // manipulate the source register
+              riscv_instr::DMSRC : begin
+                  twod_req_d.src[31: 0] = acc_qdata_arga_i[31:0];
+                  twod_req_d.src[AddrWidth-1:32] = acc_qdata_argb_i[AddrWidth-1-32: 0];
+                  acc_qready_o = 1'b1;
+                  is_dma_op    = 1'b1;
+                  dma_op_name  = "DMSRC";
+              end
+
+              // manipulate the destination register
+              riscv_instr::DMDST : begin
+                  twod_req_d.dst[31: 0] = acc_qdata_arga_i[31:0];
+                  twod_req_d.dst[AddrWidth-1:32] = acc_qdata_argb_i[AddrWidth-1-32: 0];
+                  acc_qready_o = 1'b1;
+                  is_dma_op    = 1'b1;
+                  dma_op_name  = "DMDST";
+              end
+
+              // start the DMA
+              riscv_instr::DMCPYI,
+              riscv_instr::DMCPY : begin
+                  automatic logic [1:0] cfg;
+
+                  // Parse the transfer parameters from the register or immediate.
+                  cfg = '0;
+                  unique casez (acc_qdata_op_i)
+                      riscv_instr::DMCPYI : cfg = acc_qdata_op_i[24:20];
+                      riscv_instr::DMCPY :  cfg = acc_qdata_argb_i;
+                      default:;
+                  endcase
+                  dma_op_name = "DMCPY";
+                  is_dma_op   = 1'b1;
+
+                  twod_req_d.num_bytes   = acc_qdata_arga_i;
+                  twod_req_d.decouple_rw = cfg[0];
+                  twod_req_d.is_twod     = cfg[1];
+
+                  // Perform the following sequence:
+                  // 1. wait for acc response channel to be ready (pready)
+                  // 2. request twod transfer (valid)
+                  // 3. wait for twod transfer to be accepted (ready)
+                  // 4. send acc response (pvalid)
+                  // 5. acknowledge acc request (qready)
+                  if (acc_pready_spill) begin
+                      twod_req_valid = 1'b1;
+                      if (twod_req_ready) begin
+                          acc_pdata_spill.id    = acc_qid_i;
+                          acc_pdata_spill.data  = next_id;
+                          acc_pdata_spill.error = 1'b0;
+                          acc_pvalid_spill      = 1'b1;
+                          acc_qready_o          = twod_req_ready;
+                      end
+                  end
+              end
+
+              // status of the DMA
+              riscv_instr::DMSTATI,
+              riscv_instr::DMSTAT: begin
+                  automatic logic [1:0] status;
+
+                  // Parse the status index from the register or immediate.
+                  status = '0;
+                  unique casez (acc_qdata_op_i)
+                      riscv_instr::DMSTATI: status = acc_qdata_op_i[24:20];
+                      riscv_instr::DMSTAT:  status = acc_qdata_argb_i;
+                      default:;
+                  endcase
+                  dma_op_name = "DMSTAT";
+                  is_dma_op   = 1'b1;
+
+                  // Compose the response.
+                  acc_pdata_spill.id    = acc_qid_i;
+                  acc_pdata_spill.error = 1'b0;
+                  case (status)
+                      2'b00 : acc_pdata_spill.data = completed_id;
+                      2'b01 : acc_pdata_spill.data = next_id;
+                      2'b10 : acc_pdata_spill.data = {{{8'd63}{1'b0}}, dma_busy_o};
+                      2'b11 : acc_pdata_spill.data = {{{8'd63}{1'b0}}, !twod_req_ready};
+                      default:;
+                  endcase
+
+                  // Wait for acc response channel to become ready, then ack the
+                  // request.
+                  if (acc_pready_spill) begin
+                      acc_pvalid_spill = 1'b1;
+                      acc_qready_o     = 1'b1;
+                  end
+              end
+
+              // manipulate the strides
+              riscv_instr::DMSTR : begin
+                  twod_req_d.stride_src = acc_qdata_arga_i;
+                  twod_req_d.stride_dst = acc_qdata_argb_i;
+                  acc_qready_o = 1'b1;
+                  is_dma_op    = 1'b1;
+                  dma_op_name  = "DMSTR";
+              end
+
+              // manipulate the strides
+              riscv_instr::DMREP : begin
+                  twod_req_d.num_repetitions = acc_qdata_arga_i;
+                  acc_qready_o = 1'b1;
+                  is_dma_op    = 1'b1;
+                  dma_op_name  = "DMREP";
+              end
+
+              default:;
+          endcase
+        end
+    end
+
+    //--------------------------------------
+    // State
+    //--------------------------------------
+    `FF(twod_req_q, twod_req_d, '0)
+
+endmodule

--- a/snitch-core/accelerator/snitch_fp_ss.sv
+++ b/snitch-core/accelerator/snitch_fp_ss.sv
@@ -1,0 +1,2671 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+`include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
+
+// Floating Point Subsystem
+module snitch_fp_ss import snitch_pkg::*; #(
+  parameter int unsigned AddrWidth = 32,
+  parameter int unsigned DataWidth = 32,
+  parameter int unsigned NumFPOutstandingLoads = 0,
+  parameter int unsigned NumFPOutstandingMem = 0,
+  parameter int unsigned NumFPUSequencerInstr = 0,
+  parameter type dreq_t = logic,
+  parameter type drsp_t = logic,
+  parameter bit RegisterSequencer = 0,
+  parameter bit RegisterFPUIn     = 0,
+  parameter bit RegisterFPUOut    = 0,
+  parameter bit Xfrep = 1,
+  parameter fpnew_pkg::fpu_implementation_t FPUImplementation = '0,
+  parameter bit Xssr = 1,
+  parameter int unsigned NumSsrs = 0,
+  parameter logic [NumSsrs-1:0][4:0]  SsrRegs = '0,
+  parameter type acc_req_t = logic,
+  parameter type acc_resp_t = logic,
+  parameter bit RVF = 1,
+  parameter bit RVD = 1,
+  parameter bit XF16 = 0,
+  parameter bit XF16ALT = 0,
+  parameter bit XF8 = 0,
+  parameter bit XF8ALT = 0,
+  parameter bit XFVEC = 0,
+  parameter int unsigned FLEN = DataWidth,
+  /// Derived parameter *Do not override*
+  parameter type addr_t = logic [AddrWidth-1:0],
+  parameter type data_t = logic [DataWidth-1:0]
+) (
+  input  logic             clk_i,
+  input  logic             rst_i,
+  // pragma translate_off
+  output fpu_trace_port_t  trace_port_o,
+  output fpu_sequencer_trace_port_t sequencer_tracer_port_o,
+  // pragma translate_on
+  // Accelerator Interface - Slave
+  input  acc_req_t         acc_req_i,
+  input  logic             acc_req_valid_i,
+  output logic             acc_req_ready_o,
+  output acc_resp_t        acc_resp_o,
+  output logic             acc_resp_valid_o,
+  input  logic             acc_resp_ready_i,
+  // TCDM Data Interface for regular FP load/stores.
+  output dreq_t            data_req_o,
+  input  drsp_t            data_rsp_i,
+  // Register Interface
+  // FPU **un-timed** Side-channel
+  input  fpnew_pkg::roundmode_e fpu_rnd_mode_i,
+  input  fpnew_pkg::fmt_mode_t  fpu_fmt_mode_i,
+  output fpnew_pkg::status_t    fpu_status_o,
+  // SSR Interface
+  output logic  [2:0][4:0] ssr_raddr_o,
+  input  data_t [2:0]      ssr_rdata_i,
+  output logic  [2:0]      ssr_rvalid_o,
+  input  logic  [2:0]      ssr_rready_i,
+  output logic  [2:0]      ssr_rdone_o,
+  output logic  [0:0][4:0] ssr_waddr_o,
+  output data_t [0:0]      ssr_wdata_o,
+  output logic  [0:0]      ssr_wvalid_o,
+  input  logic  [0:0]      ssr_wready_i,
+  output logic  [0:0]      ssr_wdone_o,
+  // SSR stream control interface
+  input  logic             streamctl_done_i,
+  input  logic             streamctl_valid_i,
+  output logic             streamctl_ready_o,
+  // Core event strobes
+  output core_events_t core_events_o
+);
+
+  fpnew_pkg::operation_e  fpu_op;
+  fpnew_pkg::roundmode_e  fpu_rnd_mode;
+  fpnew_pkg::fp_format_e  src_fmt, dst_fmt;
+  fpnew_pkg::int_format_e int_fmt;
+  logic                   vectorial_op;
+  logic                   set_dyn_rm;
+
+  logic [2:0][4:0]      fpr_raddr;
+  logic [2:0][FLEN-1:0] fpr_rdata;
+
+  logic [0:0]           fpr_we;
+  logic [0:0][4:0]      fpr_waddr;
+  logic [0:0][FLEN-1:0] fpr_wdata;
+  logic [0:0]           fpr_wvalid;
+  logic [0:0]           fpr_wready;
+
+  logic ssr_active_d, ssr_active_q, ssr_active_ena;
+  `FFLAR(ssr_active_q, Xssr & ssr_active_d, ssr_active_ena, 1'b0, clk_i, rst_i)
+
+  typedef struct packed {
+    logic       ssr; // write-back to SSR at rd
+    logic       acc; // write-back to result bus
+    logic [4:0] rd;  // write-back to floating point regfile
+  } tag_t;
+  tag_t fpu_tag_in, fpu_tag_out;
+
+  logic use_fpu;
+  logic [2:0][FLEN-1:0] op;
+  logic [2:0] op_ready; // operand is ready
+
+  logic        lsu_qready;
+  logic        lsu_qvalid;
+  logic [FLEN-1:0] ld_result;
+  logic [4:0]  lsu_rd;
+  logic        lsu_pvalid;
+  logic        lsu_pready;
+  logic is_store, is_load;
+
+  logic [31:0] sb_d, sb_q;
+  logic rd_is_fp;
+  `FFAR(sb_q, sb_d, '0, clk_i, rst_i)
+
+  logic csr_instr;
+
+  // FPU Controller
+  logic fpu_out_valid, fpu_out_ready;
+  logic fpu_in_valid, fpu_in_ready;
+
+  typedef enum logic [2:0] {
+    None,
+    AccBus,
+    RegA, RegB, RegC,
+    RegBRep, // Replication for vectors
+    RegDest
+  } op_select_e;
+  op_select_e [2:0] op_select;
+
+  typedef enum logic [1:0] {
+    ResNone, ResAccBus
+  } result_select_e;
+  result_select_e result_select;
+
+  logic op_mode;
+
+  logic [4:0] rs1, rs2, rs3, rd;
+
+  // LSU
+  typedef enum logic [1:0] {
+    Byte       = 2'b00,
+    HalfWord   = 2'b01,
+    Word       = 2'b10,
+    DoubleWord = 2'b11
+  } ls_size_e;
+  ls_size_e ls_size;
+
+
+  logic dst_ready;
+
+  // -------------
+  // FPU Sequencer
+  // -------------
+  acc_req_t         acc_req, acc_req_q;
+  logic             acc_req_valid, acc_req_valid_q;
+  logic             acc_req_ready, acc_req_ready_q;
+  if (Xfrep) begin : gen_fpu_sequencer
+    snitch_sequencer #(
+      .AddrWidth (AddrWidth),
+      .DataWidth (DataWidth),
+      .Depth     (NumFPUSequencerInstr)
+    ) i_snitch_fpu_sequencer (
+      .clk_i,
+      .rst_i,
+      // pragma translate_off
+      .trace_port_o     ( sequencer_tracer_port_o ),
+      // pragma translate_on
+      .inp_qaddr_i      ( acc_req_i.addr      ),
+      .inp_qid_i        ( acc_req_i.id        ),
+      .inp_qdata_op_i   ( acc_req_i.data_op   ),
+      .inp_qdata_arga_i ( acc_req_i.data_arga ),
+      .inp_qdata_argb_i ( acc_req_i.data_argb ),
+      .inp_qdata_argc_i ( acc_req_i.data_argc ),
+      .inp_qvalid_i     ( acc_req_valid_i     ),
+      .inp_qready_o     ( acc_req_ready_o     ),
+      .oup_qaddr_o      ( acc_req.addr        ),
+      .oup_qid_o        ( acc_req.id          ),
+      .oup_qdata_op_o   ( acc_req.data_op     ),
+      .oup_qdata_arga_o ( acc_req.data_arga   ),
+      .oup_qdata_argb_o ( acc_req.data_argb   ),
+      .oup_qdata_argc_o ( acc_req.data_argc   ),
+      .oup_qvalid_o     ( acc_req_valid       ),
+      .oup_qready_i     ( acc_req_ready       ),
+      .streamctl_done_i,
+      .streamctl_valid_i,
+      .streamctl_ready_o
+    );
+  end else begin : gen_no_fpu_sequencer
+    // pragma translate_off
+    assign sequencer_tracer_port_o = 0;
+    // pragma translate_on
+    assign acc_req_ready_o = acc_req_ready;
+    assign acc_req_valid = acc_req_valid_i;
+    assign acc_req = acc_req_i;
+  end
+
+  // Optional spill-register
+  spill_register  #(
+    .T      ( acc_req_t                           ),
+    .Bypass ( !RegisterSequencer || !Xfrep )
+  ) i_spill_register_acc (
+    .clk_i   ,
+    .rst_ni  ( ~rst_i          ),
+    .valid_i ( acc_req_valid   ),
+    .ready_o ( acc_req_ready   ),
+    .data_i  ( acc_req         ),
+    .valid_o ( acc_req_valid_q ),
+    .ready_i ( acc_req_ready_q ),
+    .data_o  ( acc_req_q       )
+  );
+
+  // Ensure SSR CSR only written on instruction commit
+  assign ssr_active_ena = acc_req_valid_q & acc_req_ready_q;
+
+  // this handles WAW Hazards - Potentially this can be relaxed if necessary
+  // at the expense of increased timing pressure
+  assign dst_ready = ~(rd_is_fp & sb_q[rd]);
+
+  // check that either:
+  // 1. The FPU and all operands are ready
+  // 2. The LSU request can be handled
+  // 3. The regfile operand is ready
+  assign fpu_in_valid = use_fpu & acc_req_valid_q & (&op_ready) & dst_ready;
+                                      // FPU ready
+  assign acc_req_ready_q = dst_ready & ((fpu_in_ready & fpu_in_valid)
+                                      // Load/Store
+                                      | (lsu_qvalid & lsu_qready)
+                                      | csr_instr
+                                      // Direct Reg Write
+                                      | (acc_req_valid_q && result_select == ResAccBus));
+
+  // either the FPU or the regfile produced a result
+  assign acc_resp_valid_o = (fpu_tag_out.acc & fpu_out_valid);
+  // stall FPU if we forward from reg
+  assign fpu_out_ready = ((fpu_tag_out.acc & acc_resp_ready_i) | (~fpu_tag_out.acc & fpr_wready));
+
+  // FPU Result
+  logic [FLEN-1:0] fpu_result;
+
+  // FPU Tag
+  assign acc_resp_o.id = fpu_tag_out.rd;
+  // accelerator bus write-port
+  assign acc_resp_o.data = fpu_result;
+
+  assign rd = acc_req_q.data_op[11:7];
+  assign rs1 = acc_req_q.data_op[19:15];
+  assign rs2 = acc_req_q.data_op[24:20];
+  assign rs3 = acc_req_q.data_op[31:27];
+
+  // Scoreboard/Operand Valid
+  // Track floating point destination registers
+  always_comb begin
+    sb_d = sb_q;
+    // if the instruction is going to write the FPR mark it
+    if (acc_req_valid_q & acc_req_ready_q & rd_is_fp) sb_d[rd] = 1'b1;
+    // reset the value if we are committing the register
+    if (fpr_we) sb_d[fpr_waddr] = 1'b0;
+    // don't track any dependencies for SSRs if enabled
+    if (ssr_active_q) begin
+      for (int i = 0; i < NumSsrs; i++) sb_d[SsrRegs[i]] = 1'b0;
+    end
+  end
+
+  // Determine whether destination register is SSR
+  logic is_rd_ssr;
+  always_comb begin
+    is_rd_ssr = 1'b0;
+    for (int s = 0; s < NumSsrs; s++)
+      is_rd_ssr |= (SsrRegs[s] == rd);
+  end
+
+  always_comb begin
+    acc_resp_o.error = 1'b0;
+    fpu_op = fpnew_pkg::ADD;
+    use_fpu = 1'b1;
+    fpu_rnd_mode = (fpnew_pkg::roundmode_e'(acc_req_q.data_op[14:12]) == fpnew_pkg::DYN)
+                   ? fpu_rnd_mode_i
+                   : fpnew_pkg::roundmode_e'(acc_req_q.data_op[14:12]);
+
+    set_dyn_rm = 1'b0;
+
+    src_fmt = fpnew_pkg::FP32;
+    dst_fmt = fpnew_pkg::FP32;
+    int_fmt = fpnew_pkg::INT32;
+
+    result_select = ResNone;
+
+    op_select[0] = None;
+    op_select[1] = None;
+    op_select[2] = None;
+
+    vectorial_op = 1'b0;
+    op_mode = 1'b0;
+
+    fpu_tag_in.rd = rd;
+    fpu_tag_in.acc = 1'b0; // RD is on accelerator bus
+    fpu_tag_in.ssr = ssr_active_q & is_rd_ssr;
+
+    is_store = 1'b0;
+    is_load = 1'b0;
+    ls_size = Word;
+
+    // Destination register is in FPR
+    rd_is_fp = 1'b1;
+    csr_instr = 1'b0; // is a csr instruction
+    // SSR register
+    ssr_active_d = ssr_active_q;
+    unique casez (acc_req_q.data_op)
+      // FP - FP Operations
+      // Single Precision
+      riscv_instr::FADD_S: begin
+        fpu_op = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+      end
+      riscv_instr::FSUB_S: begin
+        fpu_op = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+        op_mode = 1'b1;
+      end
+      riscv_instr::FMUL_S: begin
+        fpu_op = fpnew_pkg::MUL;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+      end
+      riscv_instr::FDIV_S: begin  // currently illegal
+        fpu_op = fpnew_pkg::DIV;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+      end
+      riscv_instr::FSGNJ_S,
+      riscv_instr::FSGNJN_S,
+      riscv_instr::FSGNJX_S: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+      end
+      riscv_instr::FMIN_S,
+      riscv_instr::FMAX_S: begin
+        fpu_op = fpnew_pkg::MINMAX;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+      end
+      riscv_instr::FSQRT_S: begin  // currently illegal
+        fpu_op = fpnew_pkg::SQRT;
+        op_select[0] = RegA;
+        op_select[1] = RegA;
+      end
+      riscv_instr::FMADD_S: begin
+        fpu_op = fpnew_pkg::FMADD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+      end
+      riscv_instr::FMSUB_S: begin
+        fpu_op = fpnew_pkg::FMADD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        op_mode      = 1'b1;
+      end
+      riscv_instr::FNMSUB_S: begin
+        fpu_op = fpnew_pkg::FNMSUB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+      end
+      riscv_instr::FNMADD_S: begin
+        fpu_op = fpnew_pkg::FNMSUB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        op_mode      = 1'b1;
+      end
+      // Vectorial Single Precision
+      riscv_instr::VFADD_S,
+      riscv_instr::VFADD_R_S: begin
+        fpu_op = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFADD_R_S}) op_select[2] = RegBRep;
+      end
+      riscv_instr::VFSUB_S,
+      riscv_instr::VFSUB_R_S: begin
+        fpu_op  = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+        op_mode      = 1'b1;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFSUB_R_S}) op_select[2] = RegBRep;
+      end
+      riscv_instr::VFMUL_S,
+      riscv_instr::VFMUL_R_S: begin
+        fpu_op = fpnew_pkg::MUL;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMUL_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFDIV_S,
+      riscv_instr::VFDIV_R_S: begin  // currently illegal
+        fpu_op = fpnew_pkg::DIV;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFDIV_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFMIN_S,
+      riscv_instr::VFMIN_R_S: begin
+        fpu_op = fpnew_pkg::MINMAX;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        fpu_rnd_mode = fpnew_pkg::RNE;
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMIN_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFMAX_S,
+      riscv_instr::VFMAX_R_S: begin
+        fpu_op = fpnew_pkg::MINMAX;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        fpu_rnd_mode = fpnew_pkg::RTZ;
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMAX_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFSQRT_S: begin // currently illegal
+        fpu_op = fpnew_pkg::SQRT;
+        op_select[0] = RegA;
+        op_select[1] = RegA;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+      end
+      riscv_instr::VFMAC_S,
+      riscv_instr::VFMAC_R_S: begin
+        fpu_op = fpnew_pkg::FMADD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMAC_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFMRE_S,
+      riscv_instr::VFMRE_R_S: begin
+        fpu_op = fpnew_pkg::FNMSUB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMRE_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFSGNJ_S,
+      riscv_instr::VFSGNJ_R_S: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        fpu_rnd_mode = fpnew_pkg::RNE;
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFSGNJ_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFSGNJN_S,
+      riscv_instr::VFSGNJN_R_S: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        fpu_rnd_mode = fpnew_pkg::RTZ;
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFSGNJN_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFSGNJX_S,
+      riscv_instr::VFSGNJX_R_S: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        fpu_rnd_mode = fpnew_pkg::RDN;
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFSGNJX_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFSUM_S,
+      riscv_instr::VFNSUM_S: begin
+        fpu_op = fpnew_pkg::VSUM;
+        op_select[0] = RegA;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP32;
+        dst_fmt      = fpnew_pkg::FP32;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFNSUM_S}) op_mode = 1'b1;
+      end
+      riscv_instr::VFCPKA_S_S: begin
+        fpu_op = fpnew_pkg::CPKAB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+      end
+      riscv_instr::VFCPKA_S_D: begin
+        fpu_op = fpnew_pkg::CPKAB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP64;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+      end
+      // Double Precision
+      riscv_instr::FADD_D: begin
+        fpu_op = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      riscv_instr::FSUB_D: begin
+        fpu_op = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+        op_mode = 1'b1;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      riscv_instr::FMUL_D: begin
+        fpu_op = fpnew_pkg::MUL;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      riscv_instr::FDIV_D: begin
+        fpu_op = fpnew_pkg::DIV;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      riscv_instr::FSGNJ_D,
+      riscv_instr::FSGNJN_D,
+      riscv_instr::FSGNJX_D: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      riscv_instr::FMIN_D,
+      riscv_instr::FMAX_D: begin
+        fpu_op = fpnew_pkg::MINMAX;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      riscv_instr::FSQRT_D: begin
+        fpu_op = fpnew_pkg::SQRT;
+        op_select[0] = RegA;
+        op_select[1] = RegA;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      riscv_instr::FMADD_D: begin
+        fpu_op = fpnew_pkg::FMADD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      riscv_instr::FMSUB_D: begin
+        fpu_op = fpnew_pkg::FMADD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        op_mode      = 1'b1;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      riscv_instr::FNMSUB_D: begin
+        fpu_op = fpnew_pkg::FNMSUB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      riscv_instr::FNMADD_D: begin
+        fpu_op = fpnew_pkg::FNMSUB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        op_mode      = 1'b1;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      riscv_instr::FCVT_S_D: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP32;
+      end
+      riscv_instr::FCVT_D_S: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP32;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      // [Alternate] Half Precision
+      riscv_instr::FADD_H: begin
+        fpu_op = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+      end
+      riscv_instr::FSUB_H: begin
+        fpu_op = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+        op_mode = 1'b1;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+      end
+      riscv_instr::FMUL_H: begin
+        fpu_op = fpnew_pkg::MUL;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+      end
+      riscv_instr::FDIV_H: begin
+        fpu_op = fpnew_pkg::DIV;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+      end
+      riscv_instr::FSGNJ_H,
+      riscv_instr::FSGNJN_H,
+      riscv_instr::FSGNJX_H: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+      end
+      riscv_instr::FMIN_H,
+      riscv_instr::FMAX_H: begin
+        fpu_op = fpnew_pkg::MINMAX;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+      end
+      riscv_instr::FSQRT_H: begin
+        fpu_op = fpnew_pkg::SQRT;
+        op_select[0] = RegA;
+        op_select[1] = RegA;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+      end
+      riscv_instr::FMADD_H: begin
+        fpu_op = fpnew_pkg::FMADD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+      end
+      riscv_instr::FMSUB_H: begin
+        fpu_op = fpnew_pkg::FMADD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        op_mode      = 1'b1;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+      end
+      riscv_instr::FNMSUB_H: begin
+        fpu_op = fpnew_pkg::FNMSUB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+      end
+      riscv_instr::FNMADD_H: begin
+        fpu_op = fpnew_pkg::FNMSUB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        op_mode      = 1'b1;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+      end
+      riscv_instr::VFSUM_H,
+      riscv_instr::VFNSUM_H: begin
+        fpu_op = fpnew_pkg::VSUM;
+        op_select[0] = RegA;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFNSUM_H}) op_mode = 1'b1;
+      end
+      riscv_instr::FMULEX_S_H: begin
+        fpu_op = fpnew_pkg::MUL;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP32;
+      end
+      riscv_instr::FMACEX_S_H: begin
+        fpu_op = fpnew_pkg::FMADD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP32;
+      end
+      riscv_instr::FCVT_S_H: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP32;
+      end
+      riscv_instr::FCVT_H_S: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP32;
+        dst_fmt      = fpnew_pkg::FP16;
+      end
+      riscv_instr::FCVT_D_H: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      riscv_instr::FCVT_H_D: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP16;
+      end
+      riscv_instr::FCVT_H_H: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+      end
+      // Vectorial [alternate] Half Precision
+      riscv_instr::VFADD_H,
+      riscv_instr::VFADD_R_H: begin
+        fpu_op = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFADD_R_H}) op_select[2] = RegBRep;
+      end
+      riscv_instr::VFSUB_H,
+      riscv_instr::VFSUB_R_H: begin
+        fpu_op  = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+        op_mode      = 1'b1;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFSUB_R_H}) op_select[2] = RegBRep;
+      end
+      riscv_instr::VFMUL_H,
+      riscv_instr::VFMUL_R_H: begin
+        fpu_op = fpnew_pkg::MUL;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMUL_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFDIV_H,
+      riscv_instr::VFDIV_R_H: begin
+        fpu_op = fpnew_pkg::DIV;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFDIV_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFMIN_H,
+      riscv_instr::VFMIN_R_H: begin
+        fpu_op = fpnew_pkg::MINMAX;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        fpu_rnd_mode = fpnew_pkg::RNE;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMIN_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFMAX_H,
+      riscv_instr::VFMAX_R_H: begin
+        fpu_op = fpnew_pkg::MINMAX;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        fpu_rnd_mode = fpnew_pkg::RTZ;
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMAX_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFSQRT_H: begin
+        fpu_op = fpnew_pkg::SQRT;
+        op_select[0] = RegA;
+        op_select[1] = RegA;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+      end
+      riscv_instr::VFMAC_H,
+      riscv_instr::VFMAC_R_H: begin
+        fpu_op = fpnew_pkg::FMADD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMAC_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFMRE_H,
+      riscv_instr::VFMRE_R_H: begin
+        fpu_op = fpnew_pkg::FNMSUB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMRE_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFSGNJ_H,
+      riscv_instr::VFSGNJ_R_H: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        fpu_rnd_mode = fpnew_pkg::RNE;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFSGNJ_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFSGNJN_H,
+      riscv_instr::VFSGNJN_R_H: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        fpu_rnd_mode = fpnew_pkg::RTZ;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFSGNJN_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFSGNJX_H,
+      riscv_instr::VFSGNJX_R_H: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        fpu_rnd_mode = fpnew_pkg::RDN;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFSGNJX_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFCPKA_H_S: begin
+        fpu_op = fpnew_pkg::CPKAB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP32;
+        dst_fmt      = fpnew_pkg::FP16;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+      end
+      riscv_instr::VFCPKB_H_S: begin
+        fpu_op = fpnew_pkg::CPKAB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        op_mode      = 1'b1;
+        src_fmt      = fpnew_pkg::FP32;
+        dst_fmt      = fpnew_pkg::FP16;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+      end
+      riscv_instr::VFCVT_S_H,
+      riscv_instr::VFCVTU_S_H: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP32;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCVTU_S_H}) op_mode = 1'b1;
+      end
+      riscv_instr::VFCVT_H_S,
+      riscv_instr::VFCVTU_H_S: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP32;
+        dst_fmt      = fpnew_pkg::FP16;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCVTU_H_S}) op_mode = 1'b1;
+      end
+      riscv_instr::VFCPKA_H_D: begin
+        fpu_op = fpnew_pkg::CPKAB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP16;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+      end
+      riscv_instr::VFCPKB_H_D: begin
+        fpu_op = fpnew_pkg::CPKAB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        op_mode      = 1'b1;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP16;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+      end
+      riscv_instr::VFDOTPEX_S_H,
+      riscv_instr::VFDOTPEX_S_R_H: begin
+        fpu_op = fpnew_pkg::SDOTP;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP32;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFDOTPEX_S_R_H}) op_select[2] = RegBRep;
+      end
+      riscv_instr::VFNDOTPEX_S_H,
+      riscv_instr::VFNDOTPEX_S_R_H: begin
+        fpu_op = fpnew_pkg::SDOTP;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        op_mode      = 1'b1;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP32;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFNDOTPEX_S_R_H}) op_select[2] = RegBRep;
+      end
+      riscv_instr::VFSUMEX_S_H,
+      riscv_instr::VFNSUMEX_S_H: begin
+        fpu_op = fpnew_pkg::EXVSUM;
+        op_select[0] = RegA;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP32;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFNSUMEX_S_H}) op_mode = 1'b1;
+      end
+      // [Alternate] Quarter Precision
+      riscv_instr::FADD_B: begin
+        fpu_op = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+      end
+      riscv_instr::FSUB_B: begin
+        fpu_op = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+        op_mode = 1'b1;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+      end
+      riscv_instr::FMUL_B: begin
+        fpu_op = fpnew_pkg::MUL;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+      end
+      riscv_instr::FDIV_B: begin
+        fpu_op = fpnew_pkg::DIV;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+      end
+      riscv_instr::FSGNJ_B,
+      riscv_instr::FSGNJN_B,
+      riscv_instr::FSGNJX_B: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+      end
+      riscv_instr::FMIN_B,
+      riscv_instr::FMAX_B: begin
+        fpu_op = fpnew_pkg::MINMAX;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+      end
+      riscv_instr::FSQRT_B: begin
+        fpu_op = fpnew_pkg::SQRT;
+        op_select[0] = RegA;
+        op_select[1] = RegA;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+      end
+      riscv_instr::FMADD_B: begin
+        fpu_op = fpnew_pkg::FMADD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+      end
+      riscv_instr::FMSUB_B: begin
+        fpu_op = fpnew_pkg::FMADD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        op_mode      = 1'b1;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+      end
+      riscv_instr::FNMSUB_B: begin
+        fpu_op = fpnew_pkg::FNMSUB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+      end
+      riscv_instr::FNMADD_B: begin
+        fpu_op = fpnew_pkg::FNMSUB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegC;
+        op_mode      = 1'b1;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+      end
+      riscv_instr::VFSUM_B,
+      riscv_instr::VFNSUM_B: begin
+        fpu_op = fpnew_pkg::VSUM;
+        op_select[0] = RegA;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFNSUM_B}) op_mode = 1'b1;
+      end
+      riscv_instr::FMULEX_S_B: begin
+        fpu_op = fpnew_pkg::MUL;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP32;
+      end
+      riscv_instr::FMACEX_S_B: begin
+        fpu_op = fpnew_pkg::FMADD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP32;
+      end
+      riscv_instr::FCVT_S_B: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP32;
+      end
+      riscv_instr::FCVT_B_S: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP32;
+        dst_fmt      = fpnew_pkg::FP8;
+      end
+      riscv_instr::FCVT_D_B: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP64;
+      end
+      riscv_instr::FCVT_B_D: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP8;
+      end
+      riscv_instr::FCVT_H_B: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP16;
+      end
+      riscv_instr::FCVT_B_H: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP8;
+      end
+      // Vectorial [alternate] Quarter Precision
+      riscv_instr::VFADD_B,
+      riscv_instr::VFADD_R_B: begin
+        fpu_op = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFADD_R_B}) op_select[2] = RegBRep;
+      end
+      riscv_instr::VFSUB_B,
+      riscv_instr::VFSUB_R_B: begin
+        fpu_op  = fpnew_pkg::ADD;
+        op_select[1] = RegA;
+        op_select[2] = RegB;
+        op_mode      = 1'b1;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFSUB_R_B}) op_select[2] = RegBRep;
+      end
+      riscv_instr::VFMUL_B,
+      riscv_instr::VFMUL_R_B: begin
+        fpu_op = fpnew_pkg::MUL;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMUL_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFDIV_B,
+      riscv_instr::VFDIV_R_B: begin
+        fpu_op = fpnew_pkg::DIV;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFDIV_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFMIN_B,
+      riscv_instr::VFMIN_R_B: begin
+        fpu_op = fpnew_pkg::MINMAX;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        fpu_rnd_mode = fpnew_pkg::RNE;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMIN_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFMAX_B,
+      riscv_instr::VFMAX_R_B: begin
+        fpu_op = fpnew_pkg::MINMAX;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+        fpu_rnd_mode = fpnew_pkg::RTZ;
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMAX_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFSQRT_B: begin
+        fpu_op = fpnew_pkg::SQRT;
+        op_select[0] = RegA;
+        op_select[1] = RegA;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+      end
+      riscv_instr::VFMAC_B,
+      riscv_instr::VFMAC_R_B: begin
+        fpu_op = fpnew_pkg::FMADD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMAC_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFMRE_B,
+      riscv_instr::VFMRE_R_B: begin
+        fpu_op = fpnew_pkg::FNMSUB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFMRE_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFSGNJ_B,
+      riscv_instr::VFSGNJ_R_B: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        fpu_rnd_mode = fpnew_pkg::RNE;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFSGNJ_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFSGNJN_B,
+      riscv_instr::VFSGNJN_R_B: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        fpu_rnd_mode = fpnew_pkg::RTZ;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFSGNJN_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFSGNJX_B,
+      riscv_instr::VFSGNJX_R_B: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        fpu_rnd_mode = fpnew_pkg::RDN;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFSGNJX_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFCPKA_B_S,
+      riscv_instr::VFCPKB_B_S: begin
+        fpu_op = fpnew_pkg::CPKAB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP32;
+        dst_fmt      = fpnew_pkg::FP8;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCPKB_B_S}) op_mode = 1;
+      end
+      riscv_instr::VFCPKC_B_S,
+      riscv_instr::VFCPKD_B_S: begin
+        fpu_op = fpnew_pkg::CPKCD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP32;
+        dst_fmt      = fpnew_pkg::FP8;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCPKD_B_S}) op_mode = 1;
+      end
+     riscv_instr::VFCPKA_B_D,
+      riscv_instr::VFCPKB_B_D: begin
+        fpu_op = fpnew_pkg::CPKAB;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP8;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCPKB_B_D}) op_mode = 1;
+      end
+      riscv_instr::VFCPKC_B_D,
+      riscv_instr::VFCPKD_B_D: begin
+        fpu_op = fpnew_pkg::CPKCD;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP8;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCPKD_B_D}) op_mode = 1;
+      end
+      riscv_instr::VFCVT_S_B,
+      riscv_instr::VFCVTU_S_B: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP32;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCVTU_S_B}) op_mode = 1'b1;
+      end
+      riscv_instr::VFCVT_B_S,
+      riscv_instr::VFCVTU_B_S: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP32;
+        dst_fmt      = fpnew_pkg::FP8;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCVTU_B_S}) op_mode = 1'b1;
+      end
+      riscv_instr::VFCVT_H_H,
+      riscv_instr::VFCVTU_H_H: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCVTU_H_H}) op_mode = 1'b1;
+      end
+      riscv_instr::VFCVT_H_B,
+      riscv_instr::VFCVTU_H_B: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP16;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCVTU_H_B}) op_mode = 1'b1;
+      end
+      riscv_instr::VFCVT_B_H,
+      riscv_instr::VFCVTU_B_H: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP8;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCVTU_B_H}) op_mode = 1'b1;
+      end
+      riscv_instr::VFCVT_B_B,
+      riscv_instr::VFCVTU_B_B: begin
+        fpu_op = fpnew_pkg::F2F;
+        op_select[0] = RegA;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCVTU_B_B}) op_mode = 1'b1;
+      end
+      riscv_instr::VFDOTPEX_H_B,
+      riscv_instr::VFDOTPEX_H_R_B: begin
+        fpu_op = fpnew_pkg::SDOTP;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP16;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFDOTPEX_H_R_B}) op_select[2] = RegBRep;
+      end
+      riscv_instr::VFNDOTPEX_H_B,
+      riscv_instr::VFNDOTPEX_H_R_B: begin
+        fpu_op = fpnew_pkg::SDOTP;
+        op_select[0] = RegA;
+        op_select[1] = RegB;
+        op_select[2] = RegDest;
+        op_mode      = 1'b1;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP16;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFNDOTPEX_H_R_B}) op_select[2] = RegBRep;
+      end
+      riscv_instr::VFSUMEX_H_B,
+      riscv_instr::VFNSUMEX_H_B: begin
+        fpu_op = fpnew_pkg::EXVSUM;
+        op_select[0] = RegA;
+        op_select[2] = RegDest;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP16;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFNSUMEX_H_B}) op_mode = 1'b1;
+      end
+      // -------------------
+      // From float to int
+      // -------------------
+      // Single Precision Floating-Point
+      riscv_instr::FLE_S,
+      riscv_instr::FLT_S,
+      riscv_instr::FEQ_S: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        src_fmt        = fpnew_pkg::FP32;
+        dst_fmt        = fpnew_pkg::FP32;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      riscv_instr::FCLASS_S: begin
+        fpu_op = fpnew_pkg::CLASSIFY;
+        op_select[0]   = RegA;
+        fpu_rnd_mode   = fpnew_pkg::RNE;
+        src_fmt        = fpnew_pkg::FP32;
+        dst_fmt        = fpnew_pkg::FP32;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      riscv_instr::FCVT_W_S,
+      riscv_instr::FCVT_WU_S: begin
+        fpu_op = fpnew_pkg::F2I;
+        op_select[0]   = RegA;
+        src_fmt        = fpnew_pkg::FP32;
+        dst_fmt        = fpnew_pkg::FP32;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::FCVT_WU_S}) op_mode = 1'b1; // unsigned
+      end
+      riscv_instr::FMV_X_W: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        fpu_rnd_mode   = fpnew_pkg::RUP; // passthrough without checking nan-box
+        src_fmt        = fpnew_pkg::FP32;
+        dst_fmt        = fpnew_pkg::FP32;
+        op_mode        = 1'b1; // sign-extend result
+        op_select[0]   = RegA;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      // Vectorial Single Precision
+      riscv_instr::VFEQ_S,
+      riscv_instr::VFEQ_R_S: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RDN;
+        src_fmt        = fpnew_pkg::FP32;
+        dst_fmt        = fpnew_pkg::FP32;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFEQ_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFNE_S,
+      riscv_instr::VFNE_R_S: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RDN;
+        src_fmt        = fpnew_pkg::FP32;
+        dst_fmt        = fpnew_pkg::FP32;
+        op_mode        = 1'b1;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFNE_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFLT_S,
+      riscv_instr::VFLT_R_S: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RTZ;
+        src_fmt        = fpnew_pkg::FP32;
+        dst_fmt        = fpnew_pkg::FP32;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFLT_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFGE_S,
+      riscv_instr::VFGE_R_S: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RTZ;
+        src_fmt        = fpnew_pkg::FP32;
+        dst_fmt        = fpnew_pkg::FP32;
+        op_mode        = 1'b1;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFGE_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFLE_S,
+      riscv_instr::VFLE_R_S: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RNE;
+        src_fmt        = fpnew_pkg::FP32;
+        dst_fmt        = fpnew_pkg::FP32;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFLE_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFGT_S,
+      riscv_instr::VFGT_R_S: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RNE;
+        src_fmt        = fpnew_pkg::FP32;
+        dst_fmt        = fpnew_pkg::FP32;
+        op_mode        = 1'b1;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFGT_R_S}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFCLASS_S: begin
+        fpu_op = fpnew_pkg::CLASSIFY;
+        op_select[0]   = RegA;
+        fpu_rnd_mode   = fpnew_pkg::RNE;
+        src_fmt        = fpnew_pkg::FP32;
+        dst_fmt        = fpnew_pkg::FP32;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      // Double Precision Floating-Point
+      riscv_instr::FLE_D,
+      riscv_instr::FLT_D,
+      riscv_instr::FEQ_D: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        src_fmt        = fpnew_pkg::FP64;
+        dst_fmt        = fpnew_pkg::FP64;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      riscv_instr::FCLASS_D: begin
+        fpu_op = fpnew_pkg::CLASSIFY;
+        op_select[0]   = RegA;
+        fpu_rnd_mode   = fpnew_pkg::RNE;
+        src_fmt        = fpnew_pkg::FP64;
+        dst_fmt        = fpnew_pkg::FP64;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      riscv_instr::FCVT_W_D,
+      riscv_instr::FCVT_WU_D: begin
+        fpu_op = fpnew_pkg::F2I;
+        op_select[0]   = RegA;
+        src_fmt        = fpnew_pkg::FP64;
+        dst_fmt        = fpnew_pkg::FP64;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::FCVT_WU_D}) op_mode = 1'b1; // unsigned
+      end
+      riscv_instr::FMV_X_D: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        fpu_rnd_mode   = fpnew_pkg::RUP; // passthrough without checking nan-box
+        src_fmt        = fpnew_pkg::FP64;
+        dst_fmt        = fpnew_pkg::FP64;
+        op_mode        = 1'b1; // sign-extend result
+        op_select[0]   = RegA;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      // [Alternate] Half Precision Floating-Point
+      riscv_instr::FLE_H,
+      riscv_instr::FLT_H,
+      riscv_instr::FEQ_H: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        src_fmt        = fpnew_pkg::FP16;
+        dst_fmt        = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      riscv_instr::FCLASS_H: begin
+        fpu_op = fpnew_pkg::CLASSIFY;
+        op_select[0]   = RegA;
+        fpu_rnd_mode   = fpnew_pkg::RNE;
+        src_fmt        = fpnew_pkg::FP16;
+        dst_fmt        = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP16ALT;
+          dst_fmt      = fpnew_pkg::FP16ALT;
+        end
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      riscv_instr::FCVT_W_H,
+      riscv_instr::FCVT_WU_H: begin
+        fpu_op = fpnew_pkg::F2I;
+        op_select[0]   = RegA;
+        src_fmt        = fpnew_pkg::FP16;
+        dst_fmt        = fpnew_pkg::FP16;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::FCVT_WU_H}) op_mode = 1'b1; // unsigned
+      end
+      riscv_instr::FMV_X_H: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        fpu_rnd_mode   = fpnew_pkg::RUP; // passthrough without checking nan-box
+        src_fmt        = fpnew_pkg::FP16;
+        dst_fmt        = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP16ALT;
+          dst_fmt      = fpnew_pkg::FP16ALT;
+        end
+        op_mode        = 1'b1; // sign-extend result
+        op_select[0]   = RegA;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      // Vectorial [alternate] Half Precision
+      riscv_instr::VFEQ_H,
+      riscv_instr::VFEQ_R_H: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RDN;
+        src_fmt        = fpnew_pkg::FP16;
+        dst_fmt        = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP16ALT;
+          dst_fmt      = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFEQ_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFNE_H,
+      riscv_instr::VFNE_R_H: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RDN;
+        src_fmt        = fpnew_pkg::FP16;
+        dst_fmt        = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP16ALT;
+          dst_fmt      = fpnew_pkg::FP16ALT;
+        end
+        op_mode        = 1'b1;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFNE_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFLT_H,
+      riscv_instr::VFLT_R_H: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RTZ;
+        src_fmt        = fpnew_pkg::FP16;
+        dst_fmt        = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP16ALT;
+          dst_fmt      = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFLT_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFGE_H,
+      riscv_instr::VFGE_R_H: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RTZ;
+        src_fmt        = fpnew_pkg::FP16;
+        dst_fmt        = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP16ALT;
+          dst_fmt      = fpnew_pkg::FP16ALT;
+        end
+        op_mode        = 1'b1;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFGE_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFLE_H,
+      riscv_instr::VFLE_R_H: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RNE;
+        src_fmt        = fpnew_pkg::FP16;
+        dst_fmt        = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP16ALT;
+          dst_fmt      = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFLE_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFGT_H,
+      riscv_instr::VFGT_R_H: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RNE;
+        src_fmt        = fpnew_pkg::FP16;
+        dst_fmt        = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP16ALT;
+          dst_fmt      = fpnew_pkg::FP16ALT;
+        end
+        op_mode        = 1'b1;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFGT_R_H}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFCLASS_H: begin
+        fpu_op = fpnew_pkg::CLASSIFY;
+        op_select[0]   = RegA;
+        fpu_rnd_mode   = fpnew_pkg::RNE;
+        src_fmt        = fpnew_pkg::FP16;
+        dst_fmt        = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP16ALT;
+          dst_fmt      = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      riscv_instr::VFMV_X_H: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        fpu_rnd_mode   = fpnew_pkg::RUP; // passthrough without checking nan-box
+        src_fmt        = fpnew_pkg::FP16;
+        dst_fmt        = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP16ALT;
+          dst_fmt      = fpnew_pkg::FP16ALT;
+        end
+        op_mode        = 1'b1; // sign-extend result
+        op_select[0]   = RegA;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      riscv_instr::VFCVT_X_H,
+      riscv_instr::VFCVT_XU_H: begin
+        fpu_op = fpnew_pkg::F2I;
+        op_select[0]   = RegA;
+        src_fmt        = fpnew_pkg::FP16;
+        dst_fmt        = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP16ALT;
+          dst_fmt      = fpnew_pkg::FP16ALT;
+        end
+        int_fmt        = fpnew_pkg::INT16;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        set_dyn_rm     = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCVT_XU_H}) op_mode = 1'b1; // upper
+      end
+      // [Alternate] Quarter Precision Floating-Point
+      riscv_instr::FLE_B,
+      riscv_instr::FLT_B,
+      riscv_instr::FEQ_B: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        src_fmt        = fpnew_pkg::FP8;
+        dst_fmt        = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP8ALT;
+          dst_fmt      = fpnew_pkg::FP8ALT;
+        end
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      riscv_instr::FCLASS_B: begin
+        fpu_op = fpnew_pkg::CLASSIFY;
+        op_select[0]   = RegA;
+        fpu_rnd_mode   = fpnew_pkg::RNE;
+        src_fmt        = fpnew_pkg::FP8;
+        dst_fmt        = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP8ALT;
+          dst_fmt      = fpnew_pkg::FP8ALT;
+        end
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      riscv_instr::FCVT_W_B,
+      riscv_instr::FCVT_WU_B: begin
+        fpu_op = fpnew_pkg::F2I;
+        op_select[0]   = RegA;
+        src_fmt        = fpnew_pkg::FP8;
+        dst_fmt        = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP8ALT;
+          dst_fmt      = fpnew_pkg::FP8ALT;
+        end
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::FCVT_WU_B}) op_mode = 1'b1; // unsigned
+      end
+      riscv_instr::FMV_X_B: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        fpu_rnd_mode   = fpnew_pkg::RUP; // passthrough without checking nan-box
+        src_fmt        = fpnew_pkg::FP8;
+        dst_fmt        = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP8ALT;
+          dst_fmt      = fpnew_pkg::FP8ALT;
+        end
+        op_mode        = 1'b1; // sign-extend result
+        op_select[0]   = RegA;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      // Vectorial Quarter Precision
+      riscv_instr::VFEQ_B,
+      riscv_instr::VFEQ_R_B: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RDN;
+        src_fmt        = fpnew_pkg::FP8;
+        dst_fmt        = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP8ALT;
+          dst_fmt      = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFEQ_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFNE_B,
+      riscv_instr::VFNE_R_B: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RDN;
+        src_fmt        = fpnew_pkg::FP8;
+        dst_fmt        = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP8ALT;
+          dst_fmt      = fpnew_pkg::FP8ALT;
+        end
+        op_mode        = 1'b1;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFNE_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFLT_B,
+      riscv_instr::VFLT_R_B: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RTZ;
+        src_fmt        = fpnew_pkg::FP8;
+        dst_fmt        = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP8ALT;
+          dst_fmt      = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFLT_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFGE_B,
+      riscv_instr::VFGE_R_B: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RTZ;
+        src_fmt        = fpnew_pkg::FP8;
+        dst_fmt        = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP8ALT;
+          dst_fmt      = fpnew_pkg::FP8ALT;
+        end
+        op_mode        = 1'b1;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFGE_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFLE_B,
+      riscv_instr::VFLE_R_B: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RNE;
+        src_fmt        = fpnew_pkg::FP8;
+        dst_fmt        = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP8ALT;
+          dst_fmt      = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFLE_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFGT_B,
+      riscv_instr::VFGT_R_B: begin
+        fpu_op = fpnew_pkg::CMP;
+        op_select[0]   = RegA;
+        op_select[1]   = RegB;
+        fpu_rnd_mode   = fpnew_pkg::RNE;
+        src_fmt        = fpnew_pkg::FP8;
+        dst_fmt        = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP8ALT;
+          dst_fmt      = fpnew_pkg::FP8ALT;
+        end
+        op_mode        = 1'b1;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        if (acc_req_q.data_op inside {riscv_instr::VFGT_R_B}) op_select[1] = RegBRep;
+      end
+      riscv_instr::VFCLASS_B: begin
+        fpu_op = fpnew_pkg::CLASSIFY;
+        op_select[0]   = RegA;
+        fpu_rnd_mode   = fpnew_pkg::RNE;
+        src_fmt        = fpnew_pkg::FP8;
+        dst_fmt        = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP8ALT;
+          dst_fmt      = fpnew_pkg::FP8ALT;
+        end
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      riscv_instr::VFMV_X_B: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        fpu_rnd_mode   = fpnew_pkg::RUP; // passthrough without checking nan-box
+        src_fmt        = fpnew_pkg::FP8;
+        dst_fmt        = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP8ALT;
+          dst_fmt      = fpnew_pkg::FP8ALT;
+        end
+        op_mode        = 1'b1; // sign-extend result
+        op_select[0]   = RegA;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+      end
+      riscv_instr::VFCVT_X_B,
+      riscv_instr::VFCVT_XU_B: begin
+        fpu_op = fpnew_pkg::F2I;
+        op_select[0]   = RegA;
+        src_fmt        = fpnew_pkg::FP8;
+        dst_fmt        = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.src == 1'b1) begin
+          src_fmt      = fpnew_pkg::FP8ALT;
+          dst_fmt      = fpnew_pkg::FP8ALT;
+        end
+        int_fmt        = fpnew_pkg::INT8;
+        vectorial_op   = 1'b1;
+        fpu_tag_in.acc = 1'b1;
+        rd_is_fp       = 1'b0;
+        set_dyn_rm     = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCVT_XU_B}) op_mode = 1'b1; // upper
+      end
+      // -------------------
+      // From int to float
+      // -------------------
+      // Single Precision Floating-Point
+      riscv_instr::FMV_W_X: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = AccBus;
+        fpu_rnd_mode = fpnew_pkg::RUP; // passthrough without checking nan-box
+        src_fmt      = fpnew_pkg::FP32;
+        dst_fmt      = fpnew_pkg::FP32;
+      end
+      riscv_instr::FCVT_S_W,
+      riscv_instr::FCVT_S_WU: begin
+        fpu_op = fpnew_pkg::I2F;
+        op_select[0] = AccBus;
+        dst_fmt      = fpnew_pkg::FP32;
+        if (acc_req_q.data_op inside {riscv_instr::FCVT_S_WU}) op_mode = 1'b1; // unsigned
+      end
+      // Double Precision Floating-Point
+      riscv_instr::FCVT_D_W,
+      riscv_instr::FCVT_D_WU: begin
+        fpu_op = fpnew_pkg::I2F;
+        op_select[0] = AccBus;
+        src_fmt      = fpnew_pkg::FP64;
+        dst_fmt      = fpnew_pkg::FP64;
+        if (acc_req_q.data_op inside {riscv_instr::FCVT_D_WU}) op_mode = 1'b1; // unsigned
+      end
+      // [Alternate] Half Precision Floating-Point
+      riscv_instr::FMV_H_X: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = AccBus;
+        fpu_rnd_mode = fpnew_pkg::RUP; // passthrough without checking nan-box
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+      end
+      riscv_instr::FCVT_H_W,
+      riscv_instr::FCVT_H_WU: begin
+        fpu_op = fpnew_pkg::I2F;
+        op_select[0] = AccBus;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        if (acc_req_q.data_op inside {riscv_instr::FCVT_H_WU}) op_mode = 1'b1; // unsigned
+      end
+      // Vectorial Half Precision Floating-Point
+      riscv_instr::VFMV_H_X: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = AccBus;
+        fpu_rnd_mode = fpnew_pkg::RUP; // passthrough without checking nan-box
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        vectorial_op = 1'b1;
+      end
+      riscv_instr::VFCVT_H_X,
+      riscv_instr::VFCVT_H_XU: begin
+        fpu_op = fpnew_pkg::I2F;
+        op_select[0] = AccBus;
+        src_fmt      = fpnew_pkg::FP16;
+        dst_fmt      = fpnew_pkg::FP16;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP16ALT;
+          dst_fmt    = fpnew_pkg::FP16ALT;
+        end
+        int_fmt      = fpnew_pkg::INT16;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCVT_H_XU}) op_mode = 1'b1; // upper
+      end
+      // [Alternate] Quarter Precision Floating-Point
+      riscv_instr::FMV_B_X: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = AccBus;
+        fpu_rnd_mode = fpnew_pkg::RUP; // passthrough without checking nan-box
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (fpu_fmt_mode_i.dst == 1'b1) begin
+          src_fmt    = fpnew_pkg::FP8ALT;
+          dst_fmt    = fpnew_pkg::FP8ALT;
+        end
+      end
+      riscv_instr::FCVT_B_W,
+      riscv_instr::FCVT_B_WU: begin
+        fpu_op = fpnew_pkg::I2F;
+        op_select[0] = AccBus;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        if (acc_req_q.data_op inside {riscv_instr::FCVT_B_WU}) op_mode = 1'b1; // unsigned
+      end
+      // Vectorial Quarter Precision Floating-Point
+      riscv_instr::VFMV_B_X: begin
+        fpu_op = fpnew_pkg::SGNJ;
+        op_select[0] = AccBus;
+        fpu_rnd_mode = fpnew_pkg::RUP; // passthrough without checking nan-box
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        vectorial_op = 1'b1;
+      end
+      riscv_instr::VFCVT_B_X,
+      riscv_instr::VFCVT_B_XU: begin
+        fpu_op = fpnew_pkg::I2F;
+        op_select[0] = AccBus;
+        src_fmt      = fpnew_pkg::FP8;
+        dst_fmt      = fpnew_pkg::FP8;
+        int_fmt      = fpnew_pkg::INT8;
+        vectorial_op = 1'b1;
+        set_dyn_rm   = 1'b1;
+        if (acc_req_q.data_op inside {riscv_instr::VFCVT_B_XU}) op_mode = 1'b1; // upper
+      end
+      // -------------
+      // Load / Store
+      // -------------
+      // Single Precision Floating-Point
+      riscv_instr::FLW: begin
+        is_load = 1'b1;
+        use_fpu = 1'b0;
+      end
+      riscv_instr::FSW: begin
+        is_store = 1'b1;
+        op_select[1] = RegB;
+        use_fpu = 1'b0;
+        rd_is_fp = 1'b0;
+      end
+      // Double Precision Floating-Point
+      riscv_instr::FLD: begin
+        is_load = 1'b1;
+        ls_size = DoubleWord;
+        use_fpu = 1'b0;
+      end
+      riscv_instr::FSD: begin
+        is_store = 1'b1;
+        op_select[1] = RegB;
+        ls_size = DoubleWord;
+        use_fpu = 1'b0;
+        rd_is_fp = 1'b0;
+      end
+      // [Alternate] Half Precision Floating-Point
+      riscv_instr::FLH: begin
+        is_load = 1'b1;
+        ls_size = HalfWord;
+        use_fpu = 1'b0;
+      end
+      riscv_instr::FSH: begin
+        is_store = 1'b1;
+        op_select[1] = RegB;
+        ls_size = HalfWord;
+        use_fpu = 1'b0;
+        rd_is_fp = 1'b0;
+      end
+      // [Alternate] Quarter Precision Floating-Point
+      riscv_instr::FLB: begin
+        is_load = 1'b1;
+        ls_size = Byte;
+        use_fpu = 1'b0;
+      end
+      riscv_instr::FSB: begin
+        is_store = 1'b1;
+        op_select[1] = RegB;
+        ls_size = Byte;
+        use_fpu = 1'b0;
+        rd_is_fp = 1'b0;
+      end
+      // -------------
+      // CSR Handling
+      // -------------
+      // Set or clear corresponding CSR
+      riscv_instr::CSRRSI: begin
+        use_fpu = 1'b0;
+        rd_is_fp = 1'b0;
+        csr_instr = 1'b1;
+        ssr_active_d |= rs1[0];
+      end
+      riscv_instr::CSRRCI: begin
+        use_fpu = 1'b0;
+        rd_is_fp = 1'b0;
+        csr_instr = 1'b1;
+        ssr_active_d &= ~rs1[0];
+      end
+      default: begin
+        use_fpu = 1'b0;
+        acc_resp_o.error = 1'b1;
+        rd_is_fp = 1'b0;
+      end
+    endcase
+    // fix round mode for vectors and fp16alt
+    if (set_dyn_rm) fpu_rnd_mode = fpu_rnd_mode_i;
+    // check if src_fmt or dst_fmt is acutually the alternate version
+    // single-format float operations ignore fpu_fmt_mode_i.src
+    // reason: for performance reasons when mixing expanding and non-expanding operations
+    if (src_fmt == fpnew_pkg::FP16 && fpu_fmt_mode_i.src == 1'b1) src_fmt = fpnew_pkg::FP16ALT;
+    if (dst_fmt == fpnew_pkg::FP16 && fpu_fmt_mode_i.dst == 1'b1) dst_fmt = fpnew_pkg::FP16ALT;
+    if (src_fmt == fpnew_pkg::FP8 && fpu_fmt_mode_i.src == 1'b1) src_fmt = fpnew_pkg::FP8ALT;
+    if (dst_fmt == fpnew_pkg::FP8 && fpu_fmt_mode_i.dst == 1'b1) dst_fmt = fpnew_pkg::FP8ALT;
+  end
+
+  snitch_regfile #(
+    .DATA_WIDTH     ( FLEN ),
+    .NR_READ_PORTS  ( 3    ),
+    .NR_WRITE_PORTS ( 1    ),
+    .ZERO_REG_ZERO  ( 0    ),
+    .ADDR_WIDTH     ( 5    )
+  ) i_ff_regfile (
+    .clk_i,
+    .raddr_i   ( fpr_raddr ),
+    .rdata_o   ( fpr_rdata ),
+    .waddr_i   ( fpr_waddr ),
+    .wdata_i   ( fpr_wdata ),
+    .we_i      ( fpr_we    )
+  );
+
+  // ----------------------
+  // Operand Select
+  // ----------------------
+  logic [2:0][FLEN-1:0] acc_qdata;
+  assign acc_qdata = {acc_req_q.data_argc, acc_req_q.data_argb, acc_req_q.data_arga};
+
+  // Mux address lines as operands for the FPU can be mangled
+  always_comb begin
+    fpr_raddr[0] = rs1;
+    fpr_raddr[1] = rs2;
+    fpr_raddr[2] = rs3;
+
+    unique case (op_select[1])
+      RegA: begin
+        fpr_raddr[1] = rs1;
+      end
+      default:;
+    endcase
+
+    unique case (op_select[2])
+      RegB,
+      RegBRep: begin
+        fpr_raddr[2] = rs2;
+      end
+      RegDest: begin
+        fpr_raddr[2] = rd;
+      end
+      default:;
+    endcase
+  end
+
+  for (genvar i = 0; i < 3; i++) begin: gen_operand_select
+    logic is_raddr_ssr;
+    always_comb begin
+      is_raddr_ssr = 1'b0;
+      for (int s = 0; s < NumSsrs; s++)
+        is_raddr_ssr |= (SsrRegs[s] == fpr_raddr[i]);
+    end
+    always_comb begin
+      ssr_rvalid_o[i] = 1'b0;
+      unique case (op_select[i])
+        None: begin
+          op[i] = '1;
+          op_ready[i] = 1'b1;
+        end
+        AccBus: begin
+          op[i] = acc_qdata[i];
+          op_ready[i] = acc_req_valid_q;
+        end
+        // Scoreboard or SSR
+        RegA, RegB, RegBRep, RegC, RegDest: begin
+          // map register 0 and 1 to SSRs
+          ssr_rvalid_o[i] = ssr_active_q & is_raddr_ssr;
+          op[i] = ssr_rvalid_o[i] ? ssr_rdata_i[i] : fpr_rdata[i];
+          // the operand is ready if it is not marked in the scoreboard
+          // and in case of it being an SSR it need to be ready as well
+          op_ready[i] = ~sb_q[fpr_raddr[i]] & (~ssr_rvalid_o[i] | ssr_rready_i[i]);
+          // Replicate if needed
+          if (op_select[i] == RegBRep) begin
+            unique case (src_fmt)
+              fpnew_pkg::FP32:    op[i] = {(FLEN / 32){op[i][31:0]}};
+              fpnew_pkg::FP16,
+              fpnew_pkg::FP16ALT: op[i] = {(FLEN / 16){op[i][15:0]}};
+              fpnew_pkg::FP8,
+              fpnew_pkg::FP8ALT:  op[i] = {(FLEN /  8){op[i][ 7:0]}};
+              default:            op[i] = op[i][FLEN-1:0];
+            endcase
+          end
+        end
+        default: begin
+          op[i] = '0;
+          op_ready[i] = 1'b1;
+        end
+      endcase
+    end
+  end
+
+  // ----------------------
+  // Floating Point Unit
+  // ----------------------
+  snitch_fpu #(
+    .RVF     ( RVF     ),
+    .RVD     ( RVD     ),
+    .XF16    ( XF16    ),
+    .XF16ALT ( XF16ALT ),
+    .XF8     ( XF8     ),
+    .XF8ALT  ( XF8ALT  ),
+    .XFVEC   ( XFVEC   ),
+    .FLEN    ( FLEN    ),
+    .FPUImplementation  (FPUImplementation),
+    .RegisterFPUIn      (RegisterFPUIn),
+    .RegisterFPUOut     (RegisterFPUOut)
+  ) i_fpu (
+    .clk_i                           ,
+    .rst_ni         ( ~rst_i        ),
+    .operands_i     ( op            ),
+    .rnd_mode_i     ( fpu_rnd_mode  ),
+    .op_i           ( fpu_op        ),
+    .op_mod_i       ( op_mode       ), // Sign of operand?
+    .src_fmt_i      ( src_fmt       ),
+    .dst_fmt_i      ( dst_fmt       ),
+    .int_fmt_i      ( int_fmt       ),
+    .vectorial_op_i ( vectorial_op  ),
+    .tag_i          ( fpu_tag_in    ),
+    .in_valid_i     ( fpu_in_valid  ),
+    .in_ready_o     ( fpu_in_ready  ),
+    .result_o       ( fpu_result    ),
+    .status_o       ( fpu_status_o  ),
+    .tag_o          ( fpu_tag_out   ),
+    .out_valid_o    ( fpu_out_valid ),
+    .out_ready_i    ( fpu_out_ready )
+  );
+
+  assign ssr_waddr_o = fpr_waddr;
+  assign ssr_wdata_o = fpr_wdata;
+  logic [63:0] nan_boxed_arga;
+  assign nan_boxed_arga = {{32{1'b1}}, acc_req_q.data_arga[31:0]};
+
+  // Arbitrate Register File Write Port
+  always_comb begin
+    fpr_we = 1'b0;
+    fpr_waddr = '0;
+    fpr_wdata = '0;
+    fpr_wvalid = 1'b0;
+    lsu_pready = 1'b0;
+    fpr_wready = 1'b1;
+    ssr_wvalid_o = 1'b0;
+    ssr_wdone_o = 1'b1;
+    // the accelerator master wants to write
+    if (acc_req_valid_q && result_select == ResAccBus) begin
+      fpr_we = 1'b1;
+      // NaN-Box the value
+      fpr_wdata = nan_boxed_arga[FLEN-1:0];
+      fpr_waddr = rd;
+      fpr_wvalid = 1'b1;
+      fpr_wready = 1'b0;
+    end else if (fpu_out_valid && !fpu_tag_out.acc) begin
+      fpr_we = 1'b1;
+      if (fpu_tag_out.ssr) begin
+        ssr_wvalid_o = 1'b1;
+        // stall write-back to SSR
+        if (!ssr_wready_i) begin
+          fpr_wready = 1'b0;
+          fpr_we = 1'b0;
+        end else begin
+          ssr_wdone_o = 1'b1;
+        end
+      end
+      fpr_wdata = fpu_result;
+      fpr_waddr = fpu_tag_out.rd;
+      fpr_wvalid = 1'b1;
+    end else if (lsu_pvalid) begin
+      lsu_pready = 1'b1;
+      fpr_we = 1'b1;
+      fpr_wdata = ld_result;
+      fpr_waddr = lsu_rd;
+      fpr_wvalid = 1'b1;
+      fpr_wready = 1'b0;
+    end
+  end
+
+  // ----------------------
+  // Load/Store Unit
+  // ----------------------
+  assign lsu_qvalid = acc_req_valid_q & (&op_ready) & (is_load | is_store);
+
+  snitch_lsu #(
+    .AddrWidth (AddrWidth),
+    .DataWidth (DataWidth),
+    .dreq_t (dreq_t),
+    .drsp_t (drsp_t),
+    .tag_t (logic [4:0]),
+    .NumOutstandingMem (NumFPOutstandingMem),
+    .NumOutstandingLoads (NumFPOutstandingLoads),
+    .NaNBox (1'b1)
+  ) i_snitch_lsu (
+    .clk_i (clk_i),
+    .rst_i (rst_i),
+    .lsu_qtag_i (rd),
+    .lsu_qwrite_i (is_store),
+    .lsu_qsigned_i (1'b1), // all floating point loads are signed
+    .lsu_qaddr_i (acc_req_q.data_argc[AddrWidth-1:0]),
+    .lsu_qdata_i (op[1]),
+    .lsu_qsize_i (ls_size),
+    .lsu_qamo_i (reqrsp_pkg::AMONone),
+    .lsu_qvalid_i (lsu_qvalid),
+    .lsu_qready_o (lsu_qready),
+    .lsu_pdata_o (ld_result),
+    .lsu_ptag_o (lsu_rd),
+    .lsu_perror_o (), // ignored for the moment
+    .lsu_pvalid_o (lsu_pvalid),
+    .lsu_pready_i (lsu_pready),
+    .lsu_empty_o (/* unused */),
+    .data_req_o,
+    .data_rsp_i
+  );
+
+  // SSRs
+  for (genvar i = 0; i < 3; i++) assign ssr_rdone_o[i] = ssr_rvalid_o[i] & acc_req_ready_q;
+  assign ssr_raddr_o = fpr_raddr;
+
+  // Counter pipeline.
+  logic issue_fpu, issue_core_to_fpu, issue_fpu_seq;
+  `FFAR(issue_fpu, fpu_in_valid & fpu_in_ready, 1'b0, clk_i, rst_i)
+  `FFAR(issue_core_to_fpu, acc_req_valid_i & acc_req_ready_o, 1'b0, clk_i, rst_i)
+  `FFAR(issue_fpu_seq, acc_req_valid & acc_req_ready, 1'b0, clk_i, rst_i)
+
+  always_comb begin
+    core_events_o = '0;
+    core_events_o.issue_fpu = issue_fpu;
+    core_events_o.issue_core_to_fpu = issue_core_to_fpu;
+    core_events_o.issue_fpu_seq = issue_fpu_seq;
+  end
+
+  // Tracer
+  // pragma translate_off
+  assign trace_port_o.source       = snitch_pkg::SrcFpu;
+  assign trace_port_o.acc_q_hs     = (acc_req_valid_q  && acc_req_ready_q );
+  assign trace_port_o.fpu_out_hs   = (fpu_out_valid && fpu_out_ready );
+  assign trace_port_o.lsu_q_hs     = (lsu_qvalid    && lsu_qready    );
+  assign trace_port_o.op_in        = acc_req_q.data_op;
+  assign trace_port_o.rs1          = rs1;
+  assign trace_port_o.rs2          = rs2;
+  assign trace_port_o.rs3          = rs3;
+  assign trace_port_o.rd           = rd;
+  assign trace_port_o.op_sel_0     = op_select[0];
+  assign trace_port_o.op_sel_1     = op_select[1];
+  assign trace_port_o.op_sel_2     = op_select[2];
+  assign trace_port_o.src_fmt      = src_fmt;
+  assign trace_port_o.dst_fmt      = dst_fmt;
+  assign trace_port_o.int_fmt      = int_fmt;
+  assign trace_port_o.acc_qdata_0  = acc_qdata[0];
+  assign trace_port_o.acc_qdata_1  = acc_qdata[1];
+  assign trace_port_o.acc_qdata_2  = acc_qdata[2];
+  assign trace_port_o.op_0         = op[0];
+  assign trace_port_o.op_1         = op[1];
+  assign trace_port_o.op_2         = op[2];
+  assign trace_port_o.use_fpu      = use_fpu;
+  assign trace_port_o.fpu_in_rd    = fpu_tag_in.rd;
+  assign trace_port_o.fpu_in_acc   = fpu_tag_in.acc;
+  assign trace_port_o.ls_size      = ls_size;
+  assign trace_port_o.is_load      = is_load;
+  assign trace_port_o.is_store     = is_store;
+  assign trace_port_o.lsu_qaddr    = i_snitch_lsu.lsu_qaddr_i;
+  assign trace_port_o.lsu_rd       = lsu_rd;
+  assign trace_port_o.acc_wb_ready = (result_select == ResAccBus);
+  assign trace_port_o.fpu_out_acc  = fpu_tag_out.acc;
+  assign trace_port_o.fpr_waddr    = fpr_waddr[0];
+  assign trace_port_o.fpr_wdata    = fpr_wdata[0];
+  assign trace_port_o.fpr_we       = fpr_we[0];
+  // pragma translate_on
+
+  /// Assertions
+  `ASSERT(RegWriteKnown, fpr_we |-> !$isunknown(fpr_wdata), clk_i, rst_i)
+endmodule

--- a/snitch-core/accelerator/snitch_fpu.sv
+++ b/snitch-core/accelerator/snitch_fpu.sv
@@ -1,0 +1,146 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+/// FPU Synthesis Wrapper
+module snitch_fpu import snitch_pkg::*; #(
+  parameter fpnew_pkg::fpu_implementation_t FPUImplementation = '0,
+  parameter bit          RVF                = 1,
+  parameter bit          RVD                = 1,
+  parameter bit          XF16               = 0,
+  parameter bit          XF16ALT            = 0,
+  parameter bit          XF8                = 0,
+  parameter bit          XF8ALT             = 0,
+  parameter bit          XFVEC              = 0,
+  parameter int unsigned FLEN               = 0,
+  parameter bit          RegisterFPUIn      = 0,
+  parameter bit          RegisterFPUOut     = 0
+) (
+  input logic                               clk_i,
+  input logic                               rst_ni,
+  // Input signals
+  input logic [2:0][FLEN-1:0]               operands_i,
+  input fpnew_pkg::roundmode_e              rnd_mode_i,
+  input fpnew_pkg::operation_e              op_i,
+  input logic                               op_mod_i,
+  input fpnew_pkg::fp_format_e              src_fmt_i,
+  input fpnew_pkg::fp_format_e              dst_fmt_i,
+  input fpnew_pkg::int_format_e             int_fmt_i,
+  input logic                               vectorial_op_i,
+  input logic [6:0]                         tag_i,
+  // Input Handshake
+  input  logic                              in_valid_i,
+  output logic                              in_ready_o,
+  // Output signals
+  output logic [FLEN-1:0]                   result_o,
+  output logic [4:0]                        status_o,
+  output logic [6:0]                        tag_o,
+  // Output handshake
+  output logic                              out_valid_o,
+  input  logic                              out_ready_i
+);
+
+  localparam fpnew_pkg::fpu_features_t FPUFeatures = '{
+    Width:             fpnew_pkg::maximum(FLEN, 32),
+    EnableVectors:     XFVEC,
+    EnableNanBox:      1'b1,
+    FpFmtMask:         {RVF, RVD, XF16, XF8, XF16ALT, XF8ALT},
+    IntFmtMask:        {XFVEC && (XF8 || XF8ALT), XFVEC && (XF16 || XF16ALT), 1'b1, 1'b0}
+  };
+
+  typedef struct packed {
+    logic [2:0][FLEN-1:0]    operands;
+    fpnew_pkg::roundmode_e   rnd_mode;
+    fpnew_pkg::operation_e   op;
+    logic                    op_mod;
+    fpnew_pkg::fp_format_e   src_fmt;
+    fpnew_pkg::fp_format_e   dst_fmt;
+    fpnew_pkg::int_format_e  int_fmt;
+    logic                    vectorial_op;
+    logic [6:0]              tag;
+  } fpu_in_t;
+
+  typedef struct packed {
+    logic [FLEN-1:0] result;
+    logic [4:0]      status;
+    logic [6:0]      tag;
+  } fpu_out_t;
+
+  fpu_in_t fpu_in_q, fpu_in;
+  fpu_out_t fpu_out_q, fpu_out;
+  logic in_valid_q, in_ready_q;
+  logic out_valid, out_ready;
+
+  assign fpu_in = '{
+    operands: operands_i,
+    rnd_mode: rnd_mode_i,
+    op: op_i,
+    op_mod: op_mod_i,
+    src_fmt: src_fmt_i,
+    dst_fmt: dst_fmt_i,
+    int_fmt: int_fmt_i,
+    vectorial_op: vectorial_op_i,
+    tag: tag_i
+  };
+
+  spill_register #(
+    .T      ( fpu_in_t ),
+    .Bypass ( ~RegisterFPUIn )
+  ) i_spill_register_fpu_in (
+    .clk_i                 ,
+    .rst_ni                ,
+    .valid_i ( in_valid_i ),
+    .ready_o ( in_ready_o ),
+    .data_i  ( fpu_in     ),
+    .valid_o ( in_valid_q ),
+    .ready_i ( in_ready_q ),
+    .data_o  ( fpu_in_q   )
+  );
+
+  fpnew_top #(
+    // FPU configuration
+    .Features       ( FPUFeatures ),
+    .Implementation ( FPUImplementation ),
+    .TagType        ( logic[6:0]        )
+  ) i_fpu (
+    .clk_i                                    ,
+    .rst_ni                                   ,
+    .operands_i      ( fpu_in_q.operands     ),
+    .rnd_mode_i      ( fpu_in_q.rnd_mode     ),
+    .op_i            ( fpu_in_q.op           ),
+    .op_mod_i        ( fpu_in_q.op_mod       ),
+    .src_fmt_i       ( fpu_in_q.src_fmt      ),
+    .dst_fmt_i       ( fpu_in_q.dst_fmt      ),
+    .int_fmt_i       ( fpu_in_q.int_fmt      ),
+    .vectorial_op_i  ( fpu_in_q.vectorial_op ),
+    .tag_i           ( fpu_in_q.tag          ),
+    .in_valid_i      ( in_valid_q            ),
+    .in_ready_o      ( in_ready_q            ),
+    .flush_i         ( 1'b0                  ),
+    .result_o        ( fpu_out.result        ),
+    .status_o        ( fpu_out.status        ),
+    .tag_o           ( fpu_out.tag           ),
+    .out_valid_o     ( out_valid             ),
+    .out_ready_i     ( out_ready             ),
+    .busy_o          (                       )
+  );
+
+  spill_register #(
+    .T      ( fpu_out_t ),
+    .Bypass ( ~RegisterFPUOut )
+  ) i_spill_register_fpu_out (
+    .clk_i                  ,
+    .rst_ni                 ,
+    .valid_i ( out_valid   ),
+    .ready_o ( out_ready   ),
+    .data_i  ( fpu_out     ),
+    .valid_o ( out_valid_o ),
+    .ready_i ( out_ready_i ),
+    .data_o  ( fpu_out_q   )
+  );
+
+  assign result_o = fpu_out_q.result;
+  assign status_o = fpu_out_q.status;
+  assign tag_o = fpu_out_q.tag;
+
+endmodule

--- a/snitch-core/accelerator/snitch_int_ss.sv
+++ b/snitch-core/accelerator/snitch_int_ss.sv
@@ -1,0 +1,625 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+`include "common_cells/registers.svh"
+
+module snitch_int_ss import riscv_instr::*; import snitch_ipu_pkg::*; import snitch_pkg::*; #(
+  parameter int unsigned AddrWidth = 0,
+  parameter int unsigned DataWidth = 0,
+  parameter int unsigned NumIPUSequencerInstr = 0,
+  parameter bit          IPUSequencer = 1,
+  parameter bit          RegisterSequencer = 1,
+  parameter type         acc_req_t = logic,
+  parameter type         acc_resp_t = logic,
+  /// Derived parameter *Do not override*
+  parameter type addr_t = logic [AddrWidth-1:0],
+  parameter type data_t = logic [DataWidth-1:0]
+) (
+  input  logic          clk_i,
+  input  logic          rst_i,
+
+  // Accelerator Interface - Slave
+  input  acc_req_t         acc_req_i,
+  input  logic             acc_req_valid_i,
+  output logic             acc_req_ready_o,
+  output acc_resp_t        acc_resp_o,
+  output logic             acc_resp_valid_o,
+  input  logic             acc_resp_ready_i,
+  // SSR Interface
+  output logic  [2:0][4:0] ssr_raddr_o,
+  input  data_t [2:0]      ssr_rdata_i,
+  output logic  [2:0]      ssr_rvalid_o,
+  input  logic  [2:0]      ssr_rready_i,
+  output logic  [2:0]      ssr_rdone_o,
+  output logic  [0:0][4:0] ssr_waddr_o,
+  output data_t [0:0]      ssr_wdata_o,
+  output logic  [0:0]      ssr_wvalid_o,
+  input  logic  [0:0]      ssr_wready_i,
+  output logic  [0:0]      ssr_wdone_o,
+  // SSR stream control interface
+  input  logic             streamctl_done_i,
+  input  logic             streamctl_valid_i,
+  output logic             streamctl_ready_o
+);
+
+  logic [2:0][4:0]  int_raddr;
+  logic [2:0][31:0] int_rdata;
+
+  logic [0:0]       int_we;
+  logic [0:0][4:0]  int_waddr;
+  logic [0:0][31:0] int_wdata;
+  logic [0:0]       int_wvalid;
+  logic [0:0]       int_wready;
+
+  logic illegal;
+  logic stall;
+  logic valid_inst;
+
+  logic multicycle_active_d, multicycle_active_q;
+  logic is_multicycle;
+
+  logic [31:0] iimm;
+
+  logic [4:0] rs1, rs2, rs3, rd;
+  logic [31:0] alu_result;
+  logic [31:0]  imd_val_q [2];
+  logic [31:0]  imd_val_d [2];
+  logic [1:0]  imd_val_we;
+  logic [2:0][31:0] alu_operand;
+
+  typedef enum logic [1:0] {
+    None,
+    AccBus,
+    IImm,
+    Reg
+  } op_select_e;
+
+  typedef enum logic [1:0] {
+    ResNone, ResAccBus
+  } result_select_e;
+  result_select_e result_select;
+
+  op_select_e [2:0] op_select;
+  alu_op_e alu_op;
+
+  assign ssr_raddr_o = '0;
+  assign ssr_rvalid_o = '0;
+  assign ssr_rdone_o = '0;
+  assign ssr_waddr_o = '0;
+  assign ssr_wdata_o = '0;
+  assign ssr_wvalid_o = '0;
+  assign ssr_wdone_o = '0;
+
+  // -------------
+  // IPU Sequencer
+  // -------------
+  acc_req_t         acc_req, acc_req_q;
+  logic             acc_req_valid, acc_req_valid_q;
+  logic             acc_req_ready, acc_req_ready_q;
+  if (IPUSequencer) begin : gen_ipu_sequencer
+    snitch_sequencer #(
+      .Depth    ( NumIPUSequencerInstr )
+    ) i_snitch_ipu_sequencer (
+      .clk_i,
+      .rst_i,
+      // pragma translate_off
+      .trace_port_o     ( /* TODO(zarubaf,fschuiki) Connect */  ),
+      // pragma translate_on
+      .inp_qaddr_i      ( acc_req_i.addr      ),
+      .inp_qid_i        ( acc_req_i.id        ),
+      .inp_qdata_op_i   ( acc_req_i.data_op   ),
+      .inp_qdata_arga_i ( acc_req_i.data_arga ),
+      .inp_qdata_argb_i ( acc_req_i.data_argb ),
+      .inp_qdata_argc_i ( acc_req_i.data_argc ),
+      .inp_qvalid_i     ( acc_req_valid_i     ),
+      .inp_qready_o     ( acc_req_ready_o     ),
+      .oup_qaddr_o      ( acc_req.addr        ),
+      .oup_qid_o        ( acc_req.id          ),
+      .oup_qdata_op_o   ( acc_req.data_op     ),
+      .oup_qdata_arga_o ( acc_req.data_arga   ),
+      .oup_qdata_argb_o ( acc_req.data_argb   ),
+      .oup_qdata_argc_o ( acc_req.data_argc   ),
+      .oup_qvalid_o     ( acc_req_valid       ),
+      .oup_qready_i     ( acc_req_ready       ),
+      .streamctl_done_i,
+      .streamctl_valid_i,
+      .streamctl_ready_o
+    );
+  end else begin : gen_no_ipu_sequencer
+    // assign sequencer_tracer_port_o = 0;
+    assign acc_req_ready_o = acc_req_ready;
+    assign acc_req_valid = acc_req_valid_i;
+    assign acc_req = acc_req_i;
+  end
+
+  // Optional spill-register
+  spill_register  #(
+    .T      ( acc_req_t                           ),
+    .Bypass ( !RegisterSequencer || !IPUSequencer )
+  ) i_spill_register_acc (
+    .clk_i   ,
+    .rst_ni  ( ~rst_i          ),
+    .valid_i ( acc_req_valid   ),
+    .ready_o ( acc_req_ready   ),
+    .data_i  ( acc_req         ),
+    .valid_o ( acc_req_valid_q ),
+    .ready_i ( acc_req_ready_q ),
+    .data_o  ( acc_req_q       )
+  );
+
+  assign iimm = $signed({acc_req_q.data_op[31:20]});
+
+  // Assignments
+  assign rd = acc_req_q.data_op[11:7];
+  assign rs1 = acc_req_q.data_op[19:15];
+  assign rs2 = acc_req_q.data_op[24:20];
+  assign rs3 = acc_req_q.data_op[31:27];
+
+  `FFLAR(multicycle_active_q, multicycle_active_d, ~stall, '0, clk_i, rst_i)
+  assign multicycle_active_d = is_multicycle & ~multicycle_active_q;
+
+  // stall in case the downstream circuit isn't ready
+  assign stall = acc_resp_valid_o & ~acc_resp_ready_i;
+  assign valid_inst = acc_req_valid_q & (~is_multicycle | multicycle_active_q);
+  // TODO(zarubaf): Fix handshake
+  // A |-> B = ~A | B
+  assign acc_req_ready_q = ~stall;
+  assign acc_resp_valid_o = valid_inst & (result_select == ResAccBus);
+
+  assign acc_resp_o.data = $unsigned(alu_result);
+  assign acc_resp_o.error = illegal;
+  assign acc_resp_o.id = acc_req_q.id;
+
+  // Decoder
+  always_comb begin
+    alu_op = ALU_ANDN;
+
+    result_select = ResNone;
+
+    op_select[0] = None;
+    op_select[1] = None;
+    op_select[2] = None;
+
+    illegal = 1'b0;
+
+    is_multicycle = 1'b0;
+
+    unique casez (acc_req_q.data_op)
+      ANDN: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+      end
+      ORN: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_ORN;
+      end
+      XNOR: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_XNOR;
+      end
+      SLO, SLOI: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_SLO;
+      end
+      SRO, SROI: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_SRO;
+      end
+      ROL: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_ROL;
+      end
+      ROR, RORI: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_ROR;
+      end
+      SBCLR, SBCLRI: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_SBCLR;
+      end
+      SBSET, SBSETI: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_SBSET;
+      end
+      SBINV, SBINVI: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_SBINV;
+      end
+      SBEXT, SBEXTI: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_SBEXT;
+      end
+      GORC, GORCI: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_GORC;
+      end
+      GREV, GREVI: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_GREV;
+      end
+      CLZ: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_CLZ;
+      end
+      CTZ: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_CTZ;
+      end
+      PCNT: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_PCNT;
+      end
+      SEXT_B: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_SEXTB;
+      end
+      SEXT_H: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_SEXTH;
+      end
+      CRC32_B: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        is_multicycle = 1'b1;
+        alu_op = ALU_CRC32_B;
+      end
+      CRC32_H: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        is_multicycle = 1'b1;
+        alu_op = ALU_CRC32_H;
+      end
+      CRC32_W: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        is_multicycle = 1'b1;
+        alu_op = ALU_CRC32_W;
+      end
+      CRC32C_B: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        is_multicycle = 1'b1;
+        alu_op = ALU_CRC32C_B;
+      end
+      CRC32C_H: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        is_multicycle = 1'b1;
+        alu_op = ALU_CRC32C_H;
+      end
+      CRC32C_W: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        is_multicycle = 1'b1;
+        alu_op = ALU_CRC32C_W;
+      end
+      // Not implemented.
+      // SH1ADD:;
+      // SH2ADD:;
+      // SH3ADD:;
+      CLMUL: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        is_multicycle = 1'b1;
+        alu_op = ALU_CLMUL;
+      end
+      ALU_CLMULR: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        is_multicycle = 1'b1;
+        alu_op = ALU_CLMUL;
+      end
+      CLMULH: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        is_multicycle = 1'b1;
+        alu_op = ALU_CLMULH;
+      end
+      MIN: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_MIN;
+      end
+      MAX: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_MAX;
+      end
+      MINU: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_MINU;
+      end
+      MAXU: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_MAXU;
+      end
+      SHFL, SHFLI: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_SHFL;
+      end
+      UNSHFL, UNSHFLI: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_UNSHFL;
+      end
+      BEXT: begin
+        result_select = ResAccBus;
+        is_multicycle = 1'b1;
+      end
+      BDEP: begin
+        result_select = ResAccBus;
+        is_multicycle = 1'b1;
+      end
+      PACK: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_PACK;
+      end
+      PACKU: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_PACKU;
+      end
+      PACKH: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_PACKH;
+      end
+      BFP: begin
+        result_select = ResAccBus;
+        op_select[0] = AccBus;
+        op_select[1] = AccBus;
+        alu_op = ALU_BFP;
+      end
+      // Move back to integer register file
+      IMV_X_W: begin
+        op_select[0] = Reg;
+        alu_op = ALU_OR;
+        result_select = ResAccBus;
+      end
+      // Move from integer to IPU
+      IMV_W_X: begin
+        op_select[0] = AccBus;
+        alu_op = ALU_OR;
+      end
+      // IPU Operations
+      // Reg immediate
+      IADDI: begin
+        op_select[0] = Reg;
+        op_select[1] = IImm;
+        alu_op = ALU_ADD;
+      end
+      ISLLI: begin
+        op_select[0] = Reg;
+        op_select[1] = IImm;
+        alu_op = ALU_SLL;
+      end
+      ISLTI: begin
+        op_select[0] = Reg;
+        op_select[1] = IImm;
+        alu_op = ALU_SLT;
+      end
+      ISLTIU: begin
+        op_select[0] = Reg;
+        op_select[1] = IImm;
+        alu_op = ALU_SLTU;
+      end
+      IXORI: begin
+        op_select[0] = Reg;
+        op_select[1] = IImm;
+        alu_op = ALU_XOR;
+      end
+      ISRLI: begin
+        op_select[0] = Reg;
+        op_select[1] = IImm;
+        alu_op = ALU_SRL;
+      end
+      ISRAI: begin
+        op_select[0] = Reg;
+        op_select[1] = IImm;
+        alu_op = ALU_SRA;
+      end
+      IORI: begin
+        op_select[0] = Reg;
+        op_select[1] = IImm;
+        alu_op = ALU_OR;
+      end
+      IANDI: begin
+        op_select[0] = Reg;
+        op_select[1] = IImm;
+        alu_op = ALU_AND;
+      end
+      // Reg - Reg operations
+      IADD: begin
+        op_select[0] = Reg;
+        op_select[1] = Reg;
+        alu_op = ALU_ADD;
+      end
+      ISUB: begin
+        op_select[0] = Reg;
+        op_select[1] = Reg;
+        alu_op = ALU_SUB;
+      end
+      ISLL: begin
+        op_select[0] = Reg;
+        op_select[1] = Reg;
+        alu_op = ALU_SLL;
+      end
+      ISLT: begin
+        op_select[0] = Reg;
+        op_select[1] = Reg;
+        alu_op = ALU_SLT;
+      end
+      ISLTU: begin
+        op_select[0] = Reg;
+        op_select[1] = Reg;
+        alu_op = ALU_SLTU;
+      end
+      IXOR: begin
+        op_select[0] = Reg;
+        op_select[1] = Reg;
+        alu_op = ALU_XOR;
+      end
+      ISRL: begin
+        op_select[0] = Reg;
+        op_select[1] = Reg;
+        alu_op = ALU_SRL;
+      end
+      ISRA: begin
+        op_select[0] = Reg;
+        op_select[1] = Reg;
+        alu_op = ALU_SRA;
+      end
+      IOR: begin
+        op_select[0] = Reg;
+        op_select[1] = Reg;
+        alu_op = ALU_OR;
+      end
+      IAND: begin
+        op_select[0] = Reg;
+        op_select[1] = Reg;
+        alu_op = ALU_AND;
+      end
+      // TODO(zarubaf): Implement the rest.
+      default: begin
+        illegal = 1'b1;
+      end
+    endcase
+  end
+
+  // ----------------------
+  // Operand Select
+  // ----------------------
+  always_comb begin
+    int_raddr[0] = rs1;
+    int_raddr[1] = rs2;
+    int_raddr[2] = rs3;
+  end
+
+  for (genvar i = 0; i < 3; i++) begin: gen_operand_select
+    always_comb begin
+      alu_operand[i] = '0;
+      unique case (op_select[i])
+        None:;
+        Reg: alu_operand[i] = int_rdata[i];
+        AccBus: begin
+          unique case (i)
+            0: alu_operand[i] = acc_req_q.data_arga;
+            1: alu_operand[i] = acc_req_q.data_argb;
+            2: alu_operand[i] = acc_req_q.data_argc;
+            default:;
+          endcase
+        end
+        IImm: begin
+           alu_operand[i] = iimm;
+        end
+        default:;
+      endcase
+    end
+  end
+
+  // Write Port
+  always_comb begin
+    int_we = ~stall & valid_inst & (result_select == ResNone);
+    int_wdata = alu_result;
+    int_waddr = rd;
+  end
+
+  // -------
+  // IPU ALU
+  // -------
+  snitch_ipu_alu #(
+    .RV32B (RV32BFull)
+  ) snitch_ipu_alu (
+    .operator_i (alu_op),
+    .operand_a_i (alu_operand[0]),
+    .operand_b_i (alu_operand[1]),
+    .instr_first_cycle_i (~multicycle_active_q),
+    .imd_val_q_i (imd_val_q),
+    .imd_val_d_o (imd_val_d),
+    .imd_val_we_o (imd_val_we),
+    .result_o (alu_result),
+    .comparison_result_o (),
+    .is_equal_result_o ()
+  );
+
+  for (genvar i = 0; i < 2; i++) begin : gen_multi_cycle_buffer
+    `FFLNR(imd_val_q[i], imd_val_q[i], imd_val_we[i], clk_i)
+  end
+
+  // ---------------
+  // Integer Regfile
+  // ---------------
+  snitch_regfile #(
+    .DATA_WIDTH     ( 32 ),
+    .NR_READ_PORTS  ( 3  ),
+    .NR_WRITE_PORTS ( 1  ),
+    .ZERO_REG_ZERO  ( 0  ),
+    .ADDR_WIDTH     ( 5  )
+  ) i_ipu_regfile (
+    .clk_i,
+    .raddr_i   ( int_raddr ),
+    .rdata_o   ( int_rdata ),
+    .waddr_i   ( int_waddr ),
+    .wdata_i   ( int_wdata ),
+    .we_i      ( int_we    )
+  );
+
+endmodule

--- a/snitch-core/accelerator/snitch_ipu_alu.sv
+++ b/snitch-core/accelerator/snitch_ipu_alu.sv
@@ -1,0 +1,1233 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+/**
+ * Arithmetic logic unit
+ */
+
+// Completely based on the Ibex ALU.
+module snitch_ipu_alu import snitch_ipu_pkg::*; #(
+  parameter rv32b_e RV32B = RV32BNone
+) (
+    input  alu_op_e      operator_i,
+    input  logic [31:0]  operand_a_i,
+    input  logic [31:0]  operand_b_i,
+
+    input  logic         instr_first_cycle_i,
+
+    input  logic [31:0]  imd_val_q_i[2],
+    output logic [31:0]  imd_val_d_o[2],
+    output logic [1:0]   imd_val_we_o,
+
+    output logic [31:0]  result_o,
+    output logic         comparison_result_o,
+    output logic         is_equal_result_o
+);
+
+  logic [31:0] operand_a_rev;
+  logic [32:0] operand_b_neg;
+
+  // bit reverse operand_a for left shifts and bit counting
+  for (genvar k = 0; k < 32; k++) begin : gen_rev_operand_a
+    assign operand_a_rev[k] = operand_a_i[31-k];
+  end
+
+  ///////////
+  // Adder //
+  ///////////
+
+  logic        adder_op_b_negate;
+  logic [32:0] adder_in_a, adder_in_b;
+  logic [31:0] adder_result;
+
+  always_comb begin
+    adder_op_b_negate = 1'b0;
+    unique case (operator_i)
+      // Adder OPs
+      ALU_SUB,
+
+      // Comparator OPs
+      ALU_EQ,   ALU_NE,
+      ALU_GE,   ALU_GEU,
+      ALU_LT,   ALU_LTU,
+      ALU_SLT,  ALU_SLTU,
+
+      // MinMax OPs (RV32B Ops)
+      ALU_MIN,  ALU_MINU,
+      ALU_MAX,  ALU_MAXU: adder_op_b_negate = 1'b1;
+
+      default:;
+    endcase
+  end
+
+  // prepare operand a
+  assign adder_in_a = {operand_a_i,1'b1};
+
+  // prepare operand b
+  assign operand_b_neg = {operand_b_i,1'b0} ^ {33{1'b1}};
+  assign adder_in_b = adder_op_b_negate ? operand_b_neg : {operand_b_i, 1'b0};
+
+  // actual adder
+  logic [33:0] adder_result_ext;
+  assign adder_result_ext = $unsigned(adder_in_a) + $unsigned(adder_in_b);
+
+  assign adder_result = adder_result_ext[32:1];
+
+  ////////////////
+  // Comparison //
+  ////////////////
+
+  logic is_equal;
+  logic is_greater_equal;  // handles both signed and unsigned forms
+  logic cmp_signed;
+
+  always_comb begin
+    unique case (operator_i)
+      ALU_GE,
+      ALU_LT,
+      ALU_SLT,
+      // RV32B only
+      ALU_MIN,
+      ALU_MAX: cmp_signed = 1'b1;
+
+      default: cmp_signed = 1'b0;
+    endcase
+  end
+
+  assign is_equal = (adder_result == 32'b0);
+  assign is_equal_result_o = is_equal;
+
+  // Is greater equal
+  always_comb begin
+    if ((operand_a_i[31] ^ operand_b_i[31]) == 1'b0) begin
+      is_greater_equal = (adder_result[31] == 1'b0);
+    end else begin
+      is_greater_equal = operand_a_i[31] ^ (cmp_signed);
+    end
+  end
+
+  // GTE unsigned:
+  // (a[31] == 1 && b[31] == 1) => adder_result[31] == 0
+  // (a[31] == 0 && b[31] == 0) => adder_result[31] == 0
+  // (a[31] == 1 && b[31] == 0) => 1
+  // (a[31] == 0 && b[31] == 1) => 0
+
+  // GTE signed:
+  // (a[31] == 1 && b[31] == 1) => adder_result[31] == 0
+  // (a[31] == 0 && b[31] == 0) => adder_result[31] == 0
+  // (a[31] == 1 && b[31] == 0) => 0
+  // (a[31] == 0 && b[31] == 1) => 1
+
+  // generate comparison result
+  logic cmp_result;
+
+  always_comb begin
+    unique case (operator_i)
+      ALU_EQ:             cmp_result =  is_equal;
+      ALU_NE:             cmp_result = ~is_equal;
+      ALU_GE,   ALU_GEU,
+      ALU_MAX,  ALU_MAXU: cmp_result = is_greater_equal; // RV32B only
+      ALU_LT,   ALU_LTU,
+      ALU_MIN,  ALU_MINU, //RV32B only
+      ALU_SLT,  ALU_SLTU: cmp_result = ~is_greater_equal;
+
+      default: cmp_result = is_equal;
+    endcase
+  end
+
+  assign comparison_result_o = cmp_result;
+
+  ///////////
+  // Shift //
+  ///////////
+
+  // The shifter structure consists of a 33-bit shifter: 32-bit operand + 1 bit extension for
+  // arithmetic shifts and one-shift support.
+  // Rotations and funnel shifts are implemented as multi-cycle instructions.
+  // The shifter is also used for single-bit instructions and bit-field place as detailed below.
+  //
+  // Standard Shifts
+  // ===============
+  // For standard shift instructions, the direction of the shift is to the right by default. For
+  // left shifts, the signal shift_left signal is set. If so, the operand is initially reversed,
+  // shifted to the right by the specified amount and shifted back again. For arithmetic- and
+  // one-shifts the 33rd bit of the shifter operand can is set accordingly.
+  //
+  // Multicycle Shifts
+  // =================
+  //
+  // Rotation
+  // --------
+  // For rotations, the operand signals operand_a_i and operand_b_i are kept constant to rs1 and
+  // rs2 respectively.
+  //
+  // Rotation pseudocode:
+  //   shift_amt = rs2 & 31;
+  //   multicycle_result = (rs1 >> shift_amt) | (rs1 << (32 - shift_amt));
+  //                       ^-- cycle 0 -----^ ^-- cycle 1 --------------^
+  //
+  // Funnel Shifts
+  // -------------
+  // For funnel shifs, operand_a_i is tied to rs1 in the first cycle and rs3 in the
+  // second cycle. operand_b_i is always tied to rs2. The order of applying the shift amount or
+  // its complement is determined by bit [5] of shift_amt.
+  //
+  // Funnel shift Pseudocode: (fsl)
+  //  shift_amt = rs2 & 63;
+  //  shift_amt_compl = 32 - shift_amt[4:0]
+  //  if (shift_amt >=33):
+  //     multicycle_result = (rs1 >> shift_amt_cmpl[4:0]) | (rs3 << shift_amt[4:0]);
+  //                         ^-- cycle 0 ---------------^ ^-- cycle 1 ------------^
+  //  else if (shift_amt <= 31 && shift_amt > 0):
+  //     multicycle_result = (rs1 << shift_amt[4:0]) | (rs3 >> shift_amt_compl[4:0]);
+  //                         ^-- cycle 0 ----------^ ^-- cycle 1 -------------------^
+  //  For shift_amt == 0, 32, both shift_amt[4:0] and shift_amt_compl[4:0] == '0.
+  //  these cases need to be handled separately outside the shifting structure:
+  //  else if (shift_amt == 32):
+  //     multicycle_result = rs3
+  //  else if (shift_amt == 0):
+  //     multicycle_result = rs1.
+  //
+  // Single-Bit Instructions
+  // =======================
+  // Single bit instructions operate on bit operand_b_i[4:0] of operand_a_i.
+
+  // The operations sbset, sbclr and sbinv are implemented by generation of a bit-mask using the
+  // shifter structure. This is done by left-shifting the operand 32'h1 by the required amount.
+  // The signal shift_sbmode multiplexes the shifter input and sets the signal shift_left.
+  // Further processing is taken care of by a separate structure.
+  //
+  // For sbext, the bit defined by operand_b_i[4:0] is to be returned. This is done by simply
+  // shifting operand_a_i to the right by the required amount and returning bit [0] of the result.
+  //
+  // Bit-Field Place
+  // ===============
+  // The shifter structure is shared to compute bfp_mask << bfp_off.
+
+  logic       shift_left;
+  logic       shift_ones;
+  logic       shift_arith;
+  logic       shift_funnel;
+  logic       shift_sbmode;
+  logic [5:0] shift_amt;
+  logic [5:0] shift_amt_compl; // complementary shift amount (32 - shift_amt)
+
+  logic [31:0] shift_result;
+  logic [32:0] shift_result_ext;
+  logic [31:0] shift_result_rev;
+
+  // zbf
+  logic bfp_op;
+  logic [4:0]  bfp_len;
+  logic [4:0]  bfp_off;
+  logic [31:0] bfp_mask;
+  logic [31:0] bfp_mask_rev;
+  logic [31:0] bfp_result;
+
+  // bfp: shares the shifter structure to compute bfp_mask << bfp_off
+  assign bfp_op = (RV32B != RV32BNone) ? (operator_i == ALU_BFP) : 1'b0;
+  assign bfp_len = {~(|operand_b_i[27:24]), operand_b_i[27:24]}; // len = 0 encodes for len = 16
+  assign bfp_off = operand_b_i[20:16];
+  assign bfp_mask = (RV32B != RV32BNone) ? ~(32'hffff_ffff << bfp_len) : '0;
+  for (genvar i=0; i<32; i++) begin : gen_rev_bfp_mask
+    assign bfp_mask_rev[i] = bfp_mask[31-i];
+  end
+
+  assign bfp_result =(RV32B != RV32BNone) ?
+      (~shift_result & operand_a_i) | ((operand_b_i & bfp_mask) << bfp_off) : '0;
+
+  // bit shift_amt[5]: word swap bit: only considered for FSL/FSR.
+  // if set, reverse operations in first and second cycle.
+  assign shift_amt[5] = operand_b_i[5] & shift_funnel;
+  assign shift_amt_compl = 32 - operand_b_i[4:0];
+
+  always_comb begin
+    if (bfp_op) begin
+      shift_amt[4:0] = bfp_off ; // length field of bfp control word
+    end else begin
+      shift_amt[4:0] = instr_first_cycle_i ?
+          (operand_b_i[5] && shift_funnel ? shift_amt_compl[4:0] : operand_b_i[4:0]) :
+          (operand_b_i[5] && shift_funnel ? operand_b_i[4:0] : shift_amt_compl[4:0]);
+    end
+  end
+
+  // single-bit mode: shift
+  assign shift_sbmode = (RV32B != RV32BNone) ?
+      (operator_i == ALU_SBSET) | (operator_i == ALU_SBCLR) | (operator_i == ALU_SBINV) : 1'b0;
+
+  // left shift if this is:
+  // * a standard left shift (slo, sll)
+  // * a rol in the first cycle
+  // * a ror in the second cycle
+  // * fsl: without word-swap bit: first cycle, else: second cycle
+  // * fsr: without word-swap bit: second cycle, else: first cycle
+  // * a single-bit instruction: sbclr, sbset, sbinv (excluding sbext)
+  // * bfp: bfp_mask << bfp_off
+  always_comb begin
+    unique case (operator_i)
+      ALU_SLL: shift_left = 1'b1;
+      ALU_SLO,
+      ALU_BFP: shift_left = (RV32B != RV32BNone) ? 1'b1 : 1'b0;
+      ALU_ROL: shift_left = (RV32B != RV32BNone) ? instr_first_cycle_i : 0;
+      ALU_ROR: shift_left = (RV32B != RV32BNone) ? ~instr_first_cycle_i : 0;
+      ALU_FSL: shift_left = (RV32B != RV32BNone) ?
+        (shift_amt[5] ? ~instr_first_cycle_i : instr_first_cycle_i) : 1'b0;
+      ALU_FSR: shift_left = (RV32B != RV32BNone) ?
+          (shift_amt[5] ? instr_first_cycle_i : ~instr_first_cycle_i) : 1'b0;
+      default: shift_left = 1'b0;
+    endcase
+    if (shift_sbmode) begin
+      shift_left = 1'b1;
+    end
+  end
+
+  assign shift_arith  = (operator_i == ALU_SRA);
+  assign shift_ones   =
+      (RV32B != RV32BNone) ? (operator_i == ALU_SLO) | (operator_i == ALU_SRO) : 1'b0;
+  assign shift_funnel =
+      (RV32B != RV32BNone) ? (operator_i == ALU_FSL) | (operator_i == ALU_FSR) : 1'b0;
+
+  // shifter structure.
+  always_comb begin
+    // select shifter input
+    // for bfp, sbmode and shift_left the corresponding bit-reversed input is chosen.
+    if (RV32B == RV32BNone) begin
+      shift_result = shift_left ? operand_a_rev : operand_a_i;
+    end else begin
+      unique case (1'b1)
+        bfp_op:       shift_result = bfp_mask_rev;
+        shift_sbmode: shift_result = 32'h8000_0000;
+        default:      shift_result = shift_left ? operand_a_rev : operand_a_i;
+      endcase
+    end
+
+    shift_result_ext =
+        $signed({shift_ones | (shift_arith & shift_result[31]), shift_result}) >>> shift_amt[4:0];
+
+    shift_result = shift_result_ext[31:0];
+
+    for (int unsigned i=0; i<32; i++) begin
+      shift_result_rev[i] = shift_result[31-i];
+    end
+
+    shift_result = shift_left ? shift_result_rev : shift_result;
+
+  end
+
+  ///////////////////
+  // Bitwise Logic //
+  ///////////////////
+
+  logic bwlogic_or;
+  logic bwlogic_and;
+  logic [31:0] bwlogic_operand_b;
+  logic [31:0] bwlogic_or_result;
+  logic [31:0] bwlogic_and_result;
+  logic [31:0] bwlogic_xor_result;
+  logic [31:0] bwlogic_result;
+
+  logic bwlogic_op_b_negate;
+
+  always_comb begin
+    unique case (operator_i)
+      // Logic-with-negate OPs (RV32B Ops)
+      ALU_XNOR,
+      ALU_ORN,
+      ALU_ANDN: bwlogic_op_b_negate = (RV32B != RV32BNone) ? 1'b1 : 1'b0;
+      ALU_CMIX: bwlogic_op_b_negate = (RV32B != RV32BNone) ? ~instr_first_cycle_i : 1'b0;
+      default:  bwlogic_op_b_negate = 1'b0;
+    endcase
+  end
+
+  assign bwlogic_operand_b = bwlogic_op_b_negate ? operand_b_neg[32:1] : operand_b_i;
+
+  assign bwlogic_or_result  = operand_a_i | bwlogic_operand_b;
+  assign bwlogic_and_result = operand_a_i & bwlogic_operand_b;
+  assign bwlogic_xor_result = operand_a_i ^ bwlogic_operand_b;
+
+  assign bwlogic_or  = (operator_i == ALU_OR)  | (operator_i == ALU_ORN);
+  assign bwlogic_and = (operator_i == ALU_AND) | (operator_i == ALU_ANDN);
+
+  always_comb begin
+    unique case (1'b1)
+      bwlogic_or:  bwlogic_result = bwlogic_or_result;
+      bwlogic_and: bwlogic_result = bwlogic_and_result;
+      default:     bwlogic_result = bwlogic_xor_result;
+    endcase
+  end
+
+  logic [5:0]  bitcnt_result;
+  logic [31:0] minmax_result;
+  logic [31:0] pack_result;
+  logic [31:0] sext_result;
+  logic [31:0] singlebit_result;
+  logic [31:0] rev_result;
+  logic [31:0] shuffle_result;
+  logic [31:0] butterfly_result;
+  logic [31:0] invbutterfly_result;
+  logic [31:0] clmul_result;
+  logic [31:0] multicycle_result;
+
+  if (RV32B != RV32BNone) begin : g_alu_rvb
+
+    /////////////////
+    // Bitcounting //
+    /////////////////
+
+    // The bit-counter structure computes the number of set bits in its operand. Partial results
+    // (from left to right) are needed to compute the control masks for computation of bext/bdep
+    // by the butterfly network, if implemented.
+    // For pcnt, clz and ctz, only the end result is used.
+
+    logic        zbe_op;
+    logic        bitcnt_ctz;
+    logic        bitcnt_clz;
+    logic        bitcnt_cz;
+    logic [31:0] bitcnt_bits;
+    logic [31:0] bitcnt_mask_op;
+    logic [31:0] bitcnt_bit_mask;
+    logic [ 5:0] bitcnt_partial [32];
+    logic [31:0] bitcnt_partial_lsb_d;
+    logic [31:0] bitcnt_partial_msb_d;
+
+
+    assign bitcnt_ctz    = operator_i == ALU_CTZ;
+    assign bitcnt_clz    = operator_i == ALU_CLZ;
+    assign bitcnt_cz     = bitcnt_ctz | bitcnt_clz;
+    assign bitcnt_result = bitcnt_partial[31];
+
+    // Bit-mask generation for clz and ctz:
+    // The bit mask is generated by spreading the lowest-order set bit in the operand to all
+    // higher order bits. The resulting mask is inverted to cover the lowest order zeros. In order
+    // to create the bit mask for leading zeros, the input operand needs to be reversed.
+    assign bitcnt_mask_op = bitcnt_clz ? operand_a_rev : operand_a_i;
+
+    always_comb begin
+      bitcnt_bit_mask = bitcnt_mask_op;
+      bitcnt_bit_mask |= bitcnt_bit_mask << 1;
+      bitcnt_bit_mask |= bitcnt_bit_mask << 2;
+      bitcnt_bit_mask |= bitcnt_bit_mask << 4;
+      bitcnt_bit_mask |= bitcnt_bit_mask << 8;
+      bitcnt_bit_mask |= bitcnt_bit_mask << 16;
+      bitcnt_bit_mask = ~bitcnt_bit_mask;
+    end
+
+    assign zbe_op = (operator_i == ALU_BEXT) | (operator_i == ALU_BDEP);
+
+    always_comb begin
+      case(1'b1)
+        zbe_op:      bitcnt_bits = operand_b_i;
+        bitcnt_cz:   bitcnt_bits = bitcnt_bit_mask & ~bitcnt_mask_op; // clz / ctz
+        default:     bitcnt_bits = operand_a_i; // pcnt
+      endcase
+    end
+
+    // The parallel prefix counter is of the structure of a Brent-Kung Adder. In the first
+    // log2(width) stages, the sum of the n preceding bit lines is computed for the bit lines at
+    // positions 2**n-1 (power-of-two positions) where n denotes the current stage.
+    // In stage n=log2(width), the count for position width-1 (the MSB) is finished.
+    // For the intermediate values, an inverse adder tree then computes the bit counts for the bit
+    // lines at positions
+    // m = 2**(n-1) + i*2**(n-2), where i = [1 ... width / 2**(n-1)-1] and n = [log2(width) ... 2].
+    // Thus, at every subsequent stage the result of two previously unconnected sub-trees is
+    // summed, starting at the node summing bits [width/2-1 : 0] and [3*width/4-1: width/2]
+    // and moving to iteratively sum up all the sub-trees.
+    // The inverse adder tree thus features log2(width) - 1 stages the first of these stages is a
+    // single addition at position 3*width/4 - 1. It does not interfere with the last
+    // stage of the primary adder tree. These stages can thus be folded together, resulting in a
+    // total of 2*log2(width)-2 stages.
+    // For more details refer to R. Brent, H. T. Kung, "A Regular Layout for Parallel Adders",
+    // (1982).
+    // For a bitline at position p, only bits
+    // bitcnt_partial[max(i, such that p % log2(i) == 0)-1 : 0] are needed for generation of the
+    // butterfly network control signals. The adders in the intermediate value adder tree thus need
+    // not be full 5-bit adders. We leave the optimization to the synthesis tools.
+    //
+    // Consider the following 8-bit example for illustraton.
+    //
+    // let bitcnt_bits = 8'babcdefgh.
+    //
+    //                   a  b  c  d  e  f  g  h
+    //                   | /:  | /:  | /:  | /:
+    //                   |/ :  |/ :  |/ :  |/ :
+    // stage 1:          +  :  +  :  +  :  +  :
+    //                   |  : /:  :  |  : /:  :
+    //                   |,--+ :  :  |,--+ :  :
+    // stage 2:          +  :  :  :  +  :  :  :
+    //                   |  :  |  : /:  :  :  :
+    //                   |,-----,--+ :  :  :  : ^-primary adder tree
+    // stage 3:          +  :  +  :  :  :  :  : -------------------------
+    //                   :  | /| /| /| /| /|  : ,-intermediate adder tree
+    //                   :  |/ |/ |/ |/ |/ :  :
+    // stage 4           :  +  +  +  +  +  :  :
+    //                   :  :  :  :  :  :  :  :
+    // bitcnt_partial[i] 7  6  5  4  3  2  1  0
+
+    always_comb begin
+      bitcnt_partial = '{default: '0};
+      // stage 1
+      for (int unsigned i=1; i<32; i+=2) begin
+        bitcnt_partial[i] = {5'h0, bitcnt_bits[i]} + {5'h0, bitcnt_bits[i-1]};
+      end
+      // stage 2
+      for (int unsigned i=3; i<32; i+=4) begin
+        bitcnt_partial[i] = bitcnt_partial[i-2] + bitcnt_partial[i];
+      end
+      // stage 3
+      for (int unsigned i=7; i<32; i+=8) begin
+        bitcnt_partial[i] = bitcnt_partial[i-4] + bitcnt_partial[i];
+      end
+      // stage 4
+      for (int unsigned i=15; i <32; i+=16) begin
+        bitcnt_partial[i] = bitcnt_partial[i-8] + bitcnt_partial[i];
+      end
+      // stage 5
+      bitcnt_partial[31] = bitcnt_partial[15] + bitcnt_partial[31];
+      // ^- primary adder tree
+      // -------------------------------
+      // ,-intermediate value adder tree
+      bitcnt_partial[23] = bitcnt_partial[15] + bitcnt_partial[23];
+
+      // stage 6
+      for (int unsigned i=11; i<32; i+=8) begin
+        bitcnt_partial[i] = bitcnt_partial[i-4] + bitcnt_partial[i];
+      end
+
+      // stage 7
+      for (int unsigned i=5; i<32; i+=4) begin
+        bitcnt_partial[i] = bitcnt_partial[i-2] + bitcnt_partial[i];
+      end
+      // stage 8
+      bitcnt_partial[0] = {5'h0, bitcnt_bits[0]};
+      for (int unsigned i=2; i<32; i+=2) begin
+        bitcnt_partial[i] = bitcnt_partial[i-1] + {5'h0, bitcnt_bits[i]};
+      end
+    end
+
+    ///////////////
+    // Min / Max //
+    ///////////////
+
+    assign minmax_result = cmp_result ? operand_a_i : operand_b_i;
+
+    //////////
+    // Pack //
+    //////////
+
+    logic packu;
+    logic packh;
+    assign packu = operator_i == ALU_PACKU;
+    assign packh = operator_i == ALU_PACKH;
+
+    always_comb begin
+      unique case (1'b1)
+        packu:   pack_result = {operand_b_i[31:16], operand_a_i[31:16]};
+        packh:   pack_result = {16'h0, operand_b_i[7:0], operand_a_i[7:0]};
+        default: pack_result = {operand_b_i[15:0], operand_a_i[15:0]};
+      endcase
+    end
+
+    //////////
+    // Sext //
+    //////////
+
+    assign sext_result = (operator_i == ALU_SEXTB) ?
+        { {24{operand_a_i[7]}}, operand_a_i[7:0]} : { {16{operand_a_i[15]}}, operand_a_i[15:0]};
+
+    /////////////////////////////
+    // Single-bit Instructions //
+    /////////////////////////////
+
+    always_comb begin
+      unique case (operator_i)
+        ALU_SBSET: singlebit_result = operand_a_i | shift_result;
+        ALU_SBCLR: singlebit_result = operand_a_i & ~shift_result;
+        ALU_SBINV: singlebit_result = operand_a_i ^ shift_result;
+        default:   singlebit_result = {31'h0, shift_result[0]}; // ALU_SBEXT
+      endcase
+    end
+
+    ////////////////////////////////////
+    // General Reverse and Or-combine //
+    ////////////////////////////////////
+
+    // Only a subset of the General reverse and or-combine instructions are implemented in the
+    // balanced version of the B extension. Currently rev, rev8 and orc.b are supported in the
+    // base extension.
+
+    logic [4:0] zbp_shift_amt;
+    logic gorc_op;
+
+    assign gorc_op = (operator_i == ALU_GORC);
+    assign zbp_shift_amt[2:0] = (RV32B == RV32BFull) ? shift_amt[2:0] : {3{&shift_amt[2:0]}};
+    assign zbp_shift_amt[4:3] = (RV32B == RV32BFull) ? shift_amt[4:3] : {2{&shift_amt[4:3]}};
+
+    always_comb begin
+      rev_result = operand_a_i;
+
+      if (zbp_shift_amt[0]) begin
+        rev_result = (gorc_op ? rev_result : 32'h0)       |
+                     ((rev_result & 32'h5555_5555) <<  1) |
+                     ((rev_result & 32'haaaa_aaaa) >>  1);
+      end
+
+      if (zbp_shift_amt[1]) begin
+        rev_result = (gorc_op ? rev_result : 32'h0)       |
+                     ((rev_result & 32'h3333_3333) <<  2) |
+                     ((rev_result & 32'hcccc_cccc) >>  2);
+      end
+
+      if (zbp_shift_amt[2]) begin
+        rev_result = (gorc_op ? rev_result : 32'h0)       |
+                     ((rev_result & 32'h0f0f_0f0f) <<  4) |
+                     ((rev_result & 32'hf0f0_f0f0) >>  4);
+      end
+
+      if (zbp_shift_amt[3]) begin
+        rev_result = (gorc_op & (RV32B == RV32BFull) ? rev_result : 32'h0) |
+                     ((rev_result & 32'h00ff_00ff) <<  8) |
+                     ((rev_result & 32'hff00_ff00) >>  8);
+      end
+
+      if (zbp_shift_amt[4]) begin
+        rev_result = (gorc_op & (RV32B == RV32BFull) ? rev_result : 32'h0) |
+                     ((rev_result & 32'h0000_ffff) << 16) |
+                     ((rev_result & 32'hffff_0000) >> 16);
+      end
+    end
+
+    logic crc_hmode;
+    logic crc_bmode;
+    logic [31:0] clmul_result_rev;
+
+    if (RV32B == RV32BFull) begin : gen_alu_rvb_full
+
+      /////////////////////////
+      // Shuffle / Unshuffle //
+      /////////////////////////
+
+      localparam logic [31:0] ShuffleMaskL [4] =
+          '{32'h00ff_0000, 32'h0f00_0f00, 32'h3030_3030, 32'h4444_4444};
+      localparam logic [31:0] ShuffleMaskR [4] =
+          '{32'h0000_ff00, 32'h00f0_00f0, 32'h0c0c_0c0c, 32'h2222_2222};
+
+      localparam logic [31:0] FlipMaskL [4] =
+          '{32'h2200_1100, 32'h0044_0000, 32'h4411_0000, 32'h1100_0000};
+      localparam logic [31:0] FlipMaskR [4] =
+          '{32'h0088_0044, 32'h0000_2200, 32'h0000_8822, 32'h0000_0088};
+
+      logic [31:0] ShuffleMaskNot [4];
+      for(genvar i = 0; i < 4; i++) begin : gen_ShuffleMaskNot
+        assign ShuffleMaskNot[i] = ~(ShuffleMaskL[i] | ShuffleMaskR[i]);
+      end
+
+      logic shuffle_flip;
+      assign shuffle_flip = operator_i == ALU_UNSHFL;
+
+      logic [3:0] shuffle_mode;
+
+      always_comb begin
+        shuffle_result = operand_a_i;
+
+        if (shuffle_flip) begin
+          shuffle_mode[3] = shift_amt[0];
+          shuffle_mode[2] = shift_amt[1];
+          shuffle_mode[1] = shift_amt[2];
+          shuffle_mode[0] = shift_amt[3];
+        end else begin
+          shuffle_mode = shift_amt[3:0];
+        end
+
+        if (shuffle_flip) begin
+          shuffle_result = (shuffle_result & 32'h8822_4411) |
+              ((shuffle_result << 6)  & FlipMaskL[0]) | ((shuffle_result >> 6)  & FlipMaskR[0]) |
+              ((shuffle_result << 9)  & FlipMaskL[1]) | ((shuffle_result >> 9)  & FlipMaskR[1]) |
+              ((shuffle_result << 15) & FlipMaskL[2]) | ((shuffle_result >> 15) & FlipMaskR[2]) |
+              ((shuffle_result << 21) & FlipMaskL[3]) | ((shuffle_result >> 21) & FlipMaskR[3]);
+        end
+
+        if (shuffle_mode[3]) begin
+          shuffle_result = (shuffle_result & ShuffleMaskNot[0]) |
+              (((shuffle_result << 8) & ShuffleMaskL[0]) |
+              ((shuffle_result >> 8) & ShuffleMaskR[0]));
+        end
+        if (shuffle_mode[2]) begin
+          shuffle_result = (shuffle_result & ShuffleMaskNot[1]) |
+              (((shuffle_result << 4) & ShuffleMaskL[1]) |
+              ((shuffle_result >> 4) & ShuffleMaskR[1]));
+        end
+        if (shuffle_mode[1]) begin
+          shuffle_result = (shuffle_result & ShuffleMaskNot[2]) |
+              (((shuffle_result << 2) & ShuffleMaskL[2]) |
+              ((shuffle_result >> 2) & ShuffleMaskR[2]));
+        end
+        if (shuffle_mode[0]) begin
+          shuffle_result = (shuffle_result & ShuffleMaskNot[3]) |
+              (((shuffle_result << 1) & ShuffleMaskL[3]) |
+              ((shuffle_result >> 1) & ShuffleMaskR[3]));
+        end
+
+        if (shuffle_flip) begin
+          shuffle_result = (shuffle_result & 32'h8822_4411) |
+              ((shuffle_result << 6)  & FlipMaskL[0]) | ((shuffle_result >> 6) & FlipMaskR[0])  |
+              ((shuffle_result << 9)  & FlipMaskL[1]) | ((shuffle_result >> 9) & FlipMaskR[1])  |
+              ((shuffle_result << 15) & FlipMaskL[2]) | ((shuffle_result >> 15) & FlipMaskR[2]) |
+              ((shuffle_result << 21) & FlipMaskL[3]) | ((shuffle_result >> 21) & FlipMaskR[3]);
+        end
+      end
+
+      ///////////////
+      // Butterfly //
+      ///////////////
+
+      // The butterfly / inverse butterfly network executing bext/bdep (zbe) instructions.
+      // For bdep, the control bits mask of a local left region is generated by
+      // the inverse of a n-bit left rotate and complement upon wrap (LROTC) operation by the number
+      // of ones in the deposit bitmask to the right of the segment. n hereby denotes the width
+      // of the according segment. The bitmask for a pertaining local right region is equal to the
+      // corresponding local left region. Bext uses an analogue inverse process.
+      // Consider the following 8-bit example.  For details, see Hilewitz et al. "Fast Bit Gather,
+      // Bit Scatter and Bit Permuation Instructions for Commodity Microprocessors", (2008).
+      //
+      // The bext/bdep instructions are completed in 2 cycles. In the first cycle, the control
+      // bitmask is prepared by executing the parallel prefix bit count. In the second cycle,
+      // the bit swapping is executed according to the control masks.
+
+      // 8-bit example:  (Hilewitz et al.)
+      // Consider the instruction bdep operand_a_i deposit_mask
+      // Let operand_a_i = 8'babcd_efgh
+      //    deposit_mask = 8'b1010_1101
+      //
+      // control bitmask for stage 1:
+      //  - number of ones in the right half of the deposit bitmask: 3
+      //  - width of the segment: 4
+      //  - control bitmask = ~LROTC(4'b0, 3)[3:0] = 4'b1000
+      //
+      // control bitmask:   c3 c2  c1 c0  c3 c2  c1 c0
+      //                    1  0   0  0   1  0   0  0
+      //                    <- L ----->   <- R ----->
+      // operand_a_i        a  b   c  d   e  f   g  h
+      //                    :\ |   |  |  /:  |   |  |
+      //                    : +|---|--|-+ :  |   |  |
+      //                    :/ |   |  |  \:  |   |  |
+      // stage 1            e  b   c  d   a  f   g  h
+      //                    <L->   <R->   <L->   <R->
+      // control bitmask:   c3 c2  c3 c2  c1 c0  c1 c0
+      //                    1  1   1  1   1  0   1  0
+      //                    :\ :\ /: /:   :\ |  /:  |
+      //                    : +:-+-:+ :   : +|-+ :  |
+      //                    :/ :/ \: \:   :/ |  \:  |
+      // stage 2            c  d   e  b   g  f   a  h
+      //                    L  R   L  R   L  R   L  R
+      // control bitmask:   c3 c3  c2 c2  c1 c1  c0 c0
+      //                    1  1   0  0   1  1   0  0
+      //                    :\/:   |  |   :\/:   |  |
+      //                    :  :   |  |   :  :   |  |
+      //                    :/\:   |  |   :/\:   |  |
+      // stage 3            d  c   e  b   f  g   a  h
+      // & deposit bitmask: 1  0   1  0   1  1   0  1
+      // result:            d  0   e  0   f  g   0  h
+
+      logic [ 5:0] bitcnt_partial_q [32];
+
+      // first cycle
+      // Store partial bitcnts
+      for (genvar i=0; i<32; i++) begin : gen_bitcnt_reg_in_lsb
+        assign bitcnt_partial_lsb_d[i] = bitcnt_partial[i][0];
+      end
+
+      for (genvar i=0; i<16; i++) begin : gen_bitcnt_reg_in_b1
+        assign bitcnt_partial_msb_d[i] = bitcnt_partial[2*i+1][1];
+      end
+
+      for (genvar i=0; i<8; i++) begin : gen_bitcnt_reg_in_b2
+        assign bitcnt_partial_msb_d[16+i] = bitcnt_partial[4*i+3][2];
+      end
+
+      for (genvar i=0; i<4; i++) begin : gen_bitcnt_reg_in_b3
+        assign bitcnt_partial_msb_d[24+i] = bitcnt_partial[8*i+7][3];
+      end
+
+      for (genvar i=0; i<2; i++) begin : gen_bitcnt_reg_in_b4
+        assign bitcnt_partial_msb_d[28+i] = bitcnt_partial[16*i+15][4];
+      end
+
+      assign bitcnt_partial_msb_d[30] = bitcnt_partial[31][5];
+      assign bitcnt_partial_msb_d[31] = 1'b0; // unused
+
+      // Second cycle
+      // Load partial bitcnts
+      always_comb begin
+        bitcnt_partial_q = '{default: '0};
+
+        for (int unsigned i=0; i<32; i++) begin : gen_bitcnt_reg_out_lsb
+          bitcnt_partial_q[i][0] = imd_val_q_i[0][i];
+        end
+
+        for (int unsigned i=0; i<16; i++) begin : gen_bitcnt_reg_out_b1
+          bitcnt_partial_q[2*i+1][1] = imd_val_q_i[1][i];
+        end
+
+        for (int unsigned i=0; i<8; i++) begin : gen_bitcnt_reg_out_b2
+          bitcnt_partial_q[4*i+3][2] = imd_val_q_i[1][16+i];
+        end
+
+        for (int unsigned i=0; i<4; i++) begin : gen_bitcnt_reg_out_b3
+          bitcnt_partial_q[8*i+7][3] = imd_val_q_i[1][24+i];
+        end
+
+        for (int unsigned i=0; i<2; i++) begin : gen_bitcnt_reg_out_b4
+          bitcnt_partial_q[16*i+15][4] = imd_val_q_i[1][28+i];
+        end
+
+        bitcnt_partial_q[31][5] = imd_val_q_i[1][30];
+      end
+
+      logic [31:0] butterfly_mask_l[5];
+      logic [31:0] butterfly_mask_r[5];
+      logic [31:0] butterfly_mask_not[5];
+      logic [31:0] lrotc_stage [5]; // left rotate and complement upon wrap
+
+      // number of bits in local r = 32 / 2**(stage + 1) = 16/2**stage
+      `define _N(stg) (16 >> stg)
+
+      // bext / bdep control bit generation
+      for (genvar stg=0; stg<5; stg++) begin : gen_butterfly_ctrl_stage
+        // number of segs: 2** stg
+        for (genvar seg=0; seg<2**stg; seg++) begin : gen_butterfly_ctrl
+
+          assign lrotc_stage[stg][2*`_N(stg)*(seg+1)-1 : 2*`_N(stg)*seg] =
+              {{`_N(stg){1'b0}},{`_N(stg){1'b1}}} <<
+                bitcnt_partial_q[`_N(stg)*(2*seg+1)-1][$clog2(`_N(stg)):0];
+
+          assign butterfly_mask_l[stg][`_N(stg)*(2*seg+2)-1 : `_N(stg)*(2*seg+1)]
+                   = ~lrotc_stage[stg][`_N(stg)*(2*seg+2)-1 : `_N(stg)*(2*seg+1)];
+
+          assign butterfly_mask_r[stg][`_N(stg)*(2*seg+1)-1 : `_N(stg)*(2*seg)]
+                   = ~lrotc_stage[stg][`_N(stg)*(2*seg+2)-1 : `_N(stg)*(2*seg+1)];
+
+          assign butterfly_mask_l[stg][`_N(stg)*(2*seg+1)-1 : `_N(stg)*(2*seg)]   = '0;
+          assign butterfly_mask_r[stg][`_N(stg)*(2*seg+2)-1 : `_N(stg)*(2*seg+1)] = '0;
+        end
+      end
+      `undef _N
+
+      for (genvar stg=0; stg<5; stg++) begin : gen_butterfly_not
+        assign butterfly_mask_not[stg] =
+            ~(butterfly_mask_l[stg] | butterfly_mask_r[stg]);
+      end
+
+      always_comb begin
+        butterfly_result = operand_a_i;
+
+        butterfly_result = butterfly_result & butterfly_mask_not[0] |
+            ((butterfly_result & butterfly_mask_l[0]) >> 16)|
+            ((butterfly_result & butterfly_mask_r[0]) << 16);
+
+        butterfly_result = butterfly_result & butterfly_mask_not[1] |
+            ((butterfly_result & butterfly_mask_l[1]) >> 8)|
+            ((butterfly_result & butterfly_mask_r[1]) << 8);
+
+        butterfly_result = butterfly_result & butterfly_mask_not[2] |
+            ((butterfly_result & butterfly_mask_l[2]) >> 4)|
+            ((butterfly_result & butterfly_mask_r[2]) << 4);
+
+        butterfly_result = butterfly_result & butterfly_mask_not[3] |
+            ((butterfly_result & butterfly_mask_l[3]) >> 2)|
+            ((butterfly_result & butterfly_mask_r[3]) << 2);
+
+        butterfly_result = butterfly_result & butterfly_mask_not[4] |
+            ((butterfly_result & butterfly_mask_l[4]) >> 1)|
+            ((butterfly_result & butterfly_mask_r[4]) << 1);
+
+        butterfly_result = butterfly_result & operand_b_i;
+      end
+
+      always_comb begin
+        invbutterfly_result = operand_a_i & operand_b_i;
+
+        invbutterfly_result = invbutterfly_result & butterfly_mask_not[4] |
+            ((invbutterfly_result & butterfly_mask_l[4]) >> 1)|
+            ((invbutterfly_result & butterfly_mask_r[4]) << 1);
+
+        invbutterfly_result = invbutterfly_result & butterfly_mask_not[3] |
+            ((invbutterfly_result & butterfly_mask_l[3]) >> 2)|
+            ((invbutterfly_result & butterfly_mask_r[3]) << 2);
+
+        invbutterfly_result = invbutterfly_result & butterfly_mask_not[2] |
+            ((invbutterfly_result & butterfly_mask_l[2]) >> 4)|
+            ((invbutterfly_result & butterfly_mask_r[2]) << 4);
+
+        invbutterfly_result = invbutterfly_result & butterfly_mask_not[1] |
+            ((invbutterfly_result & butterfly_mask_l[1]) >> 8)|
+            ((invbutterfly_result & butterfly_mask_r[1]) << 8);
+
+        invbutterfly_result = invbutterfly_result & butterfly_mask_not[0] |
+            ((invbutterfly_result & butterfly_mask_l[0]) >> 16)|
+            ((invbutterfly_result & butterfly_mask_r[0]) << 16);
+      end
+
+      ///////////////////////////////////////////////////
+      // Carry-less Multiply + Cyclic Redundancy Check //
+      ///////////////////////////////////////////////////
+
+      // Carry-less multiplication can be understood as multiplication based on
+      // the addition interpreted as the bit-wise xor operation.
+      //
+      // Example: 1101 X 1011 = 1111111:
+      //
+      //       1011 X 1101
+      //       -----------
+      //              1101
+      //         xor 1101
+      //         ---------
+      //             10111
+      //        xor 0000
+      //        ----------
+      //            010111
+      //       xor 1101
+      //       -----------
+      //           1111111
+      //
+      // Architectural details:
+      //         A 32 x 32-bit array
+      //         [ operand_b[i] ? (operand_a << i) : '0 for i in 0 ... 31 ]
+      //         is generated. The entries of the array are pairwise 'xor-ed'
+      //         together in a 5-stage binary tree.
+      //
+      //
+      // Cyclic Redundancy Check:
+      //
+      // CRC-32 (CRC-32/ISO-HDLC) and CRC-32C (CRC-32/ISCSI) are directly implemented. For
+      // documentation of the crc configuration (crc-polynomials, initialization, reflection, etc.)
+      // see http://reveng.sourceforge.net/crc-catalogue/all.htm
+      // A useful guide to crc arithmetic and algorithms is given here:
+      // http://www.piclist.com/techref/method/math/crcguide.html.
+      //
+      // The CRC operation solves the following equation using binary polynomial arithmetic:
+      //
+      // rev(rd)(x) = rev(rs1)(x) * x**n mod {1, P}(x)
+      //
+      // where P denotes lower 32 bits of the corresponding CRC polynomial, rev(a) the bit reversal
+      // of a, n = 8,16, or 32 for .b, .h, .w -variants. {a, b} denotes bit concatenation.
+      //
+      // Using barret reduction, one can show that
+      //
+      // M(x) mod P(x) = R(x) =
+      //          (M(x) * x**n) & {deg(P(x)'{1'b1}}) ^ (M(x) x**-(deg(P(x) - n)) cx mu(x) cx P(x),
+      //
+      // Where mu(x) = polydiv(x**64, {1,P}) & 0xffffffff. Here, 'cx' refers to carry-less
+      // multiplication. Substituting rev(rd)(x) for R(x) and rev(rs1)(x) for M(x) and solving for
+      // rd(x) with P(x) a crc32 polynomial (deg(P(x)) = 32), we get
+      //
+      // rd = rev( (rev(rs1) << n)  ^ ((rev(rs1) >> (32-n)) cx mu cx P)
+      //    = (rs1 >> n) ^ rev(rev( (rs1 << (32-n)) cx rev(mu)) cx P)
+      //                       ^-- cycle 0--------------------^
+      //      ^- cycle 1 -------------------------------------------^
+      //
+      // In the last step we used the fact that carry-less multiplication is bit-order agnostic:
+      // rev(a cx b) = rev(a) cx rev(b).
+
+      logic clmul_rmode;
+      logic clmul_hmode;
+      logic [31:0] clmul_op_a;
+      logic [31:0] clmul_op_b;
+      logic [31:0] operand_b_rev;
+      logic [31:0] clmul_and_stage[32];
+      logic [31:0] clmul_xor_stage1[16];
+      logic [31:0] clmul_xor_stage2[8];
+      logic [31:0] clmul_xor_stage3[4];
+      logic [31:0] clmul_xor_stage4[2];
+
+      logic [31:0] clmul_result_raw;
+
+      for (genvar i=0; i<32; i++) begin: gen_rev_operand_b
+        assign operand_b_rev[i] = operand_b_i[31-i];
+      end
+
+      assign clmul_rmode = operator_i == ALU_CLMULR;
+      assign clmul_hmode = operator_i == ALU_CLMULH;
+
+      // CRC
+      localparam logic [31:0] Crc32Polynomial = 32'h04c1_1db7;
+      localparam logic [31:0] Crc32MuRev = 32'hf701_1641;
+
+      localparam logic [31:0] Crc32CPolynomial = 32'h1edc_6f41;
+      localparam logic [31:0] Crc32CMuRev = 32'hdea7_13f1;
+
+      logic crc_op;
+
+      logic crc_cpoly;
+
+      logic [31:0] crc_operand;
+      logic [31:0] crc_poly;
+      logic [31:0] crc_mu_rev;
+
+      assign crc_op = (operator_i == ALU_CRC32C_W) | (operator_i == ALU_CRC32_W) |
+                      (operator_i == ALU_CRC32C_H) | (operator_i == ALU_CRC32_H) |
+                      (operator_i == ALU_CRC32C_B) | (operator_i == ALU_CRC32_B);
+
+      assign crc_cpoly = (operator_i == ALU_CRC32C_W) |
+                         (operator_i == ALU_CRC32C_H) |
+                         (operator_i == ALU_CRC32C_B);
+
+      assign crc_hmode = (operator_i == ALU_CRC32_H) | (operator_i == ALU_CRC32C_H);
+      assign crc_bmode = (operator_i == ALU_CRC32_B) | (operator_i == ALU_CRC32C_B);
+
+      assign crc_poly   = crc_cpoly ? Crc32CPolynomial : Crc32Polynomial;
+      assign crc_mu_rev = crc_cpoly ? Crc32CMuRev : Crc32MuRev;
+
+      always_comb begin
+        unique case(1'b1)
+          crc_bmode: crc_operand = {operand_a_i[7:0], 24'h0};
+          crc_hmode: crc_operand = {operand_a_i[15:0], 16'h0};
+          default:   crc_operand = operand_a_i;
+        endcase
+      end
+
+      // Select clmul input
+      always_comb begin
+        if (crc_op) begin
+          clmul_op_a = instr_first_cycle_i ? crc_operand : imd_val_q_i[0];
+          clmul_op_b = instr_first_cycle_i ? crc_mu_rev : crc_poly;
+        end else begin
+          clmul_op_a = clmul_rmode | clmul_hmode ? operand_a_rev : operand_a_i;
+          clmul_op_b = clmul_rmode | clmul_hmode ? operand_b_rev : operand_b_i;
+        end
+      end
+
+      for (genvar i=0; i<32; i++) begin : gen_clmul_and_op
+        assign clmul_and_stage[i] = clmul_op_b[i] ? clmul_op_a << i : '0;
+      end
+
+      for (genvar i=0; i<16; i++) begin : gen_clmul_xor_op_l1
+        assign clmul_xor_stage1[i] = clmul_and_stage[2*i] ^ clmul_and_stage[2*i+1];
+      end
+
+      for (genvar i=0; i<8; i++) begin : gen_clmul_xor_op_l2
+        assign clmul_xor_stage2[i] = clmul_xor_stage1[2*i] ^ clmul_xor_stage1[2*i+1];
+      end
+
+      for (genvar i=0; i<4; i++) begin : gen_clmul_xor_op_l3
+        assign clmul_xor_stage3[i] = clmul_xor_stage2[2*i] ^ clmul_xor_stage2[2*i+1];
+      end
+
+      for (genvar i=0; i<2; i++) begin : gen_clmul_xor_op_l4
+        assign clmul_xor_stage4[i] = clmul_xor_stage3[2*i] ^ clmul_xor_stage3[2*i+1];
+      end
+
+      assign clmul_result_raw = clmul_xor_stage4[0] ^ clmul_xor_stage4[1];
+
+      for (genvar i=0; i<32; i++) begin : gen_rev_clmul_result
+        assign clmul_result_rev[i] = clmul_result_raw[31-i];
+      end
+
+      // clmulr_result = rev(clmul(rev(a), rev(b)))
+      // clmulh_result = clmulr_result >> 1
+      always_comb begin
+        case(1'b1)
+          clmul_rmode: clmul_result = clmul_result_rev;
+          clmul_hmode: clmul_result = {1'b0, clmul_result_rev[31:1]};
+          default:     clmul_result = clmul_result_raw;
+        endcase
+      end
+    end else begin : gen_no_alu_rvb_full
+      assign shuffle_result       = '0;
+      assign butterfly_result     = '0;
+      assign invbutterfly_result  = '0;
+      assign clmul_result         = '0;
+      // support signals
+      assign bitcnt_partial_lsb_d = '0;
+      assign bitcnt_partial_msb_d = '0;
+      assign clmul_result_rev     = '0;
+      assign crc_bmode            = '0;
+      assign crc_hmode            = '0;
+    end
+
+    //////////////////////////////////////
+    // Multicycle Bitmanip Instructions //
+    //////////////////////////////////////
+    // Ternary instructions + Shift Rotations + Bit extract/deposit + CRC
+    // For ternary instructions (zbt), operand_a_i is tied to rs1 in the first cycle and rs3 in the
+    // second cycle. operand_b_i is always tied to rs2.
+
+    always_comb begin
+      unique case (operator_i)
+        // ALU_CMOV: begin
+        //     multicycle_result = (operand_b_i == 32'h0) ? operand_a_i : imd_val_q_i[0];
+        //     imd_val_d_o = '{operand_a_i, 32'h0};
+        //   if (instr_first_cycle_i) begin
+        //     imd_val_we_o = 2'b01;
+        //   end else begin
+        //     imd_val_we_o = 2'b00;
+        //   end
+        // end
+
+        // ALU_CMIX: begin
+        //   multicycle_result = imd_val_q_i[0] | bwlogic_and_result;
+        //   imd_val_d_o = '{bwlogic_and_result, 32'h0};
+        //   if (instr_first_cycle_i) begin
+        //     imd_val_we_o = 2'b01;
+        //   end else begin
+        //     imd_val_we_o = 2'b00;
+        //   end
+        // end
+
+        // ALU_FSR, ALU_FSL,
+        // ALU_ROL, ALU_ROR: begin
+        //   if (shift_amt[4:0] == 5'h0) begin
+        //     multicycle_result = shift_amt[5] ? operand_a_i : imd_val_q_i[0];
+        //   end else begin
+        //     multicycle_result = imd_val_q_i[0] | shift_result;
+        //   end
+        //   imd_val_d_o = '{shift_result, 32'h0};
+        //   if (instr_first_cycle_i) begin
+        //     imd_val_we_o = 2'b01;
+        //   end else begin
+        //     imd_val_we_o = 2'b00;
+        //   end
+        // end
+
+        ALU_CRC32_W, ALU_CRC32C_W,
+        ALU_CRC32_H, ALU_CRC32C_H,
+        ALU_CRC32_B, ALU_CRC32C_B: begin
+          if (RV32B == RV32BFull) begin
+            unique case(1'b1)
+              crc_bmode: multicycle_result = clmul_result_rev ^ (operand_a_i >> 8);
+              crc_hmode: multicycle_result = clmul_result_rev ^ (operand_a_i >> 16);
+              default:   multicycle_result = clmul_result_rev;
+            endcase
+            imd_val_d_o = '{clmul_result_rev, 32'h0};
+            if (instr_first_cycle_i) begin
+              imd_val_we_o = 2'b01;
+            end else begin
+              imd_val_we_o = 2'b00;
+            end
+          end else begin
+            imd_val_d_o = '{operand_a_i, 32'h0};
+            imd_val_we_o = 2'b00;
+            multicycle_result = '0;
+          end
+        end
+
+        ALU_BEXT, ALU_BDEP: begin
+          if (RV32B == RV32BFull) begin
+            multicycle_result = (operator_i == ALU_BDEP) ? butterfly_result : invbutterfly_result;
+            imd_val_d_o = '{bitcnt_partial_lsb_d, bitcnt_partial_msb_d};
+            if (instr_first_cycle_i) begin
+              imd_val_we_o = 2'b11;
+            end else begin
+              imd_val_we_o = 2'b00;
+            end
+          end else begin
+            imd_val_d_o = '{operand_a_i, 32'h0};
+            imd_val_we_o = 2'b00;
+            multicycle_result = '0;
+          end
+        end
+
+        default: begin
+          imd_val_d_o = '{operand_a_i, 32'h0};
+          imd_val_we_o = 2'b00;
+          multicycle_result = '0;
+        end
+      endcase
+    end
+
+
+  end else begin : g_no_alu_rvb
+    // RV32B result signals
+    assign bitcnt_result       = '0;
+    assign minmax_result       = '0;
+    assign pack_result         = '0;
+    assign sext_result         = '0;
+    assign singlebit_result    = '0;
+    assign rev_result          = '0;
+    assign shuffle_result      = '0;
+    assign butterfly_result    = '0;
+    assign invbutterfly_result = '0;
+    assign clmul_result        = '0;
+    assign multicycle_result   = '0;
+    // RV32B support signals
+    assign imd_val_d_o         = '{default: '0};
+    assign imd_val_we_o        = '{default: '0};
+  end
+
+  ////////////////
+  // Result mux //
+  ////////////////
+
+  always_comb begin
+    result_o   = '0;
+
+    unique case (operator_i)
+      // Bitwise Logic Operations (negate: RV32B)
+      ALU_XOR,  ALU_XNOR,
+      ALU_OR,   ALU_ORN,
+      ALU_AND,  ALU_ANDN: result_o = bwlogic_result;
+
+      // Adder Operations
+      ALU_ADD,  ALU_SUB: result_o = adder_result;
+
+      // Shift Operations
+      ALU_SLL,  ALU_SRL,
+      ALU_SRA,
+      // RV32B
+      ALU_SLO,  ALU_SRO: result_o = shift_result;
+
+      // Shuffle Operations (RV32B)
+      ALU_SHFL, ALU_UNSHFL: result_o = shuffle_result;
+
+      // Comparison Operations
+      ALU_EQ,   ALU_NE,
+      ALU_GE,   ALU_GEU,
+      ALU_LT,   ALU_LTU,
+      ALU_SLT,  ALU_SLTU: result_o = {31'h0, cmp_result};
+
+      // MinMax Operations (RV32B)
+      ALU_MIN,  ALU_MAX,
+      ALU_MINU, ALU_MAXU: result_o = minmax_result;
+
+      // Bitcount Operations (RV32B)
+      ALU_CLZ, ALU_CTZ,
+      ALU_PCNT: result_o = {26'h0, bitcnt_result};
+
+      // Pack Operations (RV32B)
+      ALU_PACK, ALU_PACKH,
+      ALU_PACKU: result_o = pack_result;
+
+      // Sign-Extend (RV32B)
+      ALU_SEXTB, ALU_SEXTH: result_o = sext_result;
+
+      // Ternary Bitmanip Operations (RV32B)
+      ALU_CMIX, ALU_CMOV,
+      ALU_FSL,  ALU_FSR,
+      // Rotate Shift (RV32B)
+      ALU_ROL, ALU_ROR,
+      // Cyclic Redundancy Checks (RV32B)
+      ALU_CRC32_W, ALU_CRC32C_W,
+      ALU_CRC32_H, ALU_CRC32C_H,
+      ALU_CRC32_B, ALU_CRC32C_B,
+      // Bit Extract / Deposit (RV32B)
+      ALU_BEXT, ALU_BDEP: result_o = multicycle_result;
+
+      // Single-Bit Bitmanip Operations (RV32B)
+      ALU_SBSET, ALU_SBCLR,
+      ALU_SBINV, ALU_SBEXT: result_o = singlebit_result;
+
+      // General Reverse / Or-combine (RV32B)
+      ALU_GREV, ALU_GORC: result_o = rev_result;
+
+      // Bit Field Place (RV32B)
+      ALU_BFP: result_o = bfp_result;
+
+      // Carry-less Multiply Operations (RV32B)
+      ALU_CLMUL, ALU_CLMULR,
+      ALU_CLMULH: result_o = clmul_result;
+
+      default: ;
+    endcase
+  end
+
+endmodule

--- a/snitch-core/accelerator/snitch_ipu_pkg.sv
+++ b/snitch-core/accelerator/snitch_ipu_pkg.sv
@@ -1,0 +1,114 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+package snitch_ipu_pkg;
+
+  // IPU
+  typedef enum integer {
+    RV32BNone,
+    RV32BBalanced,
+    RV32BFull
+  } rv32b_e;
+
+  typedef enum logic [5:0] {
+    // Arithmetics
+    ALU_ADD,
+    ALU_SUB,
+
+    // Logics
+    ALU_XOR,
+    ALU_OR,
+    ALU_AND,
+    // RV32B
+    ALU_XNOR,
+    ALU_ORN,
+    ALU_ANDN,
+
+    // Shifts
+    ALU_SRA,
+    ALU_SRL,
+    ALU_SLL,
+    // RV32B
+    ALU_SRO,
+    ALU_SLO,
+    ALU_ROR,
+    ALU_ROL,
+    ALU_GREV,
+    ALU_GORC,
+    ALU_SHFL,
+    ALU_UNSHFL,
+
+    // Comparisons
+    ALU_LT,
+    ALU_LTU,
+    ALU_GE,
+    ALU_GEU,
+    ALU_EQ,
+    ALU_NE,
+    // RV32B
+    ALU_MIN,
+    ALU_MINU,
+    ALU_MAX,
+    ALU_MAXU,
+
+    // Pack
+    // RV32B
+    ALU_PACK,
+    ALU_PACKU,
+    ALU_PACKH,
+
+    // Sign-Extend
+    // RV32B
+    ALU_SEXTB,
+    ALU_SEXTH,
+
+    // Bitcounting
+    // RV32B
+    ALU_CLZ,
+    ALU_CTZ,
+    ALU_PCNT,
+
+    // Set lower than
+    ALU_SLT,
+    ALU_SLTU,
+
+    // Ternary Bitmanip Operations
+    // RV32B
+    ALU_CMOV,
+    ALU_CMIX,
+    ALU_FSL,
+    ALU_FSR,
+
+    // Single-Bit Operations
+    // RV32B
+    ALU_SBSET,
+    ALU_SBCLR,
+    ALU_SBINV,
+    ALU_SBEXT,
+
+    // Bit Extract / Deposit
+    // RV32B
+    ALU_BEXT,
+    ALU_BDEP,
+
+    // Bit Field Place
+    // RV32B
+    ALU_BFP,
+
+    // Carry-less Multiply
+    // RV32B
+    ALU_CLMUL,
+    ALU_CLMULR,
+    ALU_CLMULH,
+
+    // Cyclic Redundancy Check
+    ALU_CRC32_B,
+    ALU_CRC32C_B,
+    ALU_CRC32_H,
+    ALU_CRC32C_H,
+    ALU_CRC32_W,
+    ALU_CRC32C_W
+  } alu_op_e;
+
+endpackage

--- a/snitch-core/accelerator/snitch_sequencer.sv
+++ b/snitch-core/accelerator/snitch_sequencer.sv
@@ -1,0 +1,451 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+`include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
+
+/// Description: Filters FPU repetition instructions
+module snitch_sequencer import snitch_pkg::*; #(
+    parameter int unsigned AddrWidth = 0,
+    parameter int unsigned DataWidth = 0,
+    parameter int unsigned Depth = 16,
+    parameter acc_addr_e DstAddr = FP_SS,
+    /// Derived parameter *Do not override*
+    parameter type addr_t = logic [AddrWidth-1:0],
+    parameter type data_t = logic [DataWidth-1:0],
+    parameter int unsigned DepthBits = $clog2(Depth)
+) (
+    input  logic                             clk_i,
+    input  logic                             rst_i,
+    // pragma translate_off
+    output fpu_sequencer_trace_port_t        trace_port_o,
+    // pragma translate_on
+    input  acc_addr_e                        inp_qaddr_i,
+    input  logic                      [ 4:0] inp_qid_i,
+    input  logic                      [31:0] inp_qdata_op_i,  // RISC-V instruction
+    input  data_t                            inp_qdata_arga_i,
+    input  data_t                            inp_qdata_argb_i,
+    input  addr_t                            inp_qdata_argc_i,
+    input  logic                             inp_qvalid_i,
+    output logic                             inp_qready_o,
+    output acc_addr_e                        oup_qaddr_o,
+    output logic                      [ 4:0] oup_qid_o,
+    output logic                      [31:0] oup_qdata_op_o,  // RISC-V instruction
+    output data_t                            oup_qdata_arga_o,
+    output data_t                            oup_qdata_argb_o,
+    output addr_t                            oup_qdata_argc_o,
+    output logic                             oup_qvalid_o,
+    input  logic                             oup_qready_i,
+    // SSR stream control interface
+    input  logic                             streamctl_done_i,
+    input  logic                             streamctl_valid_i,
+    output logic                             streamctl_ready_o
+);
+  localparam int RptBits = 16;
+
+  typedef struct packed {
+    logic is_streamctl;
+    logic is_outer;
+    logic [DepthBits-1:0] max_inst;
+    logic [RptBits-1:0] max_rpt;
+    logic [2:0] stagger_max;
+    logic [3:0] stagger_mask;  // one-hot stagger mask
+    logic [DepthBits:0] base_pointer;  // loop base pointer where the config starts
+  } seq_cfg_t;
+
+  logic
+      seq_cfg_buffer_empty,
+      seq_cfg_buffer_full,
+      seq_cfg_buffer_push,
+      seq_cfg_buffer_pop,
+      seq_cfg_buffer_valid;
+  seq_cfg_t seq_cfg_buffer_in, seq_cfg_buffer_out;
+  seq_cfg_t curr_cfg;
+
+  logic inst_last, rpt_last, seq_last, seq_next, seq_done;
+
+  logic seq_out_ready, seq_out_valid;
+  logic [31:0] seq_qdata_op;
+  logic [AddrWidth-1:0] seq_qdata_argc;
+
+  logic core_rb_valid, core_rb_ready;
+  logic core_rpt_valid, core_rpt_ready;
+  logic core_direct_valid, core_direct_ready;
+
+  // Ringbuffer.
+  // TODO(fschuiki, zarubaf) ICEBOX: This is a hack to allow fld/fsd to be added
+  // into the main sequence buffer. It would actually be better to have a
+  // separate buffer only for fld/fsd. But this would require more precise
+  // tracking of instruction IDs to ensure ordering at the output.
+  typedef struct packed {
+    logic [31:0] qdata_op;
+    addr_t qdata_argc;
+  } seq_entry_t;
+  seq_entry_t [Depth-1:0] mem_d, mem_q;
+  logic [DepthBits:0] rb_rd_pointer;
+  logic [DepthBits:0] rb_wr_pointer;
+  logic [DepthBits:0] rb_base_pointer;
+  seq_entry_t rb_rd_data;
+  seq_entry_t rb_wr_data;
+  logic rb_wr_en;
+  logic rb_full;
+  logic rb_empty;
+  logic rb_contains_instructions, rb_contains_no_instructions;
+
+  always_comb begin : ringbuffer
+    mem_d = mem_q;
+    if (rb_wr_en) mem_d[rb_wr_pointer[DepthBits-1:0]] = rb_wr_data;
+    rb_rd_data = mem_q[rb_rd_pointer[DepthBits-1:0]];
+    rb_full = (rb_base_pointer ^ rb_wr_pointer) == 1 << DepthBits;
+    rb_contains_no_instructions = (rb_base_pointer ^ rb_wr_pointer) == '0;
+    rb_contains_instructions = ~rb_contains_no_instructions;
+    rb_empty = (rb_rd_pointer ^ rb_wr_pointer) == '0;
+  end
+
+  `FFNR(mem_q, mem_d, clk_i)
+
+  /// Compute ringbuffer addresses.
+  logic [DepthBits:0] rd_pointer_d, rd_pointer_q;
+  logic [DepthBits:0] wr_pointer_d, wr_pointer_q;
+
+  logic [RptBits-1:0] rpt_cnt_d, rpt_cnt_q;
+  logic [DepthBits-1:0] inst_cnt_d, inst_cnt_q;
+  logic [2:0] stagger_cnt_q, stagger_cnt_d;
+
+  `FFAR(rd_pointer_q, rd_pointer_d, '0, clk_i, rst_i)
+  `FFAR(wr_pointer_q, wr_pointer_d, '0, clk_i, rst_i)
+  `FFAR(rpt_cnt_q, rpt_cnt_d, '0, clk_i, rst_i)
+  `FFAR(inst_cnt_q, inst_cnt_d, '0, clk_i, rst_i)
+  `FFAR(stagger_cnt_q, stagger_cnt_d, '0, clk_i, rst_i)
+
+  // set by sequencer when done with the entire sequence
+
+  always_comb begin
+    rd_pointer_d = rd_pointer_q;
+    wr_pointer_d = wr_pointer_q;
+
+    rb_wr_en = 0;
+    core_rb_ready = ~rb_full;
+
+    // write logic
+    if (core_rb_valid && core_rb_ready) begin
+      wr_pointer_d = wr_pointer_q + 1;
+      rb_wr_en = 1;
+    end
+    // read logic
+    if ((seq_last && seq_next) || seq_done) begin
+      /* verilator lint_off WIDTH */
+      rd_pointer_d = rd_pointer_q + curr_cfg.max_inst + 1;
+      /* verilator lint_on WIDTH */
+    end
+  end
+
+
+  assign rb_wr_data.qdata_op = inp_qdata_op_i;
+  assign rb_wr_data.qdata_argc = inp_qdata_argc_i;
+  assign rb_wr_pointer = wr_pointer_q;
+  assign rb_base_pointer = rd_pointer_q;
+  assign rb_rd_pointer = rb_base_pointer + inst_cnt_q;
+
+  assign inst_last = inst_cnt_q == curr_cfg.max_inst;
+  assign rpt_last = rpt_cnt_q == curr_cfg.max_rpt;
+  assign seq_last = inst_last & rpt_last & ~(seq_cfg_buffer_valid & curr_cfg.is_streamctl);
+  assign seq_cfg_buffer_pop = (seq_last & seq_next & seq_cfg_buffer_valid) | seq_done;
+
+  always_comb begin : sequence_logic
+    inst_cnt_d = inst_cnt_q;
+    rpt_cnt_d = rpt_cnt_q;
+    stagger_cnt_d = stagger_cnt_q;
+    if (seq_done) begin
+      // We are aborting the loop: reset counters
+      inst_cnt_d = '0;
+      rpt_cnt_d = '0;
+      stagger_cnt_d = '0;
+    end else if (seq_next) begin
+      if (curr_cfg.is_outer) begin
+        if (inst_last) begin
+          inst_cnt_d = 0;
+          rpt_cnt_d = rpt_last ? 0 : rpt_cnt_q + 1;
+          stagger_cnt_d = rpt_last ?
+            0 : ((stagger_cnt_q == curr_cfg.stagger_max) ? 0 : stagger_cnt_q + 1);
+        end else begin
+          inst_cnt_d = inst_cnt_q + 1;
+        end
+      end else begin
+        if (rpt_last) begin
+          rpt_cnt_d = 0;
+          inst_cnt_d = inst_last ? 0 : inst_cnt_q + 1;
+          stagger_cnt_d = inst_last ?
+            0 : ((stagger_cnt_q == curr_cfg.stagger_max) ? 0 : stagger_cnt_q + 1);
+        end else begin
+          rpt_cnt_d = rpt_cnt_q + 1;
+          stagger_cnt_d = (stagger_cnt_q == curr_cfg.stagger_max) ? 0 : stagger_cnt_q + 1;
+        end
+      end
+    end
+  end
+
+  assign seq_next = seq_out_valid & seq_out_ready;
+
+  always_comb begin : proc_streamctl
+    seq_out_valid     = ~rb_empty;
+    seq_done          = 1'b0;
+    streamctl_ready_o = 1'b0;
+    if (seq_cfg_buffer_valid & curr_cfg.is_outer & curr_cfg.is_streamctl) begin
+      seq_out_valid     = ~rb_empty & streamctl_valid_i & ~streamctl_done_i;
+      seq_done          = ~rb_empty & streamctl_valid_i & streamctl_done_i;
+      streamctl_ready_o = (~rb_empty & seq_out_ready) | seq_done;
+    end
+  end
+
+  // Compose offloading instruction e.g. staggering.
+  /* verilator lint_off WIDTH */
+  always_comb begin
+    seq_qdata_op   = rb_rd_data.qdata_op;
+    seq_qdata_argc = rb_rd_data.qdata_argc;
+    if (curr_cfg.stagger_mask[0]) seq_qdata_op[11:7] += stagger_cnt_q;
+    if (curr_cfg.stagger_mask[1]) seq_qdata_op[19:15] += stagger_cnt_q;
+    if (curr_cfg.stagger_mask[2]) seq_qdata_op[24:20] += stagger_cnt_q;
+    if (curr_cfg.stagger_mask[3]) seq_qdata_op[31:27] += stagger_cnt_q;
+  end
+  /* verilator lint_on WIDTH */
+
+  // Sequence configuration buffer input.
+  assign core_rpt_ready = ~seq_cfg_buffer_full;
+  assign seq_cfg_buffer_push = core_rpt_valid & core_rpt_ready;
+
+  fifo_v3 #(
+      .dtype(seq_cfg_t)
+  ) seq_cfg_buffer (
+      .clk_i,
+      .rst_ni    (~rst_i),
+      .flush_i   (1'b0),
+      .testmode_i(1'b0),
+      .full_o    (seq_cfg_buffer_full),
+      .empty_o   (seq_cfg_buffer_empty),
+      .usage_o   (),
+      .data_i    (seq_cfg_buffer_in),
+      .push_i    (seq_cfg_buffer_push),
+      .data_o    (seq_cfg_buffer_out),
+      .pop_i     (seq_cfg_buffer_pop)
+  );
+
+  // Ensure that `max_inst` bits fit into assigned slot
+  `ASSERT_INIT(CheckMaxInstFieldWidth, DepthBits < 11);
+
+  assign seq_cfg_buffer_in.is_streamctl = inp_qdata_op_i[31];
+  assign seq_cfg_buffer_in.is_outer = inp_qdata_op_i[7];
+  assign seq_cfg_buffer_in.max_inst = inp_qdata_op_i[20+:DepthBits];
+  assign seq_cfg_buffer_in.stagger_mask = inp_qdata_op_i[11:8];
+  assign seq_cfg_buffer_in.stagger_max = inp_qdata_op_i[14:12];
+  assign seq_cfg_buffer_in.max_rpt = inp_qdata_arga_i[RptBits-1:0];
+  assign seq_cfg_buffer_in.base_pointer = rb_wr_pointer;
+
+  always_comb begin
+    curr_cfg = seq_cfg_buffer_out;
+    seq_cfg_buffer_valid = 1;
+    if (seq_cfg_buffer_empty || seq_cfg_buffer_out.base_pointer != rb_base_pointer) begin
+      curr_cfg.max_inst = '0;
+      curr_cfg.max_rpt = '0;
+      seq_cfg_buffer_valid = 0;
+    end
+  end
+
+  /// Generate core handshakes.
+  always_comb begin
+    core_rb_valid = '0;
+    core_rpt_valid = '0;
+    core_direct_valid = '0;
+
+    inp_qready_o = '0;
+
+    unique casez (inp_qdata_op_i)
+      // frep instructions are pushed into the sequencer control branch
+      riscv_instr::FREP_O,
+      riscv_instr::FREP_I, riscv_instr::IREP: begin
+        inp_qready_o   = core_rpt_ready;
+        core_rpt_valid = inp_qvalid_i;
+      end
+
+      // instructions which explicitly sync between int and float pipeline are
+      // pushed into the direct branch where they block
+
+      // float to int
+      riscv_instr::FLE_S,
+      riscv_instr::FLT_S,
+      riscv_instr::FEQ_S,
+      riscv_instr::FCLASS_S,
+      riscv_instr::FCVT_W_S,
+      riscv_instr::FCVT_WU_S,
+      riscv_instr::FMV_X_W,
+      riscv_instr::VFEQ_S,
+      riscv_instr::VFEQ_R_S,
+      riscv_instr::VFNE_S,
+      riscv_instr::VFNE_R_S,
+      riscv_instr::VFLT_S,
+      riscv_instr::VFLT_R_S,
+      riscv_instr::VFGE_S,
+      riscv_instr::VFGE_R_S,
+      riscv_instr::VFLE_S,
+      riscv_instr::VFLE_R_S,
+      riscv_instr::VFGT_S,
+      riscv_instr::VFGT_R_S,
+      riscv_instr::VFCLASS_S,
+      riscv_instr::FLE_D,
+      riscv_instr::FLT_D,
+      riscv_instr::FEQ_D,
+      riscv_instr::FCLASS_D,
+      riscv_instr::FCVT_W_D,
+      riscv_instr::FCVT_WU_D,
+      riscv_instr::FMV_X_D,
+      riscv_instr::FLE_H,
+      riscv_instr::FLT_H,
+      riscv_instr::FEQ_H,
+      riscv_instr::FCLASS_H,
+      riscv_instr::FCVT_W_H,
+      riscv_instr::FCVT_WU_H,
+      riscv_instr::FMV_X_H,
+      riscv_instr::VFEQ_H,
+      riscv_instr::VFEQ_R_H,
+      riscv_instr::VFNE_H,
+      riscv_instr::VFNE_R_H,
+      riscv_instr::VFLT_H,
+      riscv_instr::VFLT_R_H,
+      riscv_instr::VFGE_H,
+      riscv_instr::VFGE_R_H,
+      riscv_instr::VFLE_H,
+      riscv_instr::VFLE_R_H,
+      riscv_instr::VFGT_H,
+      riscv_instr::VFGT_R_H,
+      riscv_instr::VFCLASS_H,
+      riscv_instr::VFMV_X_H,
+      riscv_instr::VFCVT_X_H,
+      riscv_instr::VFCVT_XU_H,
+      riscv_instr::FLE_AH,
+      riscv_instr::FLT_AH,
+      riscv_instr::FEQ_AH,
+      riscv_instr::FCLASS_AH,
+      riscv_instr::FMV_X_AH,
+      riscv_instr::VFEQ_AH,
+      riscv_instr::VFEQ_R_AH,
+      riscv_instr::VFNE_AH,
+      riscv_instr::VFNE_R_AH,
+      riscv_instr::VFLT_AH,
+      riscv_instr::VFLT_R_AH,
+      riscv_instr::VFGE_AH,
+      riscv_instr::VFGE_R_AH,
+      riscv_instr::VFLE_AH,
+      riscv_instr::VFLE_R_AH,
+      riscv_instr::VFGT_AH,
+      riscv_instr::VFGT_R_AH,
+      riscv_instr::VFCLASS_AH,
+      riscv_instr::VFMV_X_AH,
+      riscv_instr::VFCVT_X_AH,
+      riscv_instr::VFCVT_XU_AH,
+      riscv_instr::FLE_B,
+      riscv_instr::FLT_B,
+      riscv_instr::FEQ_B,
+      riscv_instr::FCLASS_B,
+      riscv_instr::FCVT_W_B,
+      riscv_instr::FCVT_WU_B,
+      riscv_instr::FMV_X_B,
+      riscv_instr::VFEQ_B,
+      riscv_instr::VFEQ_R_B,
+      riscv_instr::VFNE_B,
+      riscv_instr::VFNE_R_B,
+      riscv_instr::VFLT_B,
+      riscv_instr::VFLT_R_B,
+      riscv_instr::VFGE_B,
+      riscv_instr::VFGE_R_B,
+      riscv_instr::VFLE_B,
+      riscv_instr::VFLE_R_B,
+      riscv_instr::VFGT_B,
+      riscv_instr::VFGT_R_B,
+      riscv_instr::VFCLASS_B,
+      riscv_instr::VFMV_X_B,
+      riscv_instr::VFCVT_X_B,
+      riscv_instr::VFCVT_XU_B,
+
+      // int to float
+      riscv_instr::FMV_W_X,
+      riscv_instr::FCVT_S_W,
+      riscv_instr::FCVT_S_WU,
+      riscv_instr::FCVT_D_W,
+      riscv_instr::FCVT_D_WU,
+      riscv_instr::FMV_H_X,
+      riscv_instr::FCVT_H_W,
+      riscv_instr::FCVT_H_WU,
+      riscv_instr::VFMV_H_X,
+      riscv_instr::VFCVT_H_X,
+      riscv_instr::VFCVT_H_XU,
+      riscv_instr::FMV_AH_X,
+      riscv_instr::VFMV_AH_X,
+      riscv_instr::VFCVT_AH_X,
+      riscv_instr::VFCVT_AH_XU,
+      riscv_instr::FMV_B_X,
+      riscv_instr::FCVT_B_W,
+      riscv_instr::FCVT_B_WU,
+      riscv_instr::VFMV_B_X,
+      riscv_instr::VFCVT_B_X,
+      riscv_instr::VFCVT_B_XU,
+
+      riscv_instr::IMV_X_W,
+      riscv_instr::IMV_W_X,
+      // CSR accesses
+      riscv_instr::CSRRW,
+      riscv_instr::CSRRS,
+      riscv_instr::CSRRC,
+      riscv_instr::CSRRWI,
+      riscv_instr::CSRRSI,
+      riscv_instr::CSRRCI: begin
+        inp_qready_o = core_direct_ready;
+        core_direct_valid = inp_qvalid_i;
+      end
+
+      // all other instructions are pushed into the sequence buffer
+      default: begin
+        inp_qready_o  = core_rb_ready;
+        core_rb_valid = inp_qvalid_i;
+      end
+    endcase
+  end
+
+  /// Priority encoder to core.
+  always_comb begin
+    oup_qvalid_o      = core_direct_valid;
+    oup_qaddr_o       = inp_qaddr_i;
+    oup_qid_o         = inp_qid_i;
+    oup_qdata_op_o    = inp_qdata_op_i;
+    oup_qdata_arga_o  = inp_qdata_arga_i;
+    oup_qdata_argb_o  = inp_qdata_argb_i;
+    oup_qdata_argc_o  = inp_qdata_argc_i;
+
+    core_direct_ready = 1'b0;
+    seq_out_ready     = 1'b0;
+
+    if (rb_contains_instructions) begin
+      oup_qvalid_o     = seq_out_valid;
+      oup_qid_o        = '0;
+      oup_qaddr_o      = DstAddr;
+      oup_qdata_op_o   = seq_qdata_op;
+      oup_qdata_arga_o = '0;
+      oup_qdata_argb_o = '0;
+      oup_qdata_argc_o = $unsigned(seq_qdata_argc);
+      seq_out_ready    = oup_qready_i;
+    end else begin
+      core_direct_ready = oup_qready_i;
+    end
+  end
+
+  // Trace Port
+  // pragma translate_off
+  assign trace_port_o.source    = snitch_pkg::SrcFpuSeq;
+  assign trace_port_o.cbuf_push = seq_cfg_buffer_push;
+  assign trace_port_o.is_outer  = seq_cfg_buffer_in.is_outer;
+  assign trace_port_o.max_inst  = seq_cfg_buffer_in.max_inst;
+  assign trace_port_o.max_rpt   = seq_cfg_buffer_in.max_rpt;
+  assign trace_port_o.stg_max   = seq_cfg_buffer_in.stagger_max;
+  assign trace_port_o.stg_mask  = seq_cfg_buffer_in.stagger_mask;
+  // pragma translate_on
+endmodule

--- a/snitch-core/accelerator/snitch_shared_muldiv.sv
+++ b/snitch-core/accelerator/snitch_shared_muldiv.sv
@@ -1,0 +1,447 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+/// Shared Multiply/Divide a.k.a M Extension
+`include "common_cells/registers.svh"
+/// Based on Ariane's Multiply Divide
+/// Author: Michael Schaffner,  <schaffner@iis.ee.ethz.ch>
+/// Author: Florian Zaruba , <zarubaf@iis.ee.ethz.ch>
+
+module snitch_shared_muldiv #(
+  parameter int unsigned IdWidth = 5,
+  parameter int unsigned DataWidth = 0,
+  /// Derived parameter *Do not override*
+  parameter type data_t = logic [DataWidth-1:0]
+) (
+  input  logic                clk_i,
+  input  logic                rst_ni,
+  // Accelerator Interface - Slave
+  input  logic  [31:0]        acc_qaddr_i,  // unused
+  input  logic  [IdWidth-1:0] acc_qid_i,
+  input  logic  [31:0]        acc_qdata_op_i,  // RISC-V instruction
+  input  data_t               acc_qdata_arga_i,
+  input  data_t               acc_qdata_argb_i,
+  input  data_t               acc_qdata_argc_i,
+  input  logic                acc_qvalid_i,
+  output logic                acc_qready_o,
+  output data_t               acc_pdata_o,
+  output logic [IdWidth-1:0]  acc_pid_o,
+  output logic                acc_perror_o,
+  output logic                acc_pvalid_o,
+  input  logic                acc_pready_i
+);
+  typedef struct packed {
+    logic [31:0] result;
+    logic [IdWidth-1:0] id;
+  } result_t;
+  // input handshake
+  logic div_valid_op, div_ready_op;
+  logic mul_valid_op, mul_ready_op;
+  // output handshake
+  logic mul_valid, mul_ready;
+  logic div_valid, div_ready;
+  result_t div, mul, oup;
+  logic illegal_instruction;
+
+  always_comb begin
+    mul_valid_op = 1'b0;
+    div_valid_op = 1'b0;
+    acc_qready_o = 1'b0;
+    acc_perror_o = 1'b0;
+    illegal_instruction = 1'b0;
+    unique casez (acc_qdata_op_i)
+      riscv_instr::MUL, riscv_instr::MULH, riscv_instr::MULHSU, riscv_instr::MULHU: begin
+        mul_valid_op = acc_qvalid_i;
+        acc_qready_o = mul_ready_op;
+      end
+      riscv_instr::DIV, riscv_instr::DIVU, riscv_instr::REM, riscv_instr::REMU: begin
+        div_valid_op = acc_qvalid_i;
+        acc_qready_o = div_ready_op;
+      end
+      default: illegal_instruction = 1'b1;
+    endcase
+  end
+
+  // Multiplication
+  snitch_shared_muldiv_multiplier #(
+    .Width     (32),
+    .IdWidth   (IdWidth)
+  ) i_multiplier (
+    .clk_i,
+    .rst_ni,
+    .id_i       (acc_qid_i),
+    .operator_i (acc_qdata_op_i),
+    .operand_a_i(acc_qdata_arga_i[31:0]),
+    .operand_b_i(acc_qdata_argb_i[31:0]),
+    .valid_i    (mul_valid_op),
+    .ready_o    (mul_ready_op),
+    .result_o   (mul.result),
+    .valid_o    (mul_valid),
+    .ready_i    (mul_ready),
+    .id_o       (mul.id)
+  );
+  // Serial Divider
+  snitch_shared_muldiv_serdiv #(
+    .WIDTH     (32),
+    .IdWidth   (IdWidth)
+  ) i_div (
+    .clk_i     (clk_i),
+    .rst_ni    (rst_ni),
+    .id_i      (acc_qid_i),
+    .operator_i(acc_qdata_op_i),
+    .op_a_i    (acc_qdata_arga_i[31:0]),
+    .op_b_i    (acc_qdata_argb_i[31:0]),
+    .in_vld_i  (div_valid_op),
+    .in_rdy_o  (div_ready_op),
+    .out_vld_o (div_valid),
+    .out_rdy_i (div_ready),
+    .id_o      (div.id),
+    .res_o     (div.result)
+  );
+  // Output Arbitration
+  stream_arbiter #(
+    .DATA_T(result_t),
+    .N_INP (2)
+  ) i_stream_arbiter (
+    .clk_i,
+    .rst_ni     (rst_ni),
+    .inp_data_i ({div, mul}),
+    .inp_valid_i({div_valid, mul_valid}),
+    .inp_ready_o({div_ready, mul_ready}),
+    .oup_data_o (oup),
+    .oup_valid_o(acc_pvalid_o),
+    .oup_ready_i(acc_pready_i)
+  );
+  assign acc_pdata_o = {32'b0, oup.result};
+  assign acc_pid_o   = oup.id;
+endmodule
+
+module snitch_shared_muldiv_multiplier #(
+  parameter int unsigned Width   = 64,
+  parameter int unsigned IdWidth = 5
+) (
+  input  logic               clk_i,
+  input  logic               rst_ni,
+  input  logic [IdWidth-1:0] id_i,
+  input  logic [       31:0] operator_i,
+  input  logic [  Width-1:0] operand_a_i,
+  input  logic [  Width-1:0] operand_b_i,
+  input  logic               valid_i,
+  output logic               ready_o,
+  output logic [  Width-1:0] result_o,
+  output logic               valid_o,
+  input  logic               ready_i,
+  output logic [IdWidth-1:0] id_o
+);
+  // Pipeline register
+  logic [IdWidth-1:0] id_q;
+  logic valid_d, valid_q;
+  logic select_upper_q, select_upper_d;
+  logic [2*Width-1:0] result_d, result_q;
+
+  // control registers
+  logic sign_a, sign_b;
+  // control signals
+  assign ready_o = ~valid_o | ready_i;
+  // datapath
+  logic [2*Width-1:0] mult_result;
+  assign mult_result = $signed(
+      {operand_a_i[Width-1] & sign_a, operand_a_i}
+  ) * $signed(
+      {operand_b_i[Width-1] & sign_b, operand_b_i}
+  );
+  // Sign Select MUX
+  always_comb begin
+    sign_a = 1'b0;
+    sign_b = 1'b0;
+    unique casez (operator_i)
+      riscv_instr::MULH: begin
+        sign_a = 1'b1;
+        sign_b = 1'b1;
+        select_upper_d = 1'b1;
+      end
+      riscv_instr::MULHU: begin
+        select_upper_d = 1'b1;
+      end
+      riscv_instr::MULHSU: begin
+        sign_a = 1'b1;
+        select_upper_d = 1'b1;
+      end
+      // MUL performs an XLEN-bit × XLEN-bit multiplication and places the lower
+      // XLEN bits in the destination register
+      default: begin  // including MUL
+        select_upper_d = 1'b0;
+      end
+    endcase
+  end
+  // single stage version
+  assign result_d = $signed(
+      {operand_a_i[Width-1] & sign_a, operand_a_i}
+  ) * $signed(
+      {operand_b_i[Width-1] & sign_b, operand_b_i}
+  );
+  // ressult mux
+  always_comb begin
+    result_o = result_q[Width-1:0];
+    if (select_upper_q) begin
+      result_o = result_q[2*Width-1:Width];
+    end
+  end
+
+  always_comb begin
+    valid_d = valid_q;
+    if (valid_q & ready_i) valid_d = 0;
+    if (valid_i & ready_o) valid_d = 1;
+  end
+  `FF(valid_q, valid_d, '0)
+  // Pipe-line registers
+  `FFLNR(id_q, id_i, (valid_i & ready_o), clk_i)
+  `FFLNR(result_q, result_d, (valid_i & ready_o), clk_i)
+  `FFLNR(select_upper_q, select_upper_d, (valid_i & ready_o), clk_i)
+
+  assign id_o = id_q;
+  assign valid_o = valid_q;
+
+endmodule
+
+
+module snitch_shared_muldiv_serdiv #(
+  parameter int unsigned WIDTH   = 64,
+  parameter int unsigned IdWidth = 5
+) (
+  input  logic               clk_i,
+  input  logic               rst_ni,
+  // input IF
+  input  logic [IdWidth-1:0] id_i,
+  input  logic [       31:0] operator_i,
+  input  logic [  WIDTH-1:0] op_a_i,
+  input  logic [  WIDTH-1:0] op_b_i,
+  // handshake
+  // there is a cycle delay from in_rdy_o->in_vld_i, see issue_read_operands.sv stage
+  input  logic               in_vld_i,
+  output logic               in_rdy_o,
+  // output IF
+  output logic               out_vld_o,
+  input  logic               out_rdy_i,
+  output logic [IdWidth-1:0] id_o,
+  output logic [  WIDTH-1:0] res_o
+);
+
+  logic signed_op;
+  logic rem;
+
+  always_comb begin
+    signed_op = 1'b0;
+    rem = 1'b0;
+    unique casez (operator_i)
+      riscv_instr::DIV: begin
+        signed_op = 1'b1;
+      end
+      riscv_instr::DIVU: begin
+      end
+      riscv_instr::REM: begin
+        signed_op = 1'b1;
+        rem = 1'b1;
+      end
+      riscv_instr::REMU: begin
+        rem = 1'b1;
+      end
+      default: ;
+    endcase
+  end
+
+  typedef enum logic [1:0] {
+    IDLE,
+    DIVIDE,
+    FINISH
+  } state_e;
+  state_e state_d, state_q;
+
+  logic [WIDTH-1:0] res_q, res_d;
+  logic [WIDTH-1:0] op_a_q, op_a_d;
+  logic [WIDTH-1:0] op_b_q, op_b_d;
+  logic op_a_sign, op_b_sign;
+  logic op_b_zero, op_b_zero_q, op_b_zero_d;
+
+  logic [IdWidth-1:0] id_q, id_d;
+
+  logic rem_sel_d, rem_sel_q;
+  logic comp_inv_d, comp_inv_q;
+  logic res_inv_d, res_inv_q;
+
+  logic [WIDTH-1:0] add_mux;
+  logic [WIDTH-1:0] add_out;
+  logic [WIDTH-1:0] add_tmp;
+  logic [WIDTH-1:0] b_mux;
+  logic [WIDTH-1:0] out_mux;
+
+  logic [$clog2(WIDTH+1)-1:0] cnt_q, cnt_d;
+  logic cnt_zero;
+
+  logic [WIDTH-1:0] lzc_a_input, lzc_b_input, op_b;
+  logic [$clog2(WIDTH)-1:0] lzc_a_result, lzc_b_result;
+  logic [$clog2(WIDTH+1)-1:0] shift_a;
+  logic [  $clog2(WIDTH+1):0] div_shift;
+
+  logic a_reg_en, b_reg_en, res_reg_en, ab_comp, pm_sel, load_en;
+  logic lzc_a_no_one, lzc_b_no_one;
+  logic div_res_zero_d, div_res_zero_q;
+  /////////////////////////////////////
+  // align the input operands
+  // for faster division
+  /////////////////////////////////////
+  assign op_b_zero   = (op_b_i == 0);
+  assign op_a_sign   = op_a_i[$high(op_a_i)];
+  assign op_b_sign   = op_b_i[$high(op_b_i)];
+
+  assign lzc_a_input = (signed_op & op_a_sign) ? {~op_a_i, 1'b0} : op_a_i;
+  assign lzc_b_input = (signed_op & op_b_sign) ? ~op_b_i : op_b_i;
+
+  lzc #(
+    .MODE (1),  // count leading zeros
+    .WIDTH(WIDTH)
+  ) i_lzc_a (
+    .in_i   (lzc_a_input),
+    .cnt_o  (lzc_a_result),
+    .empty_o(lzc_a_no_one)
+  );
+
+  lzc #(
+    .MODE (1),  // count leading zeros
+    .WIDTH(WIDTH)
+  ) i_lzc_b (
+    .in_i   (lzc_b_input),
+    .cnt_o  (lzc_b_result),
+    .empty_o(lzc_b_no_one)
+  );
+
+  assign shift_a = (lzc_a_no_one) ? WIDTH : lzc_a_result;
+  assign div_shift = (lzc_b_no_one) ? WIDTH : lzc_b_result - shift_a;
+
+  assign op_b = op_b_i <<< $unsigned(div_shift);
+
+  // the division is zero if |opB| > |opA| and can be terminated
+  assign div_res_zero_d = (load_en) ? ($signed(div_shift) < 0) : div_res_zero_q;
+
+  /////////////////////////////////////
+  // Datapath
+  /////////////////////////////////////
+
+  assign pm_sel = load_en & ~(signed_op & (op_a_sign ^ op_b_sign));
+  // muxes
+  assign add_mux = (load_en) ? op_a_i : op_b_q;
+  // attention: logical shift by one in case of negative operand B!
+  assign b_mux = (load_en) ? op_b : {comp_inv_q, (op_b_q[$high(op_b_q):1])};
+  // in case of bad timing, we could output from regs -> needs a cycle more in the FSM
+  assign out_mux = (rem_sel_q) ? op_a_q : res_q;
+  // invert if necessary
+  assign res_o = (res_inv_q) ? -$signed(out_mux) : out_mux;
+  // main comparator
+  assign ab_comp = ((op_a_q == op_b_q)
+          | ((op_a_q > op_b_q) ^ comp_inv_q)) & ((|op_a_q) | op_b_zero_q);
+  // main adder
+  assign add_tmp = (load_en) ? 0 : op_a_q;
+  assign add_out = (pm_sel) ? add_tmp + add_mux : add_tmp - $signed(add_mux);
+
+  /////////////////////////////////////
+  // FSM, counter
+  /////////////////////////////////////
+  assign cnt_zero = (cnt_q == 0);
+  assign cnt_d = (load_en) ? div_shift : (~cnt_zero) ? cnt_q - 1 : cnt_q;
+
+  always_comb begin : p_fsm
+    // default
+    state_d    = state_q;
+    in_rdy_o   = 1'b0;
+    out_vld_o  = 1'b0;
+    load_en    = 1'b0;
+    a_reg_en   = 1'b0;
+    b_reg_en   = 1'b0;
+    res_reg_en = 1'b0;
+    unique case (state_q)
+      IDLE: begin
+        in_rdy_o = 1'b1;
+        if (in_vld_i) begin
+          a_reg_en = 1'b1;
+          b_reg_en = 1'b1;
+          load_en  = 1'b1;
+          state_d  = DIVIDE;
+        end
+      end
+      DIVIDE: begin
+        if (!div_res_zero_q) begin
+          a_reg_en   = ab_comp;
+          b_reg_en   = 1'b1;
+          res_reg_en = 1'b1;
+        end
+        // can end the division now if the result is clearly 0
+        if (div_res_zero_q) begin
+          out_vld_o = 1'b1;
+          state_d   = FINISH;
+          if (out_rdy_i) begin
+            state_d = IDLE;
+          end
+        end else if (cnt_zero) begin
+          state_d = FINISH;
+        end
+      end
+      FINISH: begin
+        out_vld_o = 1'b1;
+
+        if (out_rdy_i) begin
+          state_d = IDLE;
+        end
+      end
+      default: state_d = IDLE;
+    endcase
+  end
+
+  /////////////////////////////////////
+  // regs, flags
+  /////////////////////////////////////
+
+  // get flags
+  assign rem_sel_d = (load_en) ? rem : rem_sel_q;
+  assign comp_inv_d = (load_en) ? signed_op & op_b_sign : comp_inv_q;
+  assign op_b_zero_d = (load_en) ? op_b_zero : op_b_zero_q;
+  assign res_inv_d = (load_en) ?
+          (~op_b_zero | rem) & signed_op & (op_a_sign ^ op_b_sign) : res_inv_q;
+
+  // transaction id
+  assign id_d = (load_en) ? id_i : id_q;
+  assign id_o = id_q;
+
+  assign op_a_d = (a_reg_en) ? add_out : op_a_q;
+  assign op_b_d = (b_reg_en) ? b_mux : op_b_q;
+  assign res_d = (load_en) ? '0 : (res_reg_en) ? {res_q[$high(res_q)-1:0], ab_comp} : res_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
+    if (!rst_ni) begin
+      state_q        <= IDLE;
+      op_a_q         <= '0;
+      op_b_q         <= '0;
+      res_q          <= '0;
+      cnt_q          <= '0;
+      id_q           <= '0;
+      rem_sel_q      <= 1'b0;
+      comp_inv_q     <= 1'b0;
+      res_inv_q      <= 1'b0;
+      op_b_zero_q    <= 1'b0;
+      div_res_zero_q <= 1'b0;
+    end else begin
+      state_q        <= state_d;
+      op_a_q         <= op_a_d;
+      op_b_q         <= op_b_d;
+      res_q          <= res_d;
+      cnt_q          <= cnt_d;
+      id_q           <= id_d;
+      rem_sel_q      <= rem_sel_d;
+      comp_inv_q     <= comp_inv_d;
+      res_inv_q      <= res_inv_d;
+      op_b_zero_q    <= op_b_zero_d;
+      div_res_zero_q <= div_res_zero_d;
+    end
+  end
+
+endmodule

--- a/snitch-core/accelerator/snitch_ssr.sv
+++ b/snitch-core/accelerator/snitch_ssr.sv
@@ -1,0 +1,231 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
+// Author: Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+
+module snitch_ssr import snitch_ssr_pkg::*; #(
+  parameter ssr_cfg_t Cfg = '0,
+  parameter int unsigned AddrWidth = 0,
+  parameter int unsigned DataWidth = 0,
+  parameter type tcdm_user_t  = logic,
+  parameter type tcdm_req_t   = logic,
+  parameter type tcdm_rsp_t   = logic,
+  parameter type isect_slv_req_t = logic,
+  parameter type isect_slv_rsp_t = logic,
+  parameter type isect_mst_req_t = logic,
+  parameter type isect_mst_rsp_t = logic,
+  parameter type ssr_rdata_t = logic,
+  /// Derived parameter *Do not override*
+  parameter type data_t = logic [DataWidth-1:0]
+) (
+  input  logic        clk_i,
+  input  logic        rst_ni,
+  // Access to configuration registers (REG_BUS).
+  input  logic  [4:0] cfg_word_i,
+  input  logic        cfg_write_i,  // 0 = read, 1 = write
+  output logic [31:0] cfg_rdata_o,
+  input  logic [31:0] cfg_wdata_i,
+  output logic        cfg_wready_o,
+  // Register lanes from switch.
+  output data_t       lane_rdata_o,
+  input  data_t       lane_wdata_i,
+  output logic        lane_valid_o,
+  input  logic        lane_ready_i,
+  // Ports into memory.
+  output tcdm_req_t   mem_req_o,
+  input  tcdm_rsp_t   mem_rsp_i,
+  // Interface with intersector
+  output isect_slv_req_t isect_slv_req_o,
+  input  isect_slv_rsp_t isect_slv_rsp_i,
+  output isect_mst_req_t isect_mst_req_o,
+  input  isect_mst_rsp_t isect_mst_rsp_i
+);
+
+  data_t fifo_out, fifo_in;
+  logic fifo_push, fifo_pop, fifo_full, fifo_empty;
+  logic has_credit, credit_take, credit_give, credit_full;
+  logic [Cfg.RptWidth-1:0] rep_max, rep_q, rep_d, rep_done, rep_enable, rep_clear;
+
+  fifo_v3 #(
+    .FALL_THROUGH ( 0           ),
+    .DATA_WIDTH   ( DataWidth   ),
+    .DEPTH        ( Cfg.DataCredits )
+  ) i_fifo (
+    .clk_i,
+    .rst_ni,
+    .testmode_i ( 1'b0       ),
+    .flush_i    ( '0         ),
+    .full_o     ( fifo_full  ),
+    .empty_o    ( fifo_empty ),
+    .usage_o    (            ),
+    .data_i     ( fifo_in    ),
+    .push_i     ( fifo_push  ),
+    .data_o     ( fifo_out   ),
+    .pop_i      ( fifo_pop   )
+  );
+
+  logic data_req_qvalid;
+  tcdm_req_t idx_req, data_req;
+  tcdm_rsp_t idx_rsp, data_rsp;
+  logic agen_valid, agen_ready, agen_write;
+  logic agen_zero, lane_zero, zero_empty;
+
+  snitch_ssr_addr_gen #(
+    .Cfg          ( Cfg         ),
+    .AddrWidth    ( AddrWidth   ),
+    .DataWidth    ( DataWidth   ),
+    .tcdm_req_t   ( tcdm_req_t  ),
+    .tcdm_rsp_t   ( tcdm_rsp_t  ),
+    .tcdm_user_t  ( tcdm_user_t ),
+    .isect_slv_req_t ( isect_slv_req_t ),
+    .isect_slv_rsp_t ( isect_slv_rsp_t ),
+    .isect_mst_req_t ( isect_mst_req_t ),
+    .isect_mst_rsp_t ( isect_mst_rsp_t )
+  ) i_addr_gen (
+    .clk_i,
+    .rst_ni,
+    .idx_req_o      ( idx_req ),
+    .idx_rsp_i      ( idx_rsp ),
+    .isect_slv_req_o,
+    .isect_slv_rsp_i,
+    .isect_mst_req_o,
+    .isect_mst_rsp_i,
+    .cfg_word_i,
+    .cfg_rdata_o,
+    .cfg_wdata_i,
+    .cfg_write_i,
+    .cfg_wready_o,
+    .reg_rep_o      ( rep_max           ),
+    .mem_addr_o     ( data_req.q.addr   ),
+    .mem_zero_o     ( agen_zero         ),
+    .mem_write_o    ( agen_write        ),
+    .mem_valid_o    ( agen_valid        ),
+    .mem_ready_i    ( agen_ready        )
+  );
+
+  // When the SSR reverses direction, the inflight data *must* be vacated before any
+  // requests can be issued (i.e. addresses consumed) to prevent stream corruption.
+  logic agen_write_q, agen_write_reversing, agen_flush, dm_write;
+  `FFLARN(agen_write_q, agen_write, agen_valid & agen_ready, '0, clk_i, rst_ni)
+
+  // When direction reverses, deassert agen readiness until credits replenished.
+  // The datamover must preserve its directional muxing until the flush is complete.
+  // This will *not* block write preloading of the FIFO.
+  assign agen_write_reversing = agen_write ^ agen_write_q;
+  assign agen_flush = agen_write_reversing & ~credit_full;
+  assign dm_write = agen_flush ? agen_write_q : agen_write;
+
+  assign agen_ready = ~agen_flush & (agen_zero ?
+    has_credit : (data_req_qvalid & data_rsp.q_ready));
+  assign data_req.q.write = agen_write;
+
+  if (Cfg.Indirection) begin : gen_demux
+    tcdm_mux #(
+      .NrPorts    ( 2             ),
+      .AddrWidth  ( AddrWidth     ),
+      .DataWidth  ( DataWidth     ),
+      .user_t     ( tcdm_user_t   ),
+      .RespDepth  ( Cfg.MuxRespDepth  ),
+      .tcdm_req_t ( tcdm_req_t    ),
+      .tcdm_rsp_t ( tcdm_rsp_t    )
+    ) i_tcdm_mux (
+      .clk_i,
+      .rst_ni,
+      .slv_req_i  ( {idx_req, data_req} ),
+      .slv_rsp_o  ( {idx_rsp, data_rsp} ),
+      .mst_req_o  ( mem_req_o ),
+      .mst_rsp_i  ( mem_rsp_i )
+    );
+  end else begin : gen_no_demux
+    assign mem_req_o = data_req;
+    assign data_rsp  = mem_rsp_i;
+    // Tie off Index responses
+    assign idx_rsp = '0;
+  end
+
+  assign data_req.q_valid = data_req_qvalid;
+  assign data_req.q.amo = reqrsp_pkg::AMONone;
+  assign data_req.q.user = '0;
+
+  assign lane_rdata_o = lane_zero ? '0 : fifo_out;
+  assign data_req.q.data = fifo_out;
+  assign data_req.q.strb = '1;
+
+  always_comb begin
+    if (dm_write) begin
+      lane_valid_o = ~fifo_full;
+      data_req_qvalid = agen_valid & ~fifo_empty & has_credit & ~agen_flush;
+      fifo_push = lane_ready_i & ~fifo_full;
+      fifo_in = lane_wdata_i;
+      rep_enable = 0;
+      fifo_pop = data_req_qvalid & data_rsp.q_ready;
+      // During writes, the credit counter tracks write responses;
+      // This is necessary as inflight responses may break subsequent reads.
+      credit_take = fifo_pop;
+      credit_give = data_rsp.p_valid;
+    end else begin
+      lane_valid_o = ~fifo_empty | (~zero_empty & lane_zero);
+      data_req_qvalid = agen_valid & ~fifo_full & has_credit & ~agen_zero & ~agen_flush;
+      fifo_push = data_rsp.p_valid;
+      fifo_in = data_rsp.p.data;
+      rep_enable = lane_ready_i & lane_valid_o;
+      fifo_pop = rep_enable & rep_done & ~(~zero_empty & lane_zero);
+      credit_take = agen_valid & agen_ready;
+      credit_give = rep_enable & rep_done;
+    end
+  end
+
+  if (Cfg.IsectMaster) begin : gen_isect_master
+    // A FIFO keeping the zero flag for in-flight reads only.
+    fifo_v3 #(
+      .FALL_THROUGH ( 0 ),
+      .DATA_WIDTH   ( 1 ),
+      .DEPTH        ( Cfg.DataCredits )
+    ) i_fifo_zero (
+      .clk_i,
+      .rst_ni,
+      .testmode_i ( 1'b0        ),
+      .flush_i    ( '0          ),
+      .full_o     (  ),
+      .empty_o    ( zero_empty  ),
+      .usage_o    (  ),
+      .data_i     ( agen_zero   ),
+      .push_i     ( credit_take & ~dm_write ),
+      .data_o     ( lane_zero   ),
+      .pop_i      ( credit_give & ~zero_empty )
+    );
+  end else begin : gen_no_isect_master
+    // If not an intersection master, we cannot inject zeros.
+    assign zero_empty = 1'b1;
+    assign lane_zero  = 1'b0;
+  end
+
+  // Credit counter that keeps track of the number of memory requests issued
+  // to ensure that the FIFO does not overfill.
+  snitch_ssr_credit_counter #(
+    .NumCredits       ( Cfg.DataCredits ),
+    .InitCreditEmpty  ( 1'b0 )
+  ) i_snitch_ssr_credit_counter (
+    .clk_i,
+    .rst_ni,
+    .credit_o      (  ),
+    .credit_give_i ( credit_give ),
+    .credit_take_i ( credit_take ),
+    .credit_init_i ( 1'b0 ),
+    .credit_left_o ( has_credit  ),
+    .credit_crit_o (  ),
+    .credit_full_o ( credit_full )
+  );
+
+  // Repetition counter.
+  assign rep_d = rep_q + 1;
+  assign rep_clear = rep_enable & rep_done;
+  `FFLARNC(rep_q, rep_d, rep_enable, rep_clear, '0, clk_i, rst_ni)
+
+  assign rep_done = (rep_q == rep_max);
+
+endmodule

--- a/snitch-core/accelerator/snitch_ssr_pkg.sv
+++ b/snitch-core/accelerator/snitch_ssr_pkg.sv
@@ -1,0 +1,70 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+// Types and fixed constants for SSRs.
+
+package snitch_ssr_pkg;
+
+  // Passed parameters for individual SSRs
+  typedef struct packed {
+    bit           Indirection;
+    bit           IsectMaster;
+    bit           IsectMasterIdx;
+    bit           IsectSlave;
+    bit           IsectSlaveSpill;
+    bit           IndirOutSpill;
+    int unsigned  NumLoops;
+    int unsigned  IndexWidth;
+    int unsigned  PointerWidth;
+    int unsigned  ShiftWidth;
+    int unsigned  RptWidth;
+    int unsigned  IndexCredits;
+    int unsigned  IsectSlaveCredits;
+    int unsigned  DataCredits;
+    int unsigned  MuxRespDepth;
+  } ssr_cfg_t;
+
+  // Derived parameters for intersection
+  typedef struct packed {
+    int unsigned  IndexWidth;
+    int unsigned  NumMaster0;
+    int unsigned  NumMaster1;
+    int unsigned  NumSlave;
+    int unsigned  IdxMaster0;
+    int unsigned  IdxMaster1;
+    int unsigned  IdxSlave;
+    int unsigned  StreamctlDepth;
+  } isect_cfg_t;
+
+  // Fields used in addresses of upper alias registers
+  // *Not* the same order as alias address, but as in upper status fields
+  typedef struct packed {
+    logic no_indir;
+    logic write;
+    logic [1:0] dims;
+  } cfg_alias_fields_t;
+
+  // Upper fields accessible on status register
+  typedef struct packed {
+    logic done;
+    logic write;
+    logic [1:0] dims;
+    logic indir;
+  } cfg_status_upper_t;
+
+  // Indexing control flags
+  typedef struct packed {
+    logic merge;
+  } idx_flags_t;
+
+  // Layout of indexing control register
+  typedef struct packed {
+    idx_flags_t flags;
+    logic [7:0] shift;
+    logic [7:0] size;
+  } cfg_idx_ctl_t;
+
+endpackage

--- a/snitch-core/include/snitch_acc_interface.svh
+++ b/snitch-core/include/snitch_acc_interface.svh
@@ -1,0 +1,28 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+`ifndef SNITCH_ACC_INTERFACE_SVH
+`define SNITCH_ACC_INTERFACE_SVH
+
+package snitch_acc_pkg;
+  import snitch_pkg::*;
+
+  typedef struct packed {
+    acc_addr_e   addr;
+    logic [4:0]  id;
+    logic [31:0] data_op;
+    data_t       data_arga;
+    data_t       data_argb;
+    addr_t       data_argc;
+  } acc_req_t;
+
+  typedef struct packed {
+    logic [4:0] id;
+    logic       error;
+    data_t      data;
+  } acc_resp_t;
+
+endpackage
+
+`endif // SNITCH_ACC_INTERFACE_SVH


### PR DESCRIPTION
This change integrates official PULP Snitch accelerator interface implementations into the codebase. 

I researched the PULP Snitch architecture and identified several key accelerator modules (FPU SS, IPU, DMA, SSR) that use the Snitch Accelerator Interface. I then downloaded these files from the pulp-platform/snitch repository and placed them in `snitch-core/accelerator`. To ensure these modules can be successfully instantiated or analyzed within the existing snitch-core environment, I extracted the `acc_req_t` and `acc_resp_t` definitions from the cluster-level RTL and provided them in a new header file `snitch-core/include/snitch_acc_interface.svh`. 

I also added a `SOURCES.txt` file in the accelerator directory to maintain a record of the source URLs for these external components. Finally, I verified that these additions do not interfere with the existing MAC unit tests.

Fixes #759

---
*PR created automatically by Jules for task [11246326203489929138](https://jules.google.com/task/11246326203489929138) started by @chatelao*