### PR TITLE
FP32 Subnormal Alignment & Mantissa Extraction

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,8 +17,8 @@ Address the gaps identified in the `docs/FP32_AUDIT.md` to ensure full complianc
 - [x] **Step 13: [F2F] Normalization Barrel Shifter**: Design a shifter that uses the LZC40 output to left-justify the accumulator magnitude, preparing it for mantissa extraction.
 - [x] **Step 14: [F2F] Base Exponent Estimation**: Implement logic to calculate the initial IEEE 754 biased exponent from the LZC result, accounting for the S23.16 fixed-point offset.
 - [x] **Step 15: [F2F] Float32 Underflow Detection**: Add hardware flags to identify when the magnitude is too small for a normal Float32 result ($E_{biased} \le 0$).
-- [ ] **Step 16: [F2F] Subnormal Mantissa Alignment**: Implement a bypass path in the normalizer to produce correctly aligned subnormal mantissas when the underflow flag is active.
-- [ ] **Step 17: [F2F] Mantissa Extraction**: Extract the 23-bit fractional mantissa from the normalized result, ensuring the implicit '1' is handled correctly for normal values.
+- [x] **Step 16: [F2F] Subnormal Mantissa Alignment**: Implement a bypass path in the normalizer to produce correctly aligned subnormal mantissas when the underflow flag is active.
+- [x] **Step 17: [F2F] Mantissa Extraction**: Extract the 23-bit fractional mantissa from the normalized result, ensuring the implicit '1' is handled correctly for normal values.
 - [ ] **Step 18: [F2F] Rounding - Guard/Sticky Bit Logic**: Implement logic to capture Guard, Round, and Sticky (GRS) bits from the shifter to support bit-accurate IEEE 754 rounding.
 - [ ] **Step 19: [F2F] Rounding - RNE Implementation**: Implement a Round-to-Nearest-Even (RNE) incrementer for the 23-bit mantissa based on GRS bits.
 - [ ] **Step 20: [F2F] Exponent Post-Rounding Correction**: Add logic to increment the exponent if the mantissa rounding results in a carry-out (e.g., rounding `1.11...1` to `10.00...0`).

--- a/src/fixed_to_float.v
+++ b/src/fixed_to_float.v
@@ -19,6 +19,7 @@ module fixed_to_float (
     output wire [5:0]  lzc,              // Leading Zero Count
     output wire [39:0] norm_mag,         // Normalized magnitude (left-justified)
     output wire signed [11:0] exp_biased, // Biased exponent (intermediate)
+    output wire [22:0] mantissa,         // 23-bit mantissa
     output wire        zero,             // Flag: Result is exactly zero
     output wire        underflow         // Flag: Result is too small for normal Float32
 );
@@ -27,24 +28,54 @@ module fixed_to_float (
     assign sign = acc[39];
     assign mag  = sign ? (~acc + 40'd1) : acc;
 
-    // Step 13: Normalization Barrel Shifter
+    // Step 13 & 16: Normalization & Subnormal Alignment
     lzc40 lzc_inst (
         .in(mag),
         .cnt(lzc)
     );
 
-    assign norm_mag = mag << lzc;
+    wire signed [11:0] shared_exp_ext = { {2{shared_exp[9]}}, shared_exp };
 
     // Step 14: Base Exponent Estimation
     // S23.16 mapping: bit 16 is 2^0.
     // If bit 39 is 1 (LZC=0), exp = 23 + shared_exp.
     // E_biased = exp + 127 = 150 + shared_exp - LZC.
-    wire signed [11:0] shared_exp_ext = { {2{shared_exp[9]}}, shared_exp };
     assign exp_biased = 12'sd150 + shared_exp_ext - $signed({6'b0, lzc});
 
     // Step 15: Float32 Underflow Detection
     assign zero = (mag == 40'd0);
     assign underflow = (exp_biased <= 12'sd0) || zero;
+
+    // Step 16: Subnormal Alignment logic
+    // For subnormals (exp_biased <= 0), we don't left-justify to bit 39.
+    // Instead, we align as if exp_biased was 1 (the smallest normal).
+    // The shift amount S = 149 + shared_exp.
+    wire signed [11:0] subnormal_shift = 12'sd149 + shared_exp_ext;
+    wire signed [11:0] shift_amt = underflow ? subnormal_shift : $signed({6'b0, lzc});
+
+    // Unify Normalization and Subnormal alignment in one barrel shifter
+    reg [39:0] norm_mag_reg;
+    wire signed [11:0] neg_shift_amt = -shift_amt;
+    always @(*) begin
+        if (shift_amt >= 12'sd40) begin
+            norm_mag_reg = 40'd0;
+        end else if (shift_amt >= 12'sd0) begin
+            norm_mag_reg = mag << shift_amt[5:0];
+        end else if (shift_amt <= -12'sd40) begin
+            norm_mag_reg = 40'd0;
+        end else begin
+            // Negative shift is right shift.
+            // We negate first to get a positive shift amount, then take the lower bits.
+            norm_mag_reg = mag >> neg_shift_amt[5:0];
+        end
+    end
+    assign norm_mag = norm_mag_reg;
+
+    // Step 17: Mantissa Extraction
+    // Bits [38:16] are the 23-bit mantissa.
+    // In normal mode, bit 39 is the implicit '1' (not stored).
+    // In subnormal mode, bit 39 is 0, correctly representing 0.mantissa.
+    assign mantissa = norm_mag[38:16];
 
 endmodule
 `endif

--- a/test/tb_fixed_to_float.v
+++ b/test/tb_fixed_to_float.v
@@ -9,6 +9,7 @@ module tb_fixed_to_float (
     output wire [5:0]  lzc,
     output wire [39:0] norm_mag,
     output wire signed [11:0] exp_biased,
+    output wire [22:0] mantissa,
     output wire        zero,
     output wire        underflow
 );
@@ -21,6 +22,7 @@ module tb_fixed_to_float (
         .lzc(lzc),
         .norm_mag(norm_mag),
         .exp_biased(exp_biased),
+        .mantissa(mantissa),
         .zero(zero),
         .underflow(underflow)
     );

--- a/test/test_fixed_to_float.py
+++ b/test/test_fixed_to_float.py
@@ -6,37 +6,69 @@ async def test_f2f_basic(dut):
     """Test Fixed-to-Float normalization and exponent estimation"""
 
     test_cases = [
-        # (acc, shared_exp, expected_sign, expected_lzc, expected_exp_biased, expected_zero, expected_underflow)
+        # (acc, shared_exp, expected_sign, expected_lzc, expected_exp_biased, expected_zero, expected_underflow, expected_mantissa)
 
         # 1.0 in S23.16 (1 << 16)
-        (1 << 16, 0, 0, 23, 127, 0, 0),
+        (1 << 16, 0, 0, 23, 127, 0, 0, 0),
 
         # -1.0 in S23.16
-        (-(1 << 16), 0, 1, 23, 127, 0, 0),
+        (-(1 << 16), 0, 1, 23, 127, 0, 0, 0),
 
-        # Max positive (approx 2^22)
-        ((1 << 39) - 1, 0, 0, 1, 149, 0, 0),
+        # 1.5 in S23.16 (1.5 * 2^16 = 3 * 2^15)
+        (3 << 15, 0, 0, 23, 127, 0, 0, 1 << 22),
+
+        # Max positive (approx 2^23)
+        ((1 << 39) - 1, 0, 0, 1, 149, 0, 0, 0x7FFFFF),
 
         # Max negative magnitude (-2^39)
-        (-(1 << 39), 0, 1, 0, 150, 0, 0),
+        (-(1 << 39), 0, 1, 0, 150, 0, 0, 0),
 
         # Smallest positive fractional (1 in bit 0)
-        (1, 0, 0, 39, 150 - 39, 0, 0),
+        (1, 0, 0, 39, 150 - 39, 0, 0, 0),
 
         # Zero
-        (0, 0, 0, 40, 150 - 40, 1, 1),
+        (0, 0, 0, 40, 150 - 40, 1, 1, 0),
 
         # Shared scaling: 1.0 * 2^10
-        (1 << 16, 10, 0, 23, 137, 0, 0),
+        (1 << 16, 10, 0, 23, 137, 0, 0, 0),
 
         # Shared scaling: 1.0 * 2^-10
-        (1 << 16, -10, 0, 23, 117, 0, 0),
+        (1 << 16, -10, 0, 23, 117, 0, 0, 0),
 
         # Extreme underflow: (1 << 0) * 2^-150
-        (1, -150, 0, 39, 150 - 39 - 150, 0, 1),
+        (1, -150, 0, 39, 150 - 39 - 150, 0, 1, 0),
+
+        # --- Subnormal cases ---
+        # Smallest normal is 2^-126.
+        # Biased exp = 150 + shared_exp - LZC.
+        # To get subnormal, we want 150 + shared_exp - LZC <= 0.
+
+        # Case: shared_exp = -150, acc = 1 << 16 (1.0)
+        # exp_biased = 150 - 150 - 23 = -23 (Underflow)
+        # Shift = 149 + (-150) = -1.
+        # norm_mag = (1 << 16) >> 1 = 1 << 15.
+        # mantissa = norm_mag[38:16] = 0.
+        (1 << 16, -150, 0, 23, -23, 0, 1, 0),
+
+        # Case: shared_exp = -127, acc = 1 << 16 (1.0)
+        # exp_biased = 150 - 127 - 23 = 0 (Underflow, exactly subnormal boundary)
+        # Shift = 149 - 127 = 22.
+        # norm_mag = (1 << 16) << 22 = 1 << 38.
+        # mantissa = norm_mag[38:16] = 1 << 22 (0.5 in mantissa for exp_biased=0)
+        # Wait, if exp_biased=0, it's 2^-126 * 0.mantissa.
+        # 1.0 * 2^-127 = 0.5 * 2^-126. Correct.
+        (1 << 16, -127, 0, 23, 0, 0, 1, 1 << 22),
+
+        # Case: shared_exp = -127, acc = 1 << 15 (0.5)
+        # exp_biased = 150 - 127 - 24 = -1
+        # Shift = 149 - 127 = 22.
+        # norm_mag = (1 << 15) << 22 = 1 << 37.
+        # mantissa = norm_mag[38:16] = 1 << 21. (0.25 in mantissa)
+        # 0.5 * 2^-127 = 0.25 * 2^-126. Correct.
+        (1 << 15, -127, 0, 24, -1, 0, 1, 1 << 21),
     ]
 
-    for acc, shared_exp, exp_sign, exp_lzc, exp_exp_biased, exp_zero, exp_underflow in test_cases:
+    for acc, shared_exp, exp_sign, exp_lzc, exp_exp_biased, exp_zero, exp_underflow, exp_mantissa in test_cases:
         # Handle 40-bit signed for Cocotb
         if acc < 0:
             if acc == -(1 << 39):
@@ -59,16 +91,18 @@ async def test_f2f_basic(dut):
 
         actual_zero = int(dut.zero.value)
         actual_underflow = int(dut.underflow.value)
+        actual_mantissa = int(dut.mantissa.value)
 
         dut._log.info(f"Input: acc=0x{acc & 0xFFFFFFFFFF:010x}, shared_exp={shared_exp}")
-        dut._log.info(f"Expected: sign={exp_sign}, lzc={exp_lzc}, exp_biased={exp_exp_biased}, zero={exp_zero}, underflow={exp_underflow}")
-        dut._log.info(f"Actual:   sign={actual_sign}, lzc={actual_lzc}, exp_biased={actual_exp_biased}, zero={actual_zero}, underflow={actual_underflow}")
+        dut._log.info(f"Expected: sign={exp_sign}, lzc={exp_lzc}, exp_biased={exp_exp_biased}, zero={exp_zero}, underflow={exp_underflow}, mantissa=0x{exp_mantissa:06x}")
+        dut._log.info(f"Actual:   sign={actual_sign}, lzc={actual_lzc}, exp_biased={actual_exp_biased}, zero={actual_zero}, underflow={actual_underflow}, mantissa=0x{actual_mantissa:06x}")
 
         assert actual_sign == exp_sign
         assert actual_lzc == exp_lzc
         assert actual_exp_biased == exp_exp_biased
         assert actual_zero == exp_zero
         assert actual_underflow == exp_underflow
+        assert actual_mantissa == exp_mantissa
 
 @cocotb.test()
 async def test_f2f_normalization(dut):


### PR DESCRIPTION
Implement Step 16 (Subnormal Mantissa Alignment) and Step 17 (Mantissa Extraction) of the IEEE 754 Float32 conversion roadmap for the OCP MX Streaming MAC Unit. This change enhances the `fixed_to_float` module to support the full dynamic range of Float32, including the subnormal range, by utilizing a unified barrel shifter and precise extraction logic. Verified with comprehensive unit tests and full project regression.

Fixes #852

---
*PR created automatically by Jules for task [17365067735905951206](https://jules.google.com/task/17365067735905951206) started by @chatelao*