### PR TITLE
Implement F2F Normalization and Exponent Estimation (Steps 12-15)

### DIFF
--- a/.github/workflows/gowin.yaml
+++ b/.github/workflows/gowin.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           # Defaults
           echo "TOP=tt_gowin_top" >> $GITHUB_ENV
-          echo "SOURCES=src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src_gowin/tt_gowin_top.v" >> $GITHUB_ENV
+          echo "SOURCES=src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src/lzc40.v src/fixed_to_float.v src_gowin/tt_gowin_top.v" >> $GITHUB_ENV
           echo "CST=src_gowin/tangnano4k.cst" >> $GITHUB_ENV
           echo "YOSYS_FLAGS=" >> $GITHUB_ENV
 
@@ -61,7 +61,7 @@ jobs:
             echo "PARAMS=-set ALIGNER_WIDTH 32 -set ACCUMULATOR_WIDTH 24 -set SUPPORT_E4M3 0 -set SUPPORT_E5M2 0 -set SUPPORT_MXFP6 0 -set SUPPORT_MXFP4 1 -set SUPPORT_INT8 0 -set SUPPORT_PIPELINING 0 -set SUPPORT_ADV_ROUNDING 0 -set SUPPORT_MIXED_PRECISION 0 -set SUPPORT_VECTOR_PACKING 0 -set ENABLE_SHARED_SCALING 0 -set SUPPORT_MX_PLUS 0 -set SUPPORT_INPUT_BUFFERING 0 -set SUPPORT_SERIAL 1" >> $GITHUB_ENV
           elif [[ "${{ matrix.variant }}" == M3-* ]]; then
             echo "TOP=tt_gowin_top_m3" >> $GITHUB_ENV
-            echo "SOURCES=src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v src_gowin/ahb2_mac_bridge.v" >> $GITHUB_ENV
+            echo "SOURCES=src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src/lzc40.v src/fixed_to_float.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v src_gowin/ahb2_mac_bridge.v" >> $GITHUB_ENV
             echo "CST=src_gowin/tangnano4k_m3.cst" >> $GITHUB_ENV
             echo "PARAMS=-set ALIGNER_WIDTH 32 -set ACCUMULATOR_WIDTH 32 -set SUPPORT_E4M3 1 -set SUPPORT_E5M2 1" >> $GITHUB_ENV
             if [ "${{ matrix.variant }}" == "M3-GPIO" ]; then

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,4 +13,4 @@ jobs:
 
       - name: Run Verilator Lint
         shell: bash
-        run: verilator --lint-only -Wall -Isrc/ --top-module tt_um_chatelao_fp8_multiplier src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v
+        run: verilator --lint-only -Wall -Isrc/ --top-module tt_um_chatelao_fp8_multiplier src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src/lzc40.v src/fixed_to_float.v

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
           # Verify compilation of all M3 modes using iverilog
           for mode in M3_MODE_GPIO M3_MODE_APB M3_MODE_AHB M3_MODE_AHB_DMA; do
             echo "Verifying $mode..."
-            iverilog -g2012 -Isrc -D$mode src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v src_gowin/ahb2_mac_bridge.v -o m3_test
+            iverilog -g2012 -Isrc -D$mode src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src/lzc40.v src/fixed_to_float.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v src_gowin/ahb2_mac_bridge.v -o m3_test
             rm m3_test
           done
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,10 +13,10 @@ Address the gaps identified in the `docs/FP32_AUDIT.md` to ensure full complianc
 - [x] **Step 9: [Infra] Parameterize Datapath Widths**: Unify `ALIGNER_WIDTH` and `ACCUMULATOR_WIDTH` to 40 bits across `src/project.v`, `src/accumulator.v`, and `src/fp8_aligner.v`. Update serialization logic to extract the appropriate 32-bit window (maintaining S23.8 mapping for backward compatibility) and verify that existing fixed-point tests pass.
 - [x] **Step 10: [Datapath] 16-bit Fractional Alignment**: Shift the internal binary point from bit 8 to bit 16 ($2^0$) in the aligner and accumulator. Verify that FP8 subnormal products (e.g., $2^{-9}$) are now preserved in the accumulator instead of being truncated, and ensure consistency with the Step 9 extraction window.
 - [x] **Step 11: [F2F] Leading Zero Count (LZC40) Module**: Implement a 40-bit LZC module to determine the normalization shift required for Float32 conversion and verify it with a dedicated unit test.
-- [ ] **Step 12: [F2F] Sign-Magnitude Extraction**: Implement logic to extract the sign bit and calculate the 39-bit absolute magnitude of the signed 40-bit accumulator.
-- [ ] **Step 13: [F2F] Normalization Barrel Shifter**: Design a shifter that uses the LZC40 output to left-justify the accumulator magnitude, preparing it for mantissa extraction.
-- [ ] **Step 14: [F2F] Base Exponent Estimation**: Implement logic to calculate the initial IEEE 754 biased exponent from the LZC result, accounting for the S23.16 fixed-point offset.
-- [ ] **Step 15: [F2F] Float32 Underflow Detection**: Add hardware flags to identify when the magnitude is too small for a normal Float32 result ($E_{biased} \le 0$).
+- [x] **Step 12: [F2F] Sign-Magnitude Extraction**: Implement logic to extract the sign bit and calculate the 39-bit absolute magnitude of the signed 40-bit accumulator.
+- [x] **Step 13: [F2F] Normalization Barrel Shifter**: Design a shifter that uses the LZC40 output to left-justify the accumulator magnitude, preparing it for mantissa extraction.
+- [x] **Step 14: [F2F] Base Exponent Estimation**: Implement logic to calculate the initial IEEE 754 biased exponent from the LZC result, accounting for the S23.16 fixed-point offset.
+- [x] **Step 15: [F2F] Float32 Underflow Detection**: Add hardware flags to identify when the magnitude is too small for a normal Float32 result ($E_{biased} \le 0$).
 - [ ] **Step 16: [F2F] Subnormal Mantissa Alignment**: Implement a bypass path in the normalizer to produce correctly aligned subnormal mantissas when the underflow flag is active.
 - [ ] **Step 17: [F2F] Mantissa Extraction**: Extract the 23-bit fractional mantissa from the normalized result, ensuring the implicit '1' is handled correctly for normal values.
 - [ ] **Step 18: [F2F] Rounding - Guard/Sticky Bit Logic**: Implement logic to capture Guard, Round, and Sticky (GRS) bits from the shifter to support bit-accurate IEEE 754 rounding.

--- a/info.yaml
+++ b/info.yaml
@@ -23,6 +23,8 @@ project:
     - "fp8_mul_serial_lns.v"
     - "fp8_aligner.v"
     - "accumulator.v"
+    - "lzc40.v"
+    - "fixed_to_float.v"
 
 # The pinout of your project. Leave unused pins blank. DO NOT delete or add any pins.
 # This section is for the datasheet/website. Use descriptive names (e.g., RX, TX, MOSI, SCL, SEG_A, etc.).  

--- a/src/fixed_to_float.v
+++ b/src/fixed_to_float.v
@@ -1,0 +1,50 @@
+`ifndef __FIXED_TO_FLOAT_V__
+`define __FIXED_TO_FLOAT_V__
+`default_nettype none
+
+/**
+ * Fixed-to-Float Conversion Module
+ *
+ * This module converts a 40-bit signed fixed-point value (S23.16)
+ * into an IEEE 754 Float32 bit pattern.
+ *
+ * Binary Point is at bit 16 (bit 16 = 2^0).
+ * Dynamic range is supported by the shared_exp input.
+ */
+module fixed_to_float (
+    input  wire [39:0] acc,              // 40-bit signed accumulator (S23.16)
+    input  wire signed [9:0] shared_exp, // 10-bit signed shared exponent
+    output wire        sign,
+    output wire [39:0] mag,              // 40-bit absolute magnitude
+    output wire [5:0]  lzc,              // Leading Zero Count
+    output wire [39:0] norm_mag,         // Normalized magnitude (left-justified)
+    output wire signed [11:0] exp_biased, // Biased exponent (intermediate)
+    output wire        zero,             // Flag: Result is exactly zero
+    output wire        underflow         // Flag: Result is too small for normal Float32
+);
+
+    // Step 12: Sign-Magnitude Extraction
+    assign sign = acc[39];
+    assign mag  = sign ? (~acc + 40'd1) : acc;
+
+    // Step 13: Normalization Barrel Shifter
+    lzc40 lzc_inst (
+        .in(mag),
+        .cnt(lzc)
+    );
+
+    assign norm_mag = mag << lzc;
+
+    // Step 14: Base Exponent Estimation
+    // S23.16 mapping: bit 16 is 2^0.
+    // If bit 39 is 1 (LZC=0), exp = 23 + shared_exp.
+    // E_biased = exp + 127 = 150 + shared_exp - LZC.
+    wire signed [11:0] shared_exp_ext = { {2{shared_exp[9]}}, shared_exp };
+    assign exp_biased = 12'sd150 + shared_exp_ext - $signed({6'b0, lzc});
+
+    // Step 15: Float32 Underflow Detection
+    assign zero = (mag == 40'd0);
+    assign underflow = (exp_biased <= 12'sd0) || zero;
+
+endmodule
+`endif

--- a/src/lzc40.v
+++ b/src/lzc40.v
@@ -2,6 +2,8 @@
 `define __LZC40_V__
 `default_nettype none
 
+/* verilator lint_off DECLFILENAME */
+
 /**
  * 40-bit Leading Zero Counter (LZC)
  *

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@
 SIM ?= icarus
 TOPLEVEL_LANG ?= verilog
 SRC_DIR = ../src
-PROJECT_SOURCES = project.v fp8_mul.v fp8_mul_lns.v fp8_mul_serial_lns.v fp8_aligner.v accumulator.v
+PROJECT_SOURCES = project.v fp8_mul.v fp8_mul_lns.v fp8_mul_serial_lns.v fp8_aligner.v accumulator.v lzc40.v fixed_to_float.v
 
 ifeq ($(GATES),yes)
 

--- a/test/Makefile_f2f
+++ b/test/Makefile_f2f
@@ -1,0 +1,13 @@
+# test/Makefile_f2f
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+SRC_DIR = ../src
+
+VERILOG_SOURCES += $(SRC_DIR)/lzc40.v
+VERILOG_SOURCES += $(SRC_DIR)/fixed_to_float.v
+VERILOG_SOURCES += $(PWD)/tb_fixed_to_float.v
+
+TOPLEVEL = tb_fixed_to_float
+MODULE = test_fixed_to_float
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/test/tb_fixed_to_float.v
+++ b/test/tb_fixed_to_float.v
@@ -1,0 +1,33 @@
+`default_nettype none
+`timescale 1ns/1ps
+
+module tb_fixed_to_float (
+    input  wire [39:0] acc,
+    input  wire signed [9:0] shared_exp,
+    output wire        sign,
+    output wire [39:0] mag,
+    output wire [5:0]  lzc,
+    output wire [39:0] norm_mag,
+    output wire signed [11:0] exp_biased,
+    output wire        zero,
+    output wire        underflow
+);
+
+    fixed_to_float dut (
+        .acc(acc),
+        .shared_exp(shared_exp),
+        .sign(sign),
+        .mag(mag),
+        .lzc(lzc),
+        .norm_mag(norm_mag),
+        .exp_biased(exp_biased),
+        .zero(zero),
+        .underflow(underflow)
+    );
+
+    initial begin
+        $dumpfile("tb_fixed_to_float.vcd");
+        $dumpvars(0, tb_fixed_to_float);
+    end
+
+endmodule

--- a/test/test_fixed_to_float.py
+++ b/test/test_fixed_to_float.py
@@ -1,0 +1,93 @@
+import cocotb
+from cocotb.triggers import Timer
+
+@cocotb.test()
+async def test_f2f_basic(dut):
+    """Test Fixed-to-Float normalization and exponent estimation"""
+
+    test_cases = [
+        # (acc, shared_exp, expected_sign, expected_lzc, expected_exp_biased, expected_zero, expected_underflow)
+
+        # 1.0 in S23.16 (1 << 16)
+        (1 << 16, 0, 0, 23, 127, 0, 0),
+
+        # -1.0 in S23.16
+        (-(1 << 16), 0, 1, 23, 127, 0, 0),
+
+        # Max positive (approx 2^22)
+        ((1 << 39) - 1, 0, 0, 1, 149, 0, 0),
+
+        # Max negative magnitude (-2^39)
+        (-(1 << 39), 0, 1, 0, 150, 0, 0),
+
+        # Smallest positive fractional (1 in bit 0)
+        (1, 0, 0, 39, 150 - 39, 0, 0),
+
+        # Zero
+        (0, 0, 0, 40, 150 - 40, 1, 1),
+
+        # Shared scaling: 1.0 * 2^10
+        (1 << 16, 10, 0, 23, 137, 0, 0),
+
+        # Shared scaling: 1.0 * 2^-10
+        (1 << 16, -10, 0, 23, 117, 0, 0),
+
+        # Extreme underflow: (1 << 0) * 2^-150
+        (1, -150, 0, 39, 150 - 39 - 150, 0, 1),
+    ]
+
+    for acc, shared_exp, exp_sign, exp_lzc, exp_exp_biased, exp_zero, exp_underflow in test_cases:
+        # Handle 40-bit signed for Cocotb
+        if acc < 0:
+            if acc == -(1 << 39):
+                dut.acc.value = 1 << 39
+            else:
+                dut.acc.value = (1 << 40) + acc
+        else:
+            dut.acc.value = acc
+
+        dut.shared_exp.value = shared_exp
+
+        await Timer(1, unit="ns")
+
+        actual_sign = int(dut.sign.value)
+        actual_lzc = int(dut.lzc.value)
+        actual_exp_biased = int(dut.exp_biased.value)
+        # Handle 12-bit signed
+        if actual_exp_biased >= 2048:
+            actual_exp_biased -= 4096
+
+        actual_zero = int(dut.zero.value)
+        actual_underflow = int(dut.underflow.value)
+
+        dut._log.info(f"Input: acc=0x{acc & 0xFFFFFFFFFF:010x}, shared_exp={shared_exp}")
+        dut._log.info(f"Expected: sign={exp_sign}, lzc={exp_lzc}, exp_biased={exp_exp_biased}, zero={exp_zero}, underflow={exp_underflow}")
+        dut._log.info(f"Actual:   sign={actual_sign}, lzc={actual_lzc}, exp_biased={actual_exp_biased}, zero={actual_zero}, underflow={actual_underflow}")
+
+        assert actual_sign == exp_sign
+        assert actual_lzc == exp_lzc
+        assert actual_exp_biased == exp_exp_biased
+        assert actual_zero == exp_zero
+        assert actual_underflow == exp_underflow
+
+@cocotb.test()
+async def test_f2f_normalization(dut):
+    """Verify that norm_mag is correctly left-justified"""
+    import random
+
+    for _ in range(100):
+        acc = random.getrandbits(39) # positive
+        if acc == 0: continue
+
+        dut.acc.value = acc
+        dut.shared_exp.value = 0
+
+        await Timer(1, unit="ns")
+
+        norm_mag = int(dut.norm_mag.value)
+        # For non-zero values, the MSB (bit 39) of norm_mag must be 1
+        assert (norm_mag & (1 << 39)) != 0
+
+        # Also verify it's a correct shift
+        lzc = int(dut.lzc.value)
+        assert norm_mag == (acc << lzc) & ((1 << 40) - 1)


### PR DESCRIPTION
This PR implements the first half of the Fixed-to-Float (F2F) conversion logic required for IEEE 754 compliance.

Key changes:
1. **src/fixed_to_float.v**: Created a new module that handles:
   - Absolute magnitude extraction from the 40-bit signed accumulator.
   - Normalization (left-justification) of the magnitude using a 40-bit Leading Zero Counter.
   - Intermediate biased exponent calculation accounting for the S23.16 fixed-point offset.
   - Underflow detection for values that cannot be represented as normal Float32.
2. **Verification Suite**:
   - Added `test/tb_fixed_to_float.v` (Verilog wrapper).
   - Added `test/test_fixed_to_float.py` (Cocotb tests).
   - Added `test/Makefile_f2f` for independent unit testing.
3. **Documentation**:
   - Updated `ROADMAP.md` to mark Steps 12, 13, 14, and 15 as completed.

The implementation has been verified with unit tests covering positive/negative values, zero, subnormals, and various shared scaling factors. Full project regressions were also performed.

Fixes #850

---
*PR created automatically by Jules for task [4916085288394277008](https://jules.google.com/task/4916085288394277008) started by @chatelao*