### PR TITLE
Implement Max Cycle Density Optimization

### DIFF
--- a/src/project.v
+++ b/src/project.v
@@ -103,6 +103,11 @@ module tt_um_chatelao_fp8_multiplier #(
     reg       packed_mode_reg;
     reg [1:0] lns_mode_reg;
 
+    // Output Buffering for High Density Throughput.
+    reg [31:0] result_latch;
+    reg [2:0]  sticky_latch_reg;
+    reg [2:0]  output_step_cnt;
+
     // --- Debug and Probing Logic ---
     wire       debug_en_val;
     wire [3:0] probe_sel_val;
@@ -314,13 +319,12 @@ module tt_um_chatelao_fp8_multiplier #(
     wire actual_packed_serial = (SUPPORT_PACKED_SERIAL && !SUPPORT_VECTOR_PACKING && !actual_input_buffering && packed_mode && (format_a == 3'b100) && (format_b_val == 3'b100));
     wire [COUNTER_WIDTH-1:0] last_stream_cycle = actual_packed_mode ? 6'd18 : 6'd34;
     wire [COUNTER_WIDTH-1:0] capture_cycle     = actual_packed_mode ? 6'd20 : 6'd36;
-    wire [COUNTER_WIDTH-1:0] last_cycle        = actual_packed_mode ? 6'd24 : 6'd40;
+    wire [COUNTER_WIDTH-1:0] last_cycle        = capture_cycle;
 
     // FSM State derivation based on the current logical cycle.
     wire [1:0] state = (logical_cycle == 6'd0) ? STATE_IDLE :
                        (logical_cycle <= 6'd2) ? STATE_LOAD_SCALE :
-                       (logical_cycle <= capture_cycle) ? STATE_STREAM :
-                       STATE_OUTPUT;
+                       STATE_STREAM;
 
     initial begin
         cycle_count = {COUNTER_WIDTH{1'b0}};
@@ -329,6 +333,9 @@ module tt_um_chatelao_fp8_multiplier #(
         overflow_wrap_reg = 1'b0;
         packed_mode_reg = 1'b0;
         lns_mode_reg = 2'd0;
+        result_latch = 32'h0;
+        sticky_latch_reg = 3'b0;
+        output_step_cnt = 3'd0;
     end
 
     // Configure bidirectional pins as inputs for Tiny Tapeout.
@@ -347,7 +354,19 @@ module tt_um_chatelao_fp8_multiplier #(
             overflow_wrap_reg <= 1'b0;
             packed_mode_reg <= 1'b0;
             lns_mode_reg <= 2'd0;
+            result_latch <= 32'h0;
+            sticky_latch_reg <= 3'b0;
+            output_step_cnt <= 3'd0;
         end else if (ena && strobe) begin
+            // Result Serialization Logic (Independent of FSM).
+            if (logical_cycle == capture_cycle) begin
+                result_latch <= final_scaled_result;
+                sticky_latch_reg <= {nan_sticky, inf_pos_sticky, inf_neg_sticky};
+                output_step_cnt <= 3'd4;
+            end else if (output_step_cnt > 3'd0) begin
+                output_step_cnt <= output_step_cnt - 3'd1;
+            end
+
             if (logical_cycle == {COUNTER_WIDTH{1'b0}}) begin
                 // Capture Metadata at the start of a block (Cycle 0).
                 round_mode_reg    <= uio_in[4:3];
@@ -383,8 +402,8 @@ module tt_um_chatelao_fp8_multiplier #(
 
     // Control signal to enable the accumulator only when valid products are arriving.
     wire acc_en    = strobe && (SUPPORT_PIPELINING ?
-                     ((logical_cycle >= 6'd4 && logical_cycle <= last_stream_cycle + 6'd1) && (state == STATE_STREAM || state == STATE_OUTPUT)) :
-                     ((logical_cycle >= 6'd3 && logical_cycle <= last_stream_cycle) && (state == STATE_STREAM)));
+                     ((logical_cycle >= 6'd4 && logical_cycle <= last_stream_cycle + 6'd1)) :
+                     ((logical_cycle >= 6'd3 && logical_cycle <= last_stream_cycle)));
 
     // Multiplier results wires.
     wire [15:0] mul_prod_lane0, mul_prod_lane1;
@@ -711,11 +730,11 @@ module tt_um_chatelao_fp8_multiplier #(
         end
     endgenerate
 
-    wire [31:0] aligner_lane0_in_prod = (ENABLE_SHARED_SCALING && logical_cycle >= capture_cycle) ?
+    wire [31:0] aligner_lane0_in_prod = (ENABLE_SHARED_SCALING && logical_cycle == capture_cycle) ?
                                     aligner_lane0_in_prod_acc :
                                     {16'd0, mul_prod_lane0_val};
-    wire signed [9:0] aligner_lane0_in_exp  = (ENABLE_SHARED_SCALING && logical_cycle >= capture_cycle) ? (shared_exp + 10'sd5) : exp_sum_lane0_adj;
-    wire aligner_lane0_in_sign = (ENABLE_SHARED_SCALING && logical_cycle >= capture_cycle) ? acc_out[ACCUMULATOR_WIDTH-1] : mul_sign_lane0_val;
+    wire signed [9:0] aligner_lane0_in_exp  = (ENABLE_SHARED_SCALING && logical_cycle == capture_cycle) ? (shared_exp + 10'sd5) : exp_sum_lane0_adj;
+    wire aligner_lane0_in_sign = (ENABLE_SHARED_SCALING && logical_cycle == capture_cycle) ? acc_out[ACCUMULATOR_WIDTH-1] : mul_sign_lane0_val;
 
     wire [31:0] aligned_lane0_res;
     fp8_aligner #(
@@ -775,15 +794,18 @@ module tt_um_chatelao_fp8_multiplier #(
     // --- Sticky Override Logic ---
     // Standardizes the representation of Infinities and NaNs in the output.
     reg [7:0] sticky_byte;
-    wire [5:0] output_byte_idx = logical_cycle - capture_cycle;
+    wire l_nan_sticky     = sticky_latch_reg[2];
+    wire l_inf_pos_sticky = sticky_latch_reg[1];
+    wire l_inf_neg_sticky = sticky_latch_reg[0];
+
     always @(*) begin
-        case (output_byte_idx)
-            6'd1: sticky_byte = (nan_sticky || (inf_pos_sticky && inf_neg_sticky)) ? 8'h7F : (inf_pos_sticky ? 8'h7F : 8'hFF);
-            6'd2: sticky_byte = (nan_sticky || (inf_pos_sticky && inf_neg_sticky)) ? 8'hC0 : 8'h80;
+        case (output_step_cnt)
+            3'd4: sticky_byte = (l_nan_sticky || (l_inf_pos_sticky && l_inf_neg_sticky)) ? 8'h7F : (l_inf_pos_sticky ? 8'h7F : 8'hFF);
+            3'd3: sticky_byte = (l_nan_sticky || (l_inf_pos_sticky && l_inf_neg_sticky)) ? 8'hC0 : 8'h80;
             default: sticky_byte = 8'h00;
         endcase
     end
-    wire sticky_any = nan_sticky | inf_pos_sticky | inf_neg_sticky;
+    wire sticky_any_latched = |sticky_latch_reg;
 
     wire [31:0] final_scaled_result = ENABLE_SHARED_SCALING ? aligned_lane0_res : acc_out_ext;
 
@@ -799,8 +821,8 @@ module tt_um_chatelao_fp8_multiplier #(
         .data_in(aligned_combined),
         .load_en(ena && strobe && logical_cycle == capture_cycle),
         .load_data(final_scaled_result),
-        .shift_en(ena && strobe && state == STATE_OUTPUT && logical_cycle > capture_cycle && logical_cycle < last_cycle),
-        .shift_out(acc_shift_out),
+        .shift_en(1'b0),
+        .shift_out(),
         .data_out(acc_out)
     );
 
@@ -834,9 +856,13 @@ module tt_um_chatelao_fp8_multiplier #(
     // --- Main Output Multiplexer ---
     // Decides what data to send to uo_out based on current cycle and configuration.
     assign uo_out = loopback_en_val ? (ui_in ^ uio_in) :
-                    (state == STATE_OUTPUT && logical_cycle > capture_cycle) ?
-                    (sticky_any ? sticky_byte : acc_shift_out) :
-                    (debug_en_val && logical_cycle == capture_cycle - 6'd1) ? metadata_echo :
+                    (output_step_cnt > 3'd0) ?
+                    (sticky_any_latched ? sticky_byte :
+                     (output_step_cnt == 3'd4) ? result_latch[31:24] :
+                     (output_step_cnt == 3'd3) ? result_latch[23:16] :
+                     (output_step_cnt == 3'd2) ? result_latch[15:8] :
+                     result_latch[7:0]) :
+                    (debug_en_val && logical_cycle == capture_cycle) ? metadata_echo :
                     (debug_en_val && logical_cycle < capture_cycle) ? probe_data :
                     8'h00;
 
@@ -892,8 +918,7 @@ module tt_um_chatelao_fp8_multiplier #(
             // State progression (verified by combinatorial definition)
             assert(state == ((logical_cycle == 6'd0) ? STATE_IDLE :
                              (logical_cycle <= 6'd2) ? STATE_LOAD_SCALE :
-                             (logical_cycle <= capture_cycle) ? STATE_STREAM :
-                             STATE_OUTPUT));
+                             STATE_STREAM));
         end
     end
 
@@ -934,15 +959,15 @@ module tt_um_chatelao_fp8_multiplier #(
         if (rst_n) begin
             if (loopback_en_val) begin
                 assert(uo_out == (ui_in ^ uio_in));
-            end else if (state == STATE_OUTPUT && logical_cycle > capture_cycle) begin
-                if (sticky_any) begin
+            end else if (output_step_cnt > 3'd0) begin
+                if (sticky_any_latched) begin
                     assert(uo_out == sticky_byte);
                 end else begin
-                    case (logical_cycle - capture_cycle)
-                        6'd1: assert(uo_out == f_scaled_acc_reg[31:24]);
-                        6'd2: assert(uo_out == f_scaled_acc_reg[23:16]);
-                        6'd3: assert(uo_out == f_scaled_acc_reg[15:8]);
-                        6'd4: assert(uo_out == f_scaled_acc_reg[7:0]);
+                    case (output_step_cnt)
+                        3'd4: assert(uo_out == result_latch[31:24]);
+                        3'd3: assert(uo_out == result_latch[23:16]);
+                        3'd2: assert(uo_out == result_latch[15:8]);
+                        3'd1: assert(uo_out == result_latch[7:0]);
                         default: assert(uo_out == 8'd0);
                     endcase
                 end

--- a/src/project.v
+++ b/src/project.v
@@ -58,7 +58,6 @@ module tt_um_chatelao_fp8_multiplier #(
     localparam STATE_IDLE       = 2'b00; // Waiting for start or processing metadata.
     localparam STATE_LOAD_SCALE = 2'b01; // Capturing scaling factors (Cycle 1 & 2).
     localparam STATE_STREAM     = 2'b10; // Processing 32 element pairs (Cycles 3-34).
-    localparam STATE_OUTPUT     = 2'b11; // Sending the 32-bit result out byte-by-byte.
 
     reg [COUNTER_WIDTH-1:0] cycle_count;
     wire strobe; // Used to handle bit-serial timing if enabled.
@@ -664,7 +663,7 @@ module tt_um_chatelao_fp8_multiplier #(
     // Optimization: Use a constant cycle window for element sticky latching to fix timing and avoid metadata latching.
     // Standard elements at 3..last_stream_cycle. Pipelined products at 4..last_stream_cycle+1.
     // This avoids Cycle 1/2 (Scales) and Cycle 3 (Pipelined garbage).
-    wire sticky_latch_en = (logical_cycle >= (SUPPORT_PIPELINING ? 6'd4 : 6'd3)) && (logical_cycle <= last_stream_cycle + (SUPPORT_PIPELINING ? 6'd1 : 6'd0));
+    wire sticky_latch_en = (logical_cycle >= (SUPPORT_PIPELINING ? 6'd4 : 6'd3)) && (logical_cycle <= last_stream_cycle + (SUPPORT_PIPELINING ? 6'd1 : 6'd0)) && (state == STATE_STREAM);
 
     always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin
@@ -781,7 +780,6 @@ module tt_um_chatelao_fp8_multiplier #(
 
     wire acc_clear = ena && strobe && (logical_cycle <= 6'd2) && (state != STATE_STREAM) && (cycle_count <= 6'd2);
 
-    wire [7:0] acc_shift_out;
     wire [31:0] acc_out_ext;
     generate
         if (ACCUMULATOR_WIDTH > 32) begin : gen_acc_out_ext_wide
@@ -822,7 +820,6 @@ module tt_um_chatelao_fp8_multiplier #(
         .load_en(ena && strobe && logical_cycle == capture_cycle),
         .load_data(final_scaled_result),
         .shift_en(1'b0),
-        .shift_out(),
         .data_out(acc_out)
     );
 
@@ -971,7 +968,7 @@ module tt_um_chatelao_fp8_multiplier #(
                         default: assert(uo_out == 8'd0);
                     endcase
                 end
-            end else if (debug_en_val && logical_cycle == capture_cycle - 6'd1) begin
+            end else if (debug_en_val && logical_cycle == capture_cycle) begin
                 assert(uo_out == metadata_echo);
             end else if (debug_en_val && logical_cycle < capture_cycle) begin
                 assert(uo_out == probe_data);

--- a/test/test_overlap.py
+++ b/test/test_overlap.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: © 2025 Jules
+# SPDX-License-Identifier: Apache-2.0
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import ClockCycles, Timer, RisingEdge
+import os
+import random
+
+# Import utilities from the original test
+from test import get_param, align_product_model, align_model, decode_format
+
+async def send_block_header(dut, scale_a, scale_b, format_a, format_b,
+                            round_mode=0, overflow_wrap=0, packed_mode=0, mx_plus_mode=0, lns_mode=0,
+                            short_protocol=False):
+    """Sends the first 3 cycles of a block."""
+    if short_protocol:
+        # Cycle 0 with Short Protocol bit set
+        dut.ui_in.value = 0x80 | (lns_mode << 3)
+        dut.uio_in.value = (format_a & 0x7) | (round_mode << 3) | (overflow_wrap << 5) | (packed_mode << 6) | (mx_plus_mode << 7)
+        await RisingEdge(dut.clk)
+        # Immediately moves to Cycle 3 (Stream)
+    else:
+        # Cycle 0: Metadata
+        dut.ui_in.value = (lns_mode << 3)
+        dut.uio_in.value = (round_mode << 3) | (overflow_wrap << 5) | (packed_mode << 6) | (mx_plus_mode << 7)
+        await RisingEdge(dut.clk)
+
+        # Cycle 1: Scale A / Format A
+        dut.ui_in.value = scale_a
+        dut.uio_in.value = (format_a & 0x7)
+        await RisingEdge(dut.clk)
+
+        # Cycle 2: Scale B / Format B
+        dut.ui_in.value = scale_b
+        dut.uio_in.value = (format_b & 0x7)
+        await RisingEdge(dut.clk)
+
+@cocotb.test()
+async def test_high_density_overlap(dut):
+    """
+    Verifies that the MAC unit can process blocks back-to-back with
+    37-cycle periodicity (Standard) or 21-cycle (Packed).
+    """
+    dut._log.info("Starting High Density Overlap Test")
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    # Initial Reset
+    dut.ena.value = 1
+    dut.ui_in.value = 0
+    dut.uio_in.value = 0
+    dut.rst_n.value = 0
+    await ClockCycles(dut.clk, 10)
+    dut.rst_n.value = 1
+    # Cycle 0 metadata is sampled on the first edge after rst_n=1.
+
+    # Test configuration
+    num_blocks = 5
+    format_a = 0 # E4M3
+    format_b = 0
+    scale_a = 127
+    scale_b = 127
+
+    # Pre-generate data for all blocks
+    blocks_data = []
+    expected_results = []
+
+    acc_width = get_param(dut, "ACCUMULATOR_WIDTH", 32)
+    aligner_width = get_param(dut, "ALIGNER_WIDTH", 40)
+    support_shared = get_param(dut, "ENABLE_SHARED_SCALING", 1)
+
+    for b in range(num_blocks):
+        a_els = [random.randint(0, 255) for _ in range(32)]
+        b_els = [random.randint(0, 255) for _ in range(32)]
+        blocks_data.append((a_els, b_els))
+
+        # Calculate expected result for each block
+        expected_acc = 0
+        for i in range(32):
+            prod = align_product_model(a_els[i], b_els[i], format_a, format_b,
+                                       aligner_width=aligner_width)
+            expected_acc = (expected_acc + prod) & 0xFFFFFFFF
+            if expected_acc & 0x80000000: expected_acc -= 0x100000000
+            # Simplified signed wrap/sat for test model
+            if expected_acc > 0x7FFFFFFF: expected_acc = 0x7FFFFFFF
+            if expected_acc < -0x80000000: expected_acc = -0x80000000
+
+        if support_shared:
+            shared_exp = scale_a + scale_b - 254
+            acc_abs = abs(expected_acc)
+            acc_sign = 1 if expected_acc < 0 else 0
+            res = align_model(acc_abs, shared_exp + 5, acc_sign, width=aligner_width)
+        else:
+            res = expected_acc
+
+        res = res & 0xFFFFFFFF
+        if res & 0x80000000: res -= 0x100000000
+        expected_results.append(res)
+
+    # Task to capture results from uo_out
+    captured_results = []
+    async def capture_results():
+        # Wait for the first capture event
+        while int(dut.user_project.output_step_cnt.value) == 0:
+            await RisingEdge(dut.clk)
+
+        for b in range(num_blocks):
+            res = 0
+            # Wait for output_step_cnt to reach 4
+            while int(dut.user_project.output_step_cnt.value) != 4:
+                await RisingEdge(dut.clk)
+
+            for i in range(4):
+                await Timer(1, unit="ns")
+                val = dut.uo_out.value
+                if val.is_resolvable:
+                    res = (res << 8) | int(val)
+                else:
+                    res = (res << 8) | 0x00
+                await RisingEdge(dut.clk)
+            captured_results.append(res if res < 0x80000000 else res - 0x100000000)
+
+    cocotb.start_soon(capture_results())
+
+    # Stream blocks
+    for b in range(num_blocks):
+        dut._log.info(f"Sending Block {b}")
+        # Cycles 0-2 (or just 0 if we used short protocol)
+        await send_block_header(dut, scale_a, scale_b, format_a, format_b)
+
+        # Cycles 3-34: Elements
+        a_els, b_els = blocks_data[b]
+        for i in range(32):
+            dut.ui_in.value = a_els[i]
+            dut.uio_in.value = b_els[i]
+            await RisingEdge(dut.clk)
+
+        # Cycle 35: Flush
+        dut.ui_in.value = 0
+        dut.uio_in.value = 0
+        await RisingEdge(dut.clk)
+
+        # Cycle 36: Capture (last_cycle)
+        # At the end of this cycle, cycle_count wraps to 0.
+        # Next block starts immediately.
+
+    # Wait for all results to be captured
+    await ClockCycles(dut.clk, 40)
+
+    for b in range(num_blocks):
+        dut._log.info(f"Block {b}: Expected {expected_results[b]}, Captured {captured_results[b]}")
+        assert captured_results[b] == expected_results[b]
+
+@cocotb.test()
+async def test_packed_fp4_overlap(dut):
+    """
+    Verifies that FP4 Packed mode can process blocks back-to-back with
+    21-cycle periodicity.
+    """
+    support_packing = get_param(dut, "SUPPORT_VECTOR_PACKING", 1)
+    if not support_packing:
+        dut._log.info("Skipping Packed FP4 Overlap Test (Not supported)")
+        return
+
+    dut._log.info("Starting Packed FP4 Overlap Test")
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    # Initial Reset
+    dut.ena.value = 1
+    dut.ui_in.value = 0
+    dut.uio_in.value = 0
+    dut.rst_n.value = 0
+    await ClockCycles(dut.clk, 10)
+    dut.rst_n.value = 1
+
+    num_blocks = 5
+    format_a = 4 # E2M1
+    format_b = 4
+    packed_mode = 1
+
+    blocks_data = []
+    expected_results = []
+    aligner_width = get_param(dut, "ALIGNER_WIDTH", 40)
+
+    for b in range(num_blocks):
+        a_els = [random.randint(0, 15) for _ in range(32)]
+        b_els = [random.randint(0, 15) for _ in range(32)]
+        blocks_data.append((a_els, b_els))
+
+        expected_acc = 0
+        for i in range(32):
+            prod = align_product_model(a_els[i], b_els[i], format_a, format_b,
+                                       aligner_width=aligner_width)
+            expected_acc = (expected_acc + prod) & 0xFFFFFFFF
+            if expected_acc & 0x80000000: expected_acc -= 0x100000000
+            if expected_acc > 0x7FFFFFFF: expected_acc = 0x7FFFFFFF
+            if expected_acc < -0x80000000: expected_acc = -0x80000000
+
+        # Result is signed 32-bit
+        res = expected_acc & 0xFFFFFFFF
+        if res & 0x80000000: res -= 0x100000000
+        expected_results.append(res)
+
+    captured_results = []
+    async def capture_results_packed():
+        while int(dut.user_project.output_step_cnt.value) == 0:
+            await RisingEdge(dut.clk)
+
+        for b in range(num_blocks):
+            res = 0
+            while int(dut.user_project.output_step_cnt.value) != 4:
+                await RisingEdge(dut.clk)
+
+            for i in range(4):
+                await Timer(1, unit="ns")
+                val = dut.uo_out.value
+                if val.is_resolvable:
+                    res = (res << 8) | int(val)
+                await RisingEdge(dut.clk)
+            captured_results.append(res if res < 0x80000000 else res - 0x100000000)
+
+    cocotb.start_soon(capture_results_packed())
+
+    for b in range(num_blocks):
+        dut._log.info(f"Sending Packed Block {b}")
+        # Cycle 0: Config (Packed=1)
+        dut.ui_in.value = 0
+        dut.uio_in.value = (1 << 6) # PACKED_EN
+        await RisingEdge(dut.clk)
+
+        # Cycle 1-2: Scales
+        dut.ui_in.value = 127
+        dut.uio_in.value = 4 # E2M1
+        await RisingEdge(dut.clk)
+        dut.ui_in.value = 127
+        dut.uio_in.value = 4
+        await RisingEdge(dut.clk)
+
+        # Cycles 3-18: 16 cycles of packed elements
+        a_els, b_els = blocks_data[b]
+        for i in range(16):
+            dut.ui_in.value = (a_els[2*i+1] << 4) | a_els[2*i]
+            dut.uio_in.value = (b_els[2*i+1] << 4) | b_els[2*i]
+            await RisingEdge(dut.clk)
+
+        # Cycle 19: Flush
+        dut.ui_in.value = 0
+        dut.uio_in.value = 0
+        await RisingEdge(dut.clk)
+
+        # Cycle 20: Capture (last_cycle for packed)
+        await RisingEdge(dut.clk)
+
+    await ClockCycles(dut.clk, 30)
+    for b in range(num_blocks):
+        dut._log.info(f"Block {b}: Expected {expected_results[b]}, Captured {captured_results[b]}")
+        assert captured_results[b] == expected_results[b]
+
+@cocotb.test()
+async def test_short_overlap(dut):
+    """Verifies overlap using the Short Protocol (23-cycle periodicity)."""
+    dut._log.info("Starting Short Protocol Overlap Test")
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    # Initial Reset
+    dut.ena.value = 1
+    dut.ui_in.value = 0
+    dut.uio_in.value = 0
+    dut.rst_n.value = 0
+    await ClockCycles(dut.clk, 10)
+    dut.rst_n.value = 1
+
+    # First block MUST be standard to load scales
+    scale_a = 127
+    scale_b = 127
+    format_a = 4 # E2M1 (needed for packed mode eventually, but here we just use it for standard short)
+    format_b = 4
+
+    await send_block_header(dut, scale_a, scale_b, format_a, format_b)
+    for i in range(33): await RisingEdge(dut.clk) # Stream + Flush
+    await RisingEdge(dut.clk) # Capture (logical_cycle 36)
+
+    # Now start Short Protocol overlap
+    num_blocks = 3
+    for b in range(num_blocks):
+        # Cycle 0: Short Start
+        dut.ui_in.value = 0x80
+        dut.uio_in.value = (format_a & 0x7)
+        await RisingEdge(dut.clk)
+
+        # Cycle 3..34
+        for i in range(32):
+            dut.ui_in.value = 0x02 # 1.0
+            dut.uio_in.value = 0x02
+            await RisingEdge(dut.clk)
+
+        # Cycle 35: Flush
+        await RisingEdge(dut.clk)
+        # Cycle 36: Capture
+        await RisingEdge(dut.clk)
+
+    await ClockCycles(dut.clk, 10)

--- a/test/test_overlap.py
+++ b/test/test_overlap.py
@@ -80,11 +80,10 @@ async def test_high_density_overlap(dut):
         for i in range(32):
             prod = align_product_model(a_els[i], b_els[i], format_a, format_b,
                                        aligner_width=aligner_width)
-            expected_acc = (expected_acc + prod) & 0xFFFFFFFF
-            if expected_acc & 0x80000000: expected_acc -= 0x100000000
-            # Simplified signed wrap/sat for test model
-            if expected_acc > 0x7FFFFFFF: expected_acc = 0x7FFFFFFF
-            if expected_acc < -0x80000000: expected_acc = -0x80000000
+            # Intermediate additions in 32-bit signed fixed point
+            expected_acc = (expected_acc + prod)
+            if expected_acc > 2147483647: expected_acc = 2147483647
+            if expected_acc < -2147483648: expected_acc = -2147483648
 
         if support_shared:
             shared_exp = scale_a + scale_b - 254
@@ -193,10 +192,9 @@ async def test_packed_fp4_overlap(dut):
         for i in range(32):
             prod = align_product_model(a_els[i], b_els[i], format_a, format_b,
                                        aligner_width=aligner_width)
-            expected_acc = (expected_acc + prod) & 0xFFFFFFFF
-            if expected_acc & 0x80000000: expected_acc -= 0x100000000
-            if expected_acc > 0x7FFFFFFF: expected_acc = 0x7FFFFFFF
-            if expected_acc < -0x80000000: expected_acc = -0x80000000
+            expected_acc = (expected_acc + prod)
+            if expected_acc > 2147483647: expected_acc = 2147483647
+            if expected_acc < -2147483648: expected_acc = -2147483648
 
         # Result is signed 32-bit
         res = expected_acc & 0xFFFFFFFF


### PR DESCRIPTION
Implemented a result buffering mechanism in the top-level module to decouple the 4-cycle output phase from the processing datapath. This enables starting a new block's setup (Metadata and Scales) during the cycles where the previous block's result is being shifted out. The block periodicity is improved from 41 to 37 cycles for standard modes and from 25 to 21 cycles for FP4 packed modes. Added a new test suite to verify back-to-back processing.

Fixes #783

---
*PR created automatically by Jules for task [1014314594386278352](https://jules.google.com/task/1014314594386278352) started by @chatelao*