### PR TITLE
Add Read the Docs Integration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](../../workflows/gds/badge.svg) ![](../../workflows/docs/badge.svg) ![](../../workflows/test/badge.svg) ![](../../workflows/fpga/badge.svg)
+![](../../workflows/gds/badge.svg) ![](../../workflows/docs/badge.svg) ![](../../workflows/test/badge.svg) ![](../../workflows/fpga/badge.svg) [![Documentation Status](https://readthedocs.org/projects/ttihp-fp8-mul/badge/?version=latest)](https://ttihp-fp8-mul.readthedocs.io/en/latest/?badge=latest)
 
 # Tiny Tapeout IHP 26a - OCP MXFP8 Streaming MAC Unit
 

--- a/docs/circuit.rst
+++ b/docs/circuit.rst
@@ -1,0 +1,5 @@
+Circuit & Architecture
+======================
+
+.. include:: ../CIRCUIT.md
+   :parser: myst_parser.sphinx_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,34 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'OCP MXFP8 Streaming MAC Unit'
+copyright = '2024, Olivier Chatelain'
+author = 'Olivier Chatelain'
+
+extensions = [
+    'myst_parser',
+    'sphinx_rtd_theme',
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']
+
+myst_enable_extensions = [
+    "amsmath",
+    "colon_fence",
+    "deflist",
+    "dollarmath",
+    "fieldlist",
+    "html_admonition",
+    "html_image",
+    "linkify",
+    "replacements",
+    "smartquotes",
+    "strikethrough",
+    "substitution",
+    "tasklist",
+]

--- a/docs/debug_tt.rst
+++ b/docs/debug_tt.rst
@@ -1,0 +1,5 @@
+Debug & Probing
+===============
+
+.. include:: ../DEBUG_TT.md
+   :parser: myst_parser.sphinx_

--- a/docs/fp32_audit.rst
+++ b/docs/fp32_audit.rst
@@ -1,0 +1,5 @@
+FP32 Audit
+==========
+
+.. include:: ../FP32_AUDIT.md
+   :parser: myst_parser.sphinx_

--- a/docs/gemini.rst
+++ b/docs/gemini.rst
@@ -1,0 +1,5 @@
+Gemini Project Goal
+===================
+
+.. include:: ../GEMINI.md
+   :parser: myst_parser.sphinx_

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,0 +1,5 @@
+Glossary
+========
+
+.. include:: GLOSSARY.md
+   :parser: myst_parser.sphinx_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,29 @@
+Welcome to OCP MXFP8 Streaming MAC Unit's documentation!
+========================================================
+
+.. image:: https://readthedocs.org/projects/ttihp-fp8-mul/badge/?version=latest
+   :target: https://ttihp-fp8-mul.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   readme
+   info
+   roadmap
+   gemini
+   circuit
+   debug_tt
+   fp32_audit
+   jtag_concept
+   mitchell_improved
+   riscv_mac_mnemonics
+   glossary
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/info.rst
+++ b/docs/info.rst
@@ -1,0 +1,5 @@
+Project Information
+===================
+
+.. include:: info.md
+   :parser: myst_parser.sphinx_

--- a/docs/jtag_concept.rst
+++ b/docs/jtag_concept.rst
@@ -1,0 +1,5 @@
+JTAG Concept
+============
+
+.. include:: ../JTAG_CONCEPT.md
+   :parser: myst_parser.sphinx_

--- a/docs/mitchell_improved.rst
+++ b/docs/mitchell_improved.rst
@@ -1,0 +1,5 @@
+Mitchell Improved
+=================
+
+.. include:: ../MITCHELL_IMPROVED.md
+   :parser: myst_parser.sphinx_

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,0 +1,5 @@
+README
+======
+
+.. include:: ../README.md
+   :parser: myst_parser.sphinx_

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx-rtd-theme
+myst-parser[linkify]

--- a/docs/riscv_mac_mnemonics.rst
+++ b/docs/riscv_mac_mnemonics.rst
@@ -1,0 +1,5 @@
+RISC-V MAC Mnemonics
+=====================
+
+.. include:: ../RISCV_MAC_MNEMONICS.md
+   :parser: myst_parser.sphinx_

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -1,0 +1,5 @@
+Roadmap
+=======
+
+.. include:: ../ROADMAP.md
+   :parser: myst_parser.sphinx_


### PR DESCRIPTION
I have integrated Read the Docs into the project to provide automated, hosted documentation. This was achieved by:
1. Creating a `.readthedocs.yaml` configuration file in the root directory.
2. Setting up a Sphinx documentation environment in the `docs/` folder, including `conf.py` and `requirements.txt`.
3. Implementing `myst-parser` to allow Sphinx to render the existing Markdown documentation.
4. Creating a structured `index.rst` and a set of `.rst` wrapper files that include the project's key Markdown files (README, Roadmap, Info, Glossary, etc.).
5. Adding the "Documentation Status" badge to the top of the main `README.md`.
6. Verifying the documentation build locally and ensuring that the changes do not interfere with the hardware verification suite.
7. Cleaning up temporary build and test artifacts to maintain a clean repository state.

Fixes #833

---
*PR created automatically by Jules for task [7528435318917856303](https://jules.google.com/task/7528435318917856303) started by @chatelao*