### PR TITLE
Add bit-serial PlantUML diagrams to README_SERIAL.md

### DIFF
--- a/README_SERIAL.md
+++ b/README_SERIAL.md
@@ -11,6 +11,12 @@ The fundamental principle of this bit-serial variant is that any N-bit operation
 - **1-Bit Datapath**: All arithmetic (multiplication, alignment, accumulation) is performed using 1-bit logic.
 - **Latency-Area Tradeoff**: By processing one bit at a time, we significantly reduce gate count and routing congestion at the cost of increased cycle count.
 
+## System Context
+
+![System Context Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/docs/diagrams/SERIAL_CONTEXT_DIAGRAM.PUML)
+
+*Source: [docs/diagrams/SERIAL_CONTEXT_DIAGRAM.PUML](docs/diagrams/SERIAL_CONTEXT_DIAGRAM.PUML)*
+
 ## Attributions
 
 This project incorporates logic and concepts from several open-source resources:
@@ -29,9 +35,21 @@ This project incorporates logic and concepts from several open-source resources:
 | **Serial Accumulator** | 1-bit Adder, Circulating Register | Performs summation using a 1-bit full adder and a carry flip-flop. The 40-bit accumulator circulates in a shift register. |
 | **Output Serializer** | Shift Register | Extracts results bit-by-bit or byte-by-byte for transmission over `uo_out`. |
 
+### Internal Datapath
+
+![Internal Datapath Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/docs/diagrams/SERIAL_DATAPATH_DIAGRAM.PUML)
+
+*Source: [docs/diagrams/SERIAL_DATAPATH_DIAGRAM.PUML](docs/diagrams/SERIAL_DATAPATH_DIAGRAM.PUML)*
+
 ## Protocol Description (Stretched)
 
 To maintain compatibility with the 8-bit streaming interface while using bit-serial internals, the unit uses a **Stretched Protocol**. 1 element is processed every $K$ clock cycles.
+
+### Protocol State Machine
+
+![Protocol State Machine Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ttihp-fp8-mul/main/docs/diagrams/SERIAL_PROTOCOL_STATES.PUML)
+
+*Source: [docs/diagrams/SERIAL_PROTOCOL_STATES.PUML](docs/diagrams/SERIAL_PROTOCOL_STATES.PUML)*
 
 ### Operational Sequence (Example K=8)
 

--- a/docs/diagrams/SERIAL_CONTEXT_DIAGRAM.PUML
+++ b/docs/diagrams/SERIAL_CONTEXT_DIAGRAM.PUML
@@ -1,0 +1,76 @@
+@startuml SERIAL_CONTEXT_DIAGRAM
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
+
+LAYOUT_WITH_LEGEND()
+skinparam rectangle<<boundary>> {
+    FontSize 20
+}
+skinparam rectangle<<container_boundary>> {
+    FontSize 20
+}
+skinparam rectangle<<system_boundary>> {
+    FontSize 20
+}
+UpdateBoundaryStyle("container", $type="container")
+UpdateBoundaryStyle("system", $type="system")
+
+Person(host, "Host System", "FPGA, Microcontroller, or SERV Core")
+
+Container_Boundary(mac_unit, "Bit-Serial OCP MX MAC Unit (Ultra-Minimal Variant)") {
+
+    Container_Boundary(fsm_block, "Stretched FSM & Control") {
+        Component(counter, "Cycle Counter", "6-bit", "Tracks logical protocol cycles.")
+        Component(k_counter, "K-Counter", "SERIAL_K_FACTOR", "Sub-cycle counter for bit-serial stretching.")
+        Component(fsm_logic, "State Machine", "Logic", "Coordinates bit-serial processing over K cycles.")
+        Component(config_regs, "Serial Config Regs", "Shift Registers", "Stores scales and formats as circulating bits.")
+        Component(strobe_gen, "Strobe Logic", "Combinatorial", "Pulse every K cycles.")
+
+        Rel_D(k_counter, strobe_gen, "Pulse")
+        Rel_D(strobe_gen, fsm_logic, "Strobe")
+        Rel_D(counter, fsm_logic, "Logical Count", "6-bit")
+        Rel_D(fsm_logic, config_regs, "Load/Shift", "Enable")
+    }
+
+    Container_Boundary(mul_block, "Bit-Serial Multiplier") {
+        Component(decoders, "Serial Decoders", "Logic", "Extracts S, E, M bits from the input stream.")
+        Component(s_mul, "Serial Multiplier", "1-bit Adder", "Performs mantissa multiplication bit-by-bit (Mitchell LNS).")
+        Component(exp_arith, "Serial Exponent", "1-bit Sub/Add", "Serial bias correction and exponent summation.")
+
+        Rel_D(decoders, s_mul, "Mantissa Bits")
+        Rel_D(decoders, exp_arith, "Exponent Bits")
+    }
+
+    Container_Boundary(align_block, "Serial Aligner Stage") {
+        Component(delay_line, "Delay-Line Aligner", "SR / Tap Mux", "Aligns products by delaying the bit-stream.")
+        Component(ser_round, "Serial Rounding", "Logic", "Bit-serial TRN/RNE rounding logic.")
+
+        Rel_D(delay_line, ser_round, "Aligned Bit-Stream")
+    }
+
+    Container_Boundary(acc_block, "Serial Accumulator") {
+        Component(ser_adder, "1-bit Full Adder", "Logic", "Sums product bit into circulating accumulator.")
+        Component(acc_sr, "Circulating SR", "40-bit Shift Reg", "Stores running sum; circulates once per element.")
+        Component(carry_ff, "Carry DFF", "1 FF", "Preserves carry-out between bits.")
+
+        Rel_D(ser_adder, acc_sr, "Sum Bit")
+        Rel_U(acc_sr, ser_adder, "LSB Feedback")
+        Rel_L(ser_adder, carry_ff, "Cout")
+        Rel_R(carry_ff, ser_adder, "Cin")
+    }
+
+    Container_Boundary(exception_block, "Exception Handling") {
+        Component(sticky, "Serial Sticky", "FFs", "Latches NaN/Inf during the stretched stream.")
+        Rel_D(sticky, host, "uo_out", "Status")
+    }
+}
+
+Rel_D(host, fsm_logic, "Control", "clk, rst_n, ena")
+Rel_D(host, config_regs, "Metadata", "ui_in, uio_in (Stretched)")
+Rel_D(host, decoders, "Serial Data", "ui_in, uio_in")
+
+Rel_R(config_regs, decoders, "Modes", "Serial Config")
+Rel_D(mul_block, delay_line, "Product Bit-Stream")
+Rel_D(ser_round, ser_adder, "Aligned Bit")
+Rel_D(acc_sr, host, "uo_out", "Serialized Result")
+
+@enduml

--- a/docs/diagrams/SERIAL_DATAPATH_DIAGRAM.PUML
+++ b/docs/diagrams/SERIAL_DATAPATH_DIAGRAM.PUML
@@ -1,0 +1,81 @@
+@startuml SERIAL_DATAPATH_DIAGRAM
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
+
+LAYOUT_WITH_LEGEND()
+
+' Green Theme Overrides
+skinparam backgroundColor white
+skinparam component {
+    BackgroundColor #90EE90
+    BorderColor #006400
+    FontColor #000000
+}
+skinparam rectangle<<container>> {
+    BackgroundColor #90EE90
+    BorderColor #006400
+    FontColor #000000
+}
+skinparam rectangle<<boundary>> {
+    FontSize 20
+    BorderColor #006400
+    FontColor #000000
+}
+skinparam rectangle<<container_boundary>> {
+    FontSize 20
+    BorderColor #006400
+    FontColor #000000
+}
+skinparam rectangle<<system_boundary>> {
+    FontSize 20
+    BorderColor #006400
+    FontColor #000000
+}
+skinparam Arrow {
+    Color black
+    FontColor black
+}
+
+UpdateBoundaryStyle("container", $type="container")
+
+title OCP MXFP8 Bit-Serial MAC - Internal Datapath (K-cycle Processing)
+
+Container_Boundary(input_pins, "Physical Interface") {
+    Component(ui_in, "ui_in[7:0]", "Input Pins", "8-bit chunks every K cycles")
+    Component(uio_in, "uio_in[7:0]", "Input Pins", "8-bit chunks every K cycles")
+}
+
+Container_Boundary(control_logic, "Stretched Control") {
+    Component(k_cnt, "K-Counter", "Logic", "Sub-cycle timing [0..K-1]")
+    Component(l_cnt, "Logical Counter", "Logic", "Protocol cycles [0..40]")
+}
+
+Container_Boundary(datapath, "Bit-Serial Datapath") {
+    Component(s_mul, "Serial Multiplier", "1-bit Logic", "Mitchell LNS Serial Adder")
+    Component(s_align, "Delay Aligner", "SR + Mux", "Aligns by delaying bit-stream")
+    Component(s_acc, "Serial Accumulator", "SR + 1-bit Adder", "40-bit Circulating Register")
+}
+
+Container_Boundary(config_sr, "Configuration SRs") {
+    Component(fmt_sr, "Format/Scale SRs", "Shift Regs", "Serialized metadata")
+}
+
+Container_Boundary(output_logic, "Serial Output") {
+    Component(ser, "Byte Serializer", "Logic", "Extracts bytes from SR every K cycles")
+}
+
+Component(uo_out, "uo_out[7:0]", "Output Pins", "8-bit Result / Probe Data")
+
+' Dataflow
+Rel_D(ui_in, s_mul, "1 bit/cycle", "Operand A")
+Rel_D(uio_in, s_mul, "1 bit/cycle", "Operand B")
+Rel_D(s_mul, s_align, "Product Stream", "1 bit/cycle")
+Rel_D(s_align, s_acc, "Aligned Stream", "1 bit/cycle")
+Rel_U(s_acc, s_acc, "LSB Feedback", "1 bit/cycle")
+
+Rel_R(l_cnt, config_sr, "Load En")
+Rel_L(config_sr, s_mul, "Config Bits")
+
+Rel_D(s_acc, ser, "40-bit Parallel", "Staged")
+Rel_D(ser, uo_out, "8-bit Chunk")
+
+@enduml

--- a/docs/diagrams/SERIAL_PROTOCOL_STATES.PUML
+++ b/docs/diagrams/SERIAL_PROTOCOL_STATES.PUML
@@ -1,0 +1,67 @@
+@startuml SERIAL_PROTOCOL_STATES
+title OCP MXFP8 Bit-Serial Stretched Protocol State Machine (K=8)
+
+skinparam state {
+  BackgroundColor<<Stretched>> #F1F8E9
+  BorderColor<<Stretched>> #33691E
+}
+
+[*] --> IDLE
+
+state IDLE {
+    IDLE : **Logical Cycle 0**
+    IDLE : **Physical Cycles 0-7**
+    IDLE : Serial Metadata Capture:
+    IDLE : - Shift-in Debug, Rounding, MX+
+    IDLE : - If Short Protocol: Jump to Stream
+}
+
+IDLE --> LOAD_SCALE : Standard Start\n(ui_in[7]=0)
+IDLE --> STREAM_DATA : Short Protocol <<Stretched>>\n(ui_in[7]=1)
+
+state LOAD_SCALE {
+    LOAD_SCALE : **Logical Cycles 1-2**
+    LOAD_SCALE : **Physical Cycles 8-23**
+    LOAD_SCALE : C1: Shift-in Scale A, Format A
+    LOAD_SCALE : C2: Shift-in Scale B, Format B
+}
+
+LOAD_SCALE --> STREAM_DATA : Logical Cycle 3
+
+state STREAM {
+    state STREAM_DATA {
+        STREAM_DATA : **Logical Cycles 3-34**
+        STREAM_DATA : **Physical Cycles 24-279**
+        STREAM_DATA : Bit-Serial Mul & Accumulate
+        STREAM_DATA : (1 bit processed per physical cycle)
+    }
+
+    state STREAM_FLUSH {
+        STREAM_FLUSH : **Logical Cycle 35**
+        STREAM_FLUSH : **Physical Cycles 280-287**
+        STREAM_FLUSH : Pipeline Flush / Final Carry
+    }
+
+    state STREAM_SCALE {
+        STREAM_SCALE : **Logical Cycle 36**
+        STREAM_SCALE : **Physical Cycles 288-295**
+        STREAM_SCALE : Final Shared Scaling (Serial)
+    }
+
+    STREAM_DATA --> STREAM_FLUSH
+    STREAM_FLUSH -> STREAM_SCALE
+}
+
+STREAM_SCALE --> OUTPUT : Logical Cycle 37
+
+state OUTPUT {
+    OUTPUT : **Logical Cycles 37-40**
+    OUTPUT : **Physical Cycles 296-327**
+    OUTPUT : Serialized Result Shift-out
+    OUTPUT : 1 Byte every 8 Physical Cycles
+}
+
+OUTPUT -> IDLE : Logical Cycle 0
+
+footer Note: Each logical cycle corresponds to SERIAL_K_FACTOR physical clock cycles.
+@enduml


### PR DESCRIPTION
This change adds visual documentation for the bit-serial implementation of the OCP MX Streaming MAC unit. It mirrors the documentation structure of the parallel version but adapts the diagrams to the bit-serial philosophy, including the "Stretched Protocol" and 1-bit datapath components.

Key changes:
- New PlantUML source files in `docs/diagrams/` for bit-serial context, datapath, and state machine.
- Updated `README_SERIAL.md` with sections for System Context, Internal Datapath, and Protocol State Machine, including rendered diagrams.
- Addressed code review feedback regarding orphan component references and branch-specific URLs.

Fixes #870

---
*PR created automatically by Jules for task [3021400369133303225](https://jules.google.com/task/3021400369133303225) started by @chatelao*