### PR TITLE
Fix GitHub Pages 404 for Interactive Demo

### DIFF
--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -72,4 +72,53 @@ jobs:
           name: gds_colored_zones
           path: gds_colored_zones.png
 
+      - name: Install Verilator
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y verilator
+
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 3.1.56
+
+      - name: Build WASM
+        run: |
+          TOP_MODULE=$(yq -r '.project.top_module' info.yaml)
+          SOURCES=$(yq -r '.project.source_files[]' info.yaml | sed 's|^|src/|' | xargs)
+
+          PARAMS="-GALIGNER_WIDTH=40 -GACCUMULATOR_WIDTH=32 -GSUPPORT_E4M3=1 -GSUPPORT_E5M2=1 -GSUPPORT_MXFP6=1 -GSUPPORT_MXFP4=1 -GSUPPORT_INT8=1 -GSUPPORT_PIPELINING=1 -GSUPPORT_ADV_ROUNDING=1 -GSUPPORT_MIXED_PRECISION=1 -GSUPPORT_VECTOR_PACKING=1 -GENABLE_SHARED_SCALING=1 -GSUPPORT_MX_PLUS=1 -GSUPPORT_INPUT_BUFFERING=1 -GSUPPORT_SERIAL=0"
+
+          OBJ_DIR=wasm/obj_dir
+          mkdir -p $OBJ_DIR
+
+          verilator --cc $SOURCES \
+            --top-module $TOP_MODULE \
+            --prefix Vtop \
+            -Isrc \
+            $PARAMS \
+            -Wno-WIDTHTRUNC -Wno-WIDTHEXPAND \
+            --Mdir $OBJ_DIR
+
+          VERILATOR_ROOT=$(verilator -V | grep VERILATOR_ROOT | head -1 | awk '{print $3}')
+
+          emcc -O3 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 \
+            --bind \
+            -DVL_IGNORE_UNKNOWN_ARCH \
+            -I$OBJ_DIR \
+            -I$VERILATOR_ROOT/include \
+            -I$VERILATOR_ROOT/include/vltstd \
+            wasm/digital_twin.cpp \
+            $(ls $OBJ_DIR/*.cpp | grep -v "__ALL.cpp") \
+            $VERILATOR_ROOT/include/verilated.cpp \
+            $VERILATOR_ROOT/include/verilated_threads.cpp \
+            -o wasm/digital_twin_Full.js
+
+      - name: Prepare Demo Directory
+        run: |
+          mkdir -p gh-pages/demo
+          cp -r docs/web/* gh-pages/demo/
+          cp wasm/digital_twin_Full.js gh-pages/demo/
+          cp wasm/digital_twin_Full.wasm gh-pages/demo/
+
       - uses: TinyTapeout/tt-gds-action/viewer@ihp-cmos5l

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -113,12 +113,3 @@ jobs:
         run: |
           cp wasm/digital_twin_Full.js docs/web/
           cp wasm/digital_twin_Full.wasm docs/web/
-
-      - name: Deploy Demo to GitHub Pages
-        if: matrix.variant == 'Full' && github.event_name == 'push' && github.ref == 'refs/heads/ihp-sg13cmos5l'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./demo
-          destination_dir: demo
-          keep_files: true


### PR DESCRIPTION
Integrated the WebAssembly build and web demo staging into the primary GDS viewer deployment workflow in `.github/workflows/gds.yaml`. This ensures that both the 3D viewer and the interactive MAC generator demo are deployed together to GitHub Pages, resolving the 404 error caused by conflicting deployment methods. Also removed the redundant deployment step from `.github/workflows/wasm.yaml`.

Fixes #789

---
*PR created automatically by Jules for task [5761560723333630833](https://jules.google.com/task/5761560723333630833) started by @chatelao*