### PR TITLE
Implement Bit-Serial Accumulator (Step 6.1)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ The goal is to achieve an ultra-minimal footprint (< 500 gates) by processing da
 
 - [x] **Step 5.1: [Datapath] 1-bit Delay-Line Aligner**: Implement the core serial alignment logic using a delay-line approach. ([details](docs/architecture/OCP_MX_SERIAL.md#phase-2-bit-serial-module-integration))
 - [ ] **Step 5.2: [Integration] Aligner Swap**: Integrate the serial aligner into the `Tiny-Serial` variant and verify functional parity. ([details](docs/architecture/OCP_MX_SERIAL.md#phase-2-bit-serial-module-integration))
-- [ ] **Step 6.1: [Datapath] Circulating Shift Register Accumulator**: Implement the serial storage and 1-bit adder with carry-out FF. ([details](docs/architecture/OCP_MX_SERIAL.md#phase-2-bit-serial-module-integration))
+- [x] **Step 6.1: [Datapath] Circulating Shift Register Accumulator**: Implement the serial storage and 1-bit adder with carry-out FF. ([details](docs/architecture/OCP_MX_SERIAL.md#phase-2-bit-serial-module-integration))
 - [ ] **Step 6.2: [Integration] Accumulator Swap**: Replace the parallel accumulator in the serial path and verify bit-serial accumulation. ([details](docs/architecture/OCP_MX_SERIAL.md#phase-2-bit-serial-module-integration))
 - [ ] **Step 7.1: [Refactor] Serial Config Registers**: Convert format, rounding, and metadata registers to serial shift registers. ([details](docs/architecture/OCP_MX_SERIAL.md#phase-3-area-optimization--refinement))
 - [ ] **Step 7.2: [Refactor] Serial Control Logic**: Optimize the FSM and pointers for bit-serial state management. ([details](docs/architecture/OCP_MX_SERIAL.md#phase-3-area-optimization--refinement))

--- a/src/accumulator_serial.v
+++ b/src/accumulator_serial.v
@@ -1,0 +1,61 @@
+`ifndef __ACCUMULATOR_SERIAL_V__
+`define __ACCUMULATOR_SERIAL_V__
+`default_nettype none
+
+/**
+ * Bit-Serial Accumulator
+ *
+ * This module implements a bit-serial storage using a circulating shift register
+ * and a 1-bit full adder.
+ *
+ * Latency: WIDTH cycles for a full circulation.
+ *
+ * Formula: Acc = Acc + Aligned_Product
+ */
+module accumulator_serial #(
+    parameter WIDTH = 40
+)(
+    input  wire clk,
+    input  wire rst_n,
+    input  wire ena,         // Shift enable (usually always high during operation)
+    input  wire clear,       // Synchronous clear of the accumulator
+    input  wire strobe,      // Carry reset (should be high for the LSB of a new addition)
+    input  wire data_in_bit, // Bit-serial aligned product bit
+    output wire data_out_bit, // Bit shifted out (current LSB)
+    output wire [WIDTH-1:0] parallel_out // Full register for debug/output
+);
+
+    reg [WIDTH-1:0] shift_reg;
+    reg carry;
+
+    // 1-bit Full Adder
+    // Sum = A ^ B ^ Cin
+    // Cout = (A & B) | (Cin & (A ^ B))
+    // A is the incoming bit, B is the current accumulator LSB.
+    wire b_bit = shift_reg[0];
+    wire cin = strobe ? 1'b0 : carry;
+    wire sum_bit = data_in_bit ^ b_bit ^ cin;
+    wire cout = (data_in_bit & b_bit) | (cin & (data_in_bit ^ b_bit));
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            shift_reg <= {WIDTH{1'b0}};
+            carry <= 1'b0;
+        end else if (ena) begin
+            if (clear) begin
+                shift_reg <= {WIDTH{1'b0}};
+                carry <= 1'b0;
+            end else begin
+                // Shift right: MSB gets the new sum, all others move towards LSB.
+                // After WIDTH cycles, this sum will be at shift_reg[0].
+                shift_reg <= {sum_bit, shift_reg[WIDTH-1:1]};
+                carry <= cout;
+            end
+        end
+    end
+
+    assign data_out_bit = shift_reg[0];
+    assign parallel_out = shift_reg;
+
+endmodule
+`endif

--- a/src/project.sby
+++ b/src/project.sby
@@ -25,5 +25,6 @@ fp8_mul_serial_lns.v
 fp8_aligner.v
 fp8_aligner_serial.v
 accumulator.v
+accumulator_serial.v
 lzc40.v
 fixed_to_float.v

--- a/test/Makefile_accumulator_serial
+++ b/test/Makefile_accumulator_serial
@@ -1,0 +1,9 @@
+# Makefile for accumulator_serial test
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+SRC_DIR = $(PWD)/../src
+VERILOG_SOURCES = $(SRC_DIR)/accumulator_serial.v $(PWD)/tb_accumulator_serial.v
+TOPLEVEL = tb_accumulator_serial
+MODULE = test_accumulator_serial
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/test/tb_accumulator_serial.v
+++ b/test/tb_accumulator_serial.v
@@ -1,0 +1,33 @@
+`default_nettype none
+`timescale 1ns/1ps
+
+module tb_accumulator_serial (
+    input  wire clk,
+    input  wire rst_n,
+    input  wire ena,
+    input  wire clear,
+    input  wire strobe,
+    input  wire data_in_bit,
+    output wire data_out_bit,
+    output wire [39:0] parallel_out
+);
+
+    accumulator_serial #(
+        .WIDTH(40)
+    ) dut (
+        .clk(clk),
+        .rst_n(rst_n),
+        .ena(ena),
+        .clear(clear),
+        .strobe(strobe),
+        .data_in_bit(data_in_bit),
+        .data_out_bit(data_out_bit),
+        .parallel_out(parallel_out)
+    );
+
+    initial begin
+        $dumpfile("results/accumulator_serial.vcd");
+        $dumpvars(0, tb_accumulator_serial);
+    end
+
+endmodule

--- a/test/test_accumulator_serial.py
+++ b/test/test_accumulator_serial.py
@@ -1,0 +1,99 @@
+import cocotb
+from cocotb.triggers import RisingEdge, Timer, ReadOnly
+from cocotb.clock import Clock
+import random
+
+async def drive_serial(dut, val, width=40):
+    for i in range(width):
+        dut.strobe.value = 1 if i == 0 else 0
+        dut.data_in_bit.value = (val >> i) & 1
+        await RisingEdge(dut.clk)
+    dut.strobe.value = 0
+    dut.data_in_bit.value = 0
+
+@cocotb.test()
+async def test_accumulator_serial_basic(dut):
+    """Test basic bit-serial accumulation"""
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    # Initialize
+    dut.ena.value = 1
+    dut.rst_n.value = 0
+    dut.clear.value = 0
+    dut.strobe.value = 0
+    dut.data_in_bit.value = 0
+
+    await RisingEdge(dut.clk)
+    await Timer(1, unit="ns")
+    dut.rst_n.value = 1
+    await RisingEdge(dut.clk)
+    await Timer(1, unit="ns")
+
+    # Accumulate 123 + 456
+    val1 = 123
+    val2 = 456
+
+    # 1. Add val1 (initial 0 + val1)
+    await drive_serial(dut, val1)
+    await Timer(1, unit="ns") # Exit ReadOnly if any
+    res1 = int(dut.parallel_out.value)
+    assert res1 == val1, f"Expected {val1}, got {res1}"
+
+    # 2. Add val2 (val1 + val2)
+    await drive_serial(dut, val2)
+    await Timer(1, unit="ns")
+    res2 = int(dut.parallel_out.value)
+    expected = (val1 + val2)
+    assert res2 == expected, f"Expected {expected}, got {res2}"
+
+@cocotb.test()
+async def test_accumulator_serial_random(dut):
+    """Random bit-serial accumulation tests"""
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    dut.ena.value = 1
+    dut.rst_n.value = 0
+    dut.clear.value = 0
+    dut.strobe.value = 0
+    dut.data_in_bit.value = 0
+    await RisingEdge(dut.clk)
+    dut.rst_n.value = 1
+    await RisingEdge(dut.clk)
+
+    accumulator = 0
+    for _ in range(20):
+        val = random.getrandbits(32)
+        await drive_serial(dut, val)
+        await Timer(1, unit="ns")
+        accumulator = (accumulator + val) & ((1 << 40) - 1)
+        res = int(dut.parallel_out.value)
+        assert res == accumulator, f"Random mismatch: expected {accumulator}, got {res}"
+
+@cocotb.test()
+async def test_accumulator_serial_clear(dut):
+    """Test serial accumulator clear"""
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    dut.ena.value = 1
+    dut.rst_n.value = 1
+    dut.clear.value = 1
+    await RisingEdge(dut.clk)
+    dut.clear.value = 0
+    await Timer(1, unit="ns")
+    assert int(dut.parallel_out.value) == 0
+
+    # Add something
+    val = 0xAA55
+    await drive_serial(dut, val)
+    await Timer(1, unit="ns")
+    assert int(dut.parallel_out.value) == val
+
+    # Clear
+    dut.clear.value = 1
+    await RisingEdge(dut.clk)
+    dut.clear.value = 0
+    await Timer(1, unit="ns")
+    assert int(dut.parallel_out.value) == 0


### PR DESCRIPTION
Implemented the bit-serial accumulator as defined in Step 6.1 of the project roadmap. The module uses a circulating shift register and a 1-bit full adder to perform bit-serial addition over 40 cycles. The implementation was verified with a new unit test suite and checked against existing regressions.

Fixes #864

---
*PR created automatically by Jules for task [5117593047149340085](https://jules.google.com/task/5117593047149340085) started by @chatelao*