### PR TITLE
Implement Bit-Serial FP8 Aligner (Step 5.1)

### DIFF
--- a/.github/workflows/gowin.yaml
+++ b/.github/workflows/gowin.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           # Defaults
           echo "TOP=tt_gowin_top" >> $GITHUB_ENV
-          echo "SOURCES=src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src/lzc40.v src/fixed_to_float.v src_gowin/tt_gowin_top.v" >> $GITHUB_ENV
+          echo "SOURCES=src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/fp8_aligner_serial.v src/accumulator.v src/lzc40.v src/fixed_to_float.v src_gowin/tt_gowin_top.v" >> $GITHUB_ENV
           echo "CST=src_gowin/tangnano4k.cst" >> $GITHUB_ENV
           echo "YOSYS_FLAGS=" >> $GITHUB_ENV
 
@@ -61,7 +61,7 @@ jobs:
             echo "PARAMS=-set ALIGNER_WIDTH 32 -set ACCUMULATOR_WIDTH 24 -set SUPPORT_E4M3 0 -set SUPPORT_E5M2 0 -set SUPPORT_MXFP6 0 -set SUPPORT_MXFP4 1 -set SUPPORT_INT8 0 -set SUPPORT_PIPELINING 0 -set SUPPORT_ADV_ROUNDING 0 -set SUPPORT_MIXED_PRECISION 0 -set SUPPORT_VECTOR_PACKING 0 -set ENABLE_SHARED_SCALING 0 -set SUPPORT_MX_PLUS 0 -set SUPPORT_INPUT_BUFFERING 0 -set SUPPORT_SERIAL 1" >> $GITHUB_ENV
           elif [[ "${{ matrix.variant }}" == M3-* ]]; then
             echo "TOP=tt_gowin_top_m3" >> $GITHUB_ENV
-            echo "SOURCES=src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src/lzc40.v src/fixed_to_float.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v src_gowin/ahb2_mac_bridge.v" >> $GITHUB_ENV
+            echo "SOURCES=src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/fp8_aligner_serial.v src/accumulator.v src/lzc40.v src/fixed_to_float.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v src_gowin/ahb2_mac_bridge.v" >> $GITHUB_ENV
             echo "CST=src_gowin/tangnano4k_m3.cst" >> $GITHUB_ENV
             echo "PARAMS=-set ALIGNER_WIDTH 32 -set ACCUMULATOR_WIDTH 32 -set SUPPORT_E4M3 1 -set SUPPORT_E5M2 1" >> $GITHUB_ENV
             if [ "${{ matrix.variant }}" == "M3-GPIO" ]; then

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,4 +13,4 @@ jobs:
 
       - name: Run Verilator Lint
         shell: bash
-        run: verilator --lint-only -Wall -Isrc/ --top-module tt_um_chatelao_fp8_multiplier src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src/lzc40.v src/fixed_to_float.v
+        run: verilator --lint-only -Wall -Isrc/ --top-module tt_um_chatelao_fp8_multiplier src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/fp8_aligner_serial.v src/accumulator.v src/lzc40.v src/fixed_to_float.v

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
           # Verify compilation of all M3 modes using iverilog
           for mode in M3_MODE_GPIO M3_MODE_APB M3_MODE_AHB M3_MODE_AHB_DMA; do
             echo "Verifying $mode..."
-            iverilog -g2012 -Isrc -D$mode src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/accumulator.v src/lzc40.v src/fixed_to_float.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v src_gowin/ahb2_mac_bridge.v -o m3_test
+            iverilog -g2012 -Isrc -D$mode src/project.v src/fp8_mul.v src/fp8_mul_lns.v src/fp8_mul_serial_lns.v src/fp8_aligner.v src/fp8_aligner_serial.v src/accumulator.v src/lzc40.v src/fixed_to_float.v src_gowin/tt_gowin_top_m3.v src_gowin/gowin_empu_m3_stub.v src_gowin/ahb2_mac_bridge.v -o m3_test
             rm m3_test
           done
 
@@ -54,6 +54,8 @@ jobs:
             export COMPILE_ARGS="-P tb.ALIGNER_WIDTH=40 -P tb.ACCUMULATOR_WIDTH=40 -P tb.SUPPORT_E5M2=0 -P tb.SUPPORT_MXFP6=0 -P tb.SUPPORT_MXFP4=1 -P tb.SUPPORT_INT8=0 -P tb.SUPPORT_PIPELINING=0 -P tb.SUPPORT_ADV_ROUNDING=0 -P tb.SUPPORT_MIXED_PRECISION=0 -P tb.ENABLE_SHARED_SCALING=0 -P tb.SUPPORT_SERIAL=0 -P tb.SERIAL_K_FACTOR=1"
           elif [ "${{ matrix.config }}" == "Tiny-Serial" ]; then
             export COMPILE_ARGS="-P tb.SUPPORT_SERIAL=1 -P tb.SERIAL_K_FACTOR=8"
+            echo "Running Serial Aligner Unit Test..."
+            make -f Makefile_aligner_serial
           fi
           bash run_tests.sh
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,8 @@ jobs:
           elif [ "${{ matrix.config }}" == "Tiny-Serial" ]; then
             export COMPILE_ARGS="-P tb.SUPPORT_SERIAL=1 -P tb.SERIAL_K_FACTOR=8"
             echo "Running Serial Aligner Unit Test..."
-            make -f Makefile_aligner_serial
+            # Use a subshell to run the unit test without overriding top-level parameters
+            (unset COMPILE_ARGS && cd test && make -f Makefile_aligner_serial)
           fi
           bash run_tests.sh
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
             export COMPILE_ARGS="-P tb.SUPPORT_SERIAL=1 -P tb.SERIAL_K_FACTOR=8"
             echo "Running Serial Aligner Unit Test..."
             # Use a subshell to run the unit test without overriding top-level parameters
-            (unset COMPILE_ARGS && cd test && make -f Makefile_aligner_serial)
+            (unset COMPILE_ARGS && make -f Makefile_aligner_serial)
           fi
           bash run_tests.sh
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,7 @@ Address the gaps identified in the `docs/FP32_AUDIT.md` to ensure full complianc
 ## 4. Bit-Serial Evolution (Tiny-Serial)
 The goal is to achieve an ultra-minimal footprint (< 500 gates) by processing data one bit at a time, inspired by the SERV core.
 
-- [ ] **Step 5.1: [Datapath] 1-bit Delay-Line Aligner**: Implement the core serial alignment logic using a delay-line approach. ([details](docs/architecture/OCP_MX_SERIAL.md#phase-2-bit-serial-module-integration))
+- [x] **Step 5.1: [Datapath] 1-bit Delay-Line Aligner**: Implement the core serial alignment logic using a delay-line approach. ([details](docs/architecture/OCP_MX_SERIAL.md#phase-2-bit-serial-module-integration))
 - [ ] **Step 5.2: [Integration] Aligner Swap**: Integrate the serial aligner into the `Tiny-Serial` variant and verify functional parity. ([details](docs/architecture/OCP_MX_SERIAL.md#phase-2-bit-serial-module-integration))
 - [ ] **Step 6.1: [Datapath] Circulating Shift Register Accumulator**: Implement the serial storage and 1-bit adder with carry-out FF. ([details](docs/architecture/OCP_MX_SERIAL.md#phase-2-bit-serial-module-integration))
 - [ ] **Step 6.2: [Integration] Accumulator Swap**: Replace the parallel accumulator in the serial path and verify bit-serial accumulation. ([details](docs/architecture/OCP_MX_SERIAL.md#phase-2-bit-serial-module-integration))

--- a/info.yaml
+++ b/info.yaml
@@ -22,6 +22,7 @@ project:
     - "fp8_mul_lns.v"
     - "fp8_mul_serial_lns.v"
     - "fp8_aligner.v"
+    - "fp8_aligner_serial.v"
     - "accumulator.v"
     - "lzc40.v"
     - "fixed_to_float.v"

--- a/src/fp8_aligner_serial.v
+++ b/src/fp8_aligner_serial.v
@@ -1,0 +1,70 @@
+`ifndef __FP8_ALIGNER_SERIAL_V__
+`define __FP8_ALIGNER_SERIAL_V__
+`default_nettype none
+
+/**
+ * Bit-Serial FP8 Aligner (Delay-Line Approach)
+ *
+ * This module aligns a bit-serial product stream (LSB first) to a
+ * fixed-point grid by delaying it based on the exponent.
+ * It also handles 2's complement conversion and sign extension.
+ *
+ * Formula: target_bit = product_bit_index + exp_sum + 3
+ * (Maps product binary point to accumulator binary point at bit 16)
+ */
+module fp8_aligner_serial #(
+    parameter WIDTH = 40,
+    parameter MAX_DELAY = 64
+)(
+    input  wire clk,
+    input  wire rst_n,
+    input  wire ena,
+    input  wire strobe,          // Start of element processing (resets state)
+    input  wire signed [9:0] exp_sum,
+    input  wire sign,
+    input  wire prod_bit,        // Bit-serial magnitude from multiplier (LSB first)
+    output wire aligned_bit      // Bit-serial 2's complement aligned output
+);
+
+    // Calculate alignment shift: k0 = exp_sum + 3
+    // This maps the product's binary point to the accumulator's binary point (bit 16).
+    // k0 is the delay we need to apply to the product stream.
+    wire signed [10:0] k0 = $signed(exp_sum) + 11'sd3;
+
+    // Delay Line for the magnitude bitstream.
+    // Using a shift register to allow variable delay via tap selection.
+    reg [MAX_DELAY-1:0] delay_line;
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) delay_line <= {MAX_DELAY{1'b0}};
+        else if (ena) delay_line <= {delay_line[MAX_DELAY-2:0], prod_bit};
+    end
+
+    // Selected magnitude bit after delay.
+    // We use a chain that includes the current prod_bit to allow for 0-cycle delay.
+    wire [MAX_DELAY:0] full_delay_chain = {delay_line, prod_bit};
+
+    // If k0 is negative, the bit is below our window and we treat it as 0 (truncate).
+    // If k0 is too large, it's also 0 (above our window).
+    wire mag_bit = (k0 >= 0 && k0 <= $signed({1'b0, MAX_DELAY[10:0]})) ? full_delay_chain[k0[6:0]] : 1'b0;
+
+    // 2's Complement Conversion: -Mag = ~Mag + 1
+    // We process the stream LSB-first, so we can use a serial adder for the +1.
+    reg carry_neg;
+    wire inv_bit = sign ? ~mag_bit : mag_bit;
+
+    // Use strobe to inject the initial carry (+1) for negation.
+    wire cin = strobe ? sign : carry_neg;
+    wire res_bit = inv_bit ^ cin;
+    wire carry_neg_next = inv_bit & cin;
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) carry_neg <= 1'b0;
+        else if (ena) begin
+            carry_neg <= carry_neg_next;
+        end
+    end
+
+    assign aligned_bit = res_bit;
+
+endmodule
+`endif

--- a/src/fp8_aligner_serial.v
+++ b/src/fp8_aligner_serial.v
@@ -45,7 +45,8 @@ module fp8_aligner_serial #(
 
     // If k0 is negative, the bit is below our window and we treat it as 0 (truncate).
     // If k0 is too large, it's also 0 (above our window).
-    wire mag_bit = (k0 >= 0 && k0 <= $signed({1'b0, MAX_DELAY[10:0]})) ? full_delay_chain[k0[6:0]] : 1'b0;
+    wire signed [11:0] max_delay_val = $signed({1'b0, MAX_DELAY[10:0]});
+    wire mag_bit = (k0 >= 0 && $signed({1'b0, k0}) <= max_delay_val) ? full_delay_chain[k0[6:0]] : 1'b0;
 
     // 2's Complement Conversion: -Mag = ~Mag + 1
     // We process the stream LSB-first, so we can use a serial adder for the +1.

--- a/src/project.sby
+++ b/src/project.sby
@@ -23,6 +23,7 @@ fp8_mul.v
 fp8_mul_lns.v
 fp8_mul_serial_lns.v
 fp8_aligner.v
+fp8_aligner_serial.v
 accumulator.v
 lzc40.v
 fixed_to_float.v

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@
 SIM ?= icarus
 TOPLEVEL_LANG ?= verilog
 SRC_DIR = ../src
-PROJECT_SOURCES = project.v fp8_mul.v fp8_mul_lns.v fp8_mul_serial_lns.v fp8_aligner.v accumulator.v lzc40.v fixed_to_float.v
+PROJECT_SOURCES = project.v fp8_mul.v fp8_mul_lns.v fp8_mul_serial_lns.v fp8_aligner.v fp8_aligner_serial.v accumulator.v lzc40.v fixed_to_float.v
 
 ifeq ($(GATES),yes)
 

--- a/test/Makefile_aligner_serial
+++ b/test/Makefile_aligner_serial
@@ -1,0 +1,11 @@
+# Makefile for Serial Aligner Unit Test
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+
+VERILOG_SOURCES += $(PWD)/../src/fp8_aligner_serial.v
+VERILOG_SOURCES += $(PWD)/tb_aligner_serial.v
+
+TOPLEVEL = tb_aligner_serial
+MODULE = test_aligner_serial
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/test/Makefile_aligner_serial
+++ b/test/Makefile_aligner_serial
@@ -8,4 +8,7 @@ VERILOG_SOURCES += $(PWD)/tb_aligner_serial.v
 TOPLEVEL = tb_aligner_serial
 MODULE = test_aligner_serial
 
+# Ensure results directory exists
+$(shell mkdir -p results)
+
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/test/tb_aligner_serial.v
+++ b/test/tb_aligner_serial.v
@@ -1,0 +1,35 @@
+`default_nettype none
+`timescale 1ns/1ps
+
+module tb_aligner_serial (
+    input  wire clk,
+    input  wire rst_n,
+    input  wire ena,
+    input  wire strobe,
+    input  wire [9:0] exp_sum,
+    input  wire sign,
+    input  wire prod_bit,
+    output wire aligned_bit
+);
+
+    fp8_aligner_serial #(
+        .WIDTH(40),
+        .MAX_DELAY(64)
+    ) dut (
+        .clk(clk),
+        .rst_n(rst_n),
+        .ena(ena),
+        .strobe(strobe),
+        .exp_sum(exp_sum),
+        .sign(sign),
+        .prod_bit(prod_bit),
+        .aligned_bit(aligned_bit)
+    );
+
+    // Dump waves
+    initial begin
+        $dumpfile("results/tb_aligner_serial.vcd");
+        $dumpvars(0, tb_aligner_serial);
+    end
+
+endmodule

--- a/test/test_aligner_serial.py
+++ b/test/test_aligner_serial.py
@@ -1,0 +1,68 @@
+import cocotb
+from cocotb.triggers import Timer, RisingEdge
+from cocotb.clock import Clock
+import random
+
+@cocotb.test()
+async def test_aligner_serial_basic(dut):
+    """Basic serial aligner test: verify alignment shift and sign handling"""
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    dut.rst_n.value = 0
+    dut.ena.value = 1
+    dut.strobe.value = 0
+    dut.exp_sum.value = 0
+    dut.sign.value = 0
+    dut.prod_bit.value = 0
+    await RisingEdge(dut.clk)
+    dut.rst_n.value = 1
+    await RisingEdge(dut.clk)
+
+    # Test Case 1: Positive product, Exp = 0
+    # Expected: Product shifted by k0 = 3
+    val = 0xA5 # 10100101
+    dut.exp_sum.value = 0
+    dut.sign.value = 0
+    dut.strobe.value = 1
+    await RisingEdge(dut.clk)
+    dut.strobe.value = 0
+
+    results = []
+    for i in range(16):
+        dut.prod_bit.value = (val >> i) & 1 if i < 8 else 0
+        await Timer(1, unit="ns")
+        results.append(int(dut.aligned_bit.value))
+        await RisingEdge(dut.clk)
+
+    # k0 = 3, so first 3 bits should be 0, then val should start
+    expected = [0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0]
+    assert results == expected, f"Expected {expected}, got {results}"
+
+    # Test Case 2: Negative product, Exp = 1
+    # Expected: Product shifted by k0 = 4, then negated
+    val = 0x01 # 00000001
+    dut.exp_sum.value = 1
+    dut.sign.value = 1 # Negative
+    dut.strobe.value = 1
+    await RisingEdge(dut.clk)
+    dut.strobe.value = 0
+
+    results = []
+    for i in range(16):
+        dut.prod_bit.value = (val >> i) & 1 if i < 8 else 0
+        await Timer(1, unit="ns")
+        results.append(int(dut.aligned_bit.value))
+        await RisingEdge(dut.clk)
+
+    # k0 = 4, so first 4 bits are 0.
+    # val = 00000001. After k0=4: 0000 0000 0001 0000
+    # Negation: -X = ~X + 1
+    # In bits (LSB first):
+    # ~X: 1111 1111 1110 1111
+    # +1: 0000 0000 0001 1111? No.
+    # X = 0x0010 (binary 0000 0000 0001 0000)
+    # -X = 0xFFF0 (binary 1111 1111 1111 0000)
+    # Bit stream (LSB first): 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+    expected_neg = [0, 0, 0, 0] + [1]*12
+    assert results == expected_neg, f"Expected {expected_neg}, got {results}"


### PR DESCRIPTION
Implementation of the bit-serial aligner stage for the OCP MX MAC unit. This module aligns a bit-serial product stream based on its exponent using a variable-length delay line, preparing it for subsequent serial accumulation. It also includes integrated 2's complement negation for negative products.

Fixes #862

---
*PR created automatically by Jules for task [12659832842003911026](https://jules.google.com/task/12659832842003911026) started by @chatelao*