### PR TITLE
Add Rationale for Input Buffering to Documentation

### DIFF
--- a/docs/hardware/FLIP_FLOP_USAGE.md
+++ b/docs/hardware/FLIP_FLOP_USAGE.md
@@ -43,3 +43,24 @@ Flip-Flops are the primary consumers of dynamic power in this design. To minimiz
 1. **Clock Gating**: The `ena` signal should be held low when no computation is required.
 2. **Short Protocol**: Reusing scale factors via the Short Protocol reduces the number of register transitions in the configuration block.
 3. **Variant Selection**: Choose the "Tiny" variant for applications where low leakage and minimal dynamic power are prioritized over throughput.
+
+## 5. Rationale for Input Buffering (256 FFs)
+
+A common question is why the design allocates 256 FFs (over 60% of the "Full" variant's total) to input buffering instead of using values directly from the `ui_in` pins. This design choice is driven by the **"Burst-then-Process"** strategy required for efficient single-lane FP4 operation.
+
+### 5.1. Decoupling Interface and Processing Speeds
+In the OCP MX protocol, "Packed Mode" allows two 4-bit elements (FP4) to be sent over a single 8-bit bus cycle.
+- **Dual-Lane (Vector Packing)**: The hardware uses both elements immediately in two parallel multipliers. No FIFO is strictly required here for throughput.
+- **Single-Lane (Input Buffering)**: The hardware only has one multiplier. To maintain the same 8-bit interface bandwidth, the controller bursts 16 bytes (32 elements) in 16 cycles. However, the single multiplier needs 32 cycles to process them.
+- **The Solution**: The 16-entry FIFO captures the entire burst in the first 16 cycles of the streaming phase. While the first 16 elements are being processed from the bus, the second 16 are buffered and then read out in cycles 17-32.
+
+### 5.2. Controller Simplicity
+Without buffering, an external controller would be forced to implement complex stalling logic or reduce its output to 4 bits per cycle when talking to a single-lane unit. By including the FIFO:
+1. The controller always uses the same high-speed 8-bit burst protocol regardless of the unit's internal lane count.
+2. Timing closure on the input pins is relaxed, as data is immediately registered into the FIFO rather than passing through long combinatorial decoding paths to the multiplier.
+
+### 5.3. Area vs. Complexity Trade-off
+While 256 FFs is a significant area investment for a 1x1 or 2x2 tile:
+- It eliminates the need for "Wait" states or "Ready" signals in the protocol, simplifying the FSM.
+- It ensures that the unit can saturate its internal datapath even when the input interface is twice as wide as the internal processing lane.
+- For area-critical applications where this throughput decoupling is not needed, the `SUPPORT_INPUT_BUFFERING` parameter can be set to `0`, reverting to direct pin-to-multiplier mapping and saving ~256 FFs.


### PR DESCRIPTION
This PR adds a detailed explanation of why the input is buffered in the "Full" configuration of the OCP MX MAC unit. It addresses the user's question about why values aren't used directly by highlighting the "Burst-then-Process" strategy used for efficient single-lane FP4 operation. This strategy decouples the high-speed 8-bit input interface from the internal processing speed, simplifying external controller logic.

Fixes #829

---
*PR created automatically by Jules for task [2961688736832033805](https://jules.google.com/task/2961688736832033805) started by @chatelao*