### PR TITLE
Integrate Bit-Serial Aligner and Accumulator

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
           elif [ "${{ matrix.config }}" == "Ultra-Tiny" ]; then
             export COMPILE_ARGS="-P tb.ALIGNER_WIDTH=40 -P tb.ACCUMULATOR_WIDTH=40 -P tb.SUPPORT_E5M2=0 -P tb.SUPPORT_MXFP6=0 -P tb.SUPPORT_MXFP4=1 -P tb.SUPPORT_INT8=0 -P tb.SUPPORT_PIPELINING=0 -P tb.SUPPORT_ADV_ROUNDING=0 -P tb.SUPPORT_MIXED_PRECISION=0 -P tb.ENABLE_SHARED_SCALING=0 -P tb.SUPPORT_SERIAL=0 -P tb.SERIAL_K_FACTOR=1"
           elif [ "${{ matrix.config }}" == "Tiny-Serial" ]; then
-            export COMPILE_ARGS="-P tb.SUPPORT_SERIAL=1 -P tb.SERIAL_K_FACTOR=8"
+            export COMPILE_ARGS="-P tb.SUPPORT_SERIAL=1 -P tb.SERIAL_K_FACTOR=40 -P tb.ENABLE_SHARED_SCALING=0"
             echo "Running Serial Aligner Unit Test..."
             # Use a subshell to run the unit test without overriding top-level parameters
             (unset COMPILE_ARGS && make -f Makefile_aligner_serial)

--- a/src/accumulator_serial.v
+++ b/src/accumulator_serial.v
@@ -20,7 +20,10 @@ module accumulator_serial #(
     input  wire ena,         // Shift enable (usually always high during operation)
     input  wire clear,       // Synchronous clear of the accumulator
     input  wire strobe,      // Carry reset (should be high for the LSB of a new addition)
-    input  wire data_in_bit, // Bit-serial aligned product bit
+    input  wire add_in_bit,  // Bit-serial aligned product bit
+    input  wire add_en,      // Enable bit-serial addition
+    input  wire load_en,     // Parallel load enable
+    input  wire [31:0] load_data, // Parallel data to load
     output wire data_out_bit, // Bit shifted out (current LSB)
     output wire [WIDTH-1:0] parallel_out // Full register for debug/output
 );
@@ -33,9 +36,11 @@ module accumulator_serial #(
     // Cout = (A & B) | (Cin & (A ^ B))
     // A is the incoming bit, B is the current accumulator LSB.
     wire b_bit = shift_reg[0];
+    wire a_bit = add_en ? add_in_bit : 1'b0;
     wire cin = strobe ? 1'b0 : carry;
-    wire sum_bit = data_in_bit ^ b_bit ^ cin;
-    wire cout = (data_in_bit & b_bit) | (cin & (data_in_bit ^ b_bit));
+    wire sum_bit = a_bit ^ b_bit ^ cin;
+    // Carry only propagates when adding.
+    wire cout = add_en ? ((a_bit & b_bit) | (cin & (a_bit ^ b_bit))) : 1'b0;
 
     always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin
@@ -45,7 +50,12 @@ module accumulator_serial #(
             if (clear) begin
                 shift_reg <= {WIDTH{1'b0}};
                 carry <= 1'b0;
+            end else if (load_en) begin
+                // Parallel load: Pad or truncate load_data to match WIDTH.
+                shift_reg <= {load_data, {(WIDTH-32){1'b0}}};
+                carry <= 1'b0;
             end else begin
+                // Always circulate when ena is high.
                 // Shift right: MSB gets the new sum, all others move towards LSB.
                 // After WIDTH cycles, this sum will be at shift_reg[0].
                 shift_reg <= {sum_bit, shift_reg[WIDTH-1:1]};

--- a/src/fp8_aligner_serial.v
+++ b/src/fp8_aligner_serial.v
@@ -26,10 +26,11 @@ module fp8_aligner_serial #(
     output wire aligned_bit      // Bit-serial 2's complement aligned output
 );
 
-    // Calculate alignment shift: k0 = exp_sum + 3
-    // This maps the product's binary point to the accumulator's binary point (bit 16).
-    // k0 is the delay we need to apply to the product stream.
-    wire signed [10:0] k0 = $signed(exp_sum) + 11'sd3;
+    // Calculate alignment shift: k0 = exp_sum + (WIDTH - 37)
+    // This maps the product's binary point to the accumulator's binary point (bit WIDTH-24).
+    // For WIDTH=40, offset is 3. For WIDTH=32, offset is -5.
+    localparam signed [10:0] OFFSET = $signed({1'b0, WIDTH[7:0]}) - 11'sd37;
+    wire signed [10:0] k0 = $signed(exp_sum) + OFFSET;
 
     // Delay Line for the magnitude bitstream.
     // Using a shift register to allow variable delay via tap selection.

--- a/src/project.v
+++ b/src/project.v
@@ -49,7 +49,7 @@ module tt_um_chatelao_fp8_multiplier #(
 );
 
     // COUNTER_WIDTH determines the size of our cycle tracker.
-    localparam COUNTER_WIDTH = 6;
+    localparam COUNTER_WIDTH = 7;
 
     /**
      * FSM (Finite State Machine) States
@@ -386,10 +386,17 @@ module tt_um_chatelao_fp8_multiplier #(
     localparam EXP_SUM_WIDTH = (SUPPORT_E5M2) ? 7 :
                                (SUPPORT_E4M3 || SUPPORT_INT8 || SUPPORT_MX_PLUS) ? 6 : 5;
 
-    // Control signal to enable the accumulator only when valid products are arriving.
-    wire acc_en    = strobe && (SUPPORT_PIPELINING ?
-                     ((logical_cycle >= 6'd4 && logical_cycle <= last_stream_cycle + 6'd1) && (state == STATE_STREAM || state == STATE_OUTPUT)) :
-                     ((logical_cycle >= 6'd3 && logical_cycle <= last_stream_cycle) && (state == STATE_STREAM)));
+    // Logical accumulation window (captures bits arriving from multiplier/pipeline).
+    wire logical_acc_en = (SUPPORT_PIPELINING ?
+                          ((logical_cycle >= 7'd4 && logical_cycle <= last_stream_cycle + 7'd1) && (state == STATE_STREAM || state == STATE_OUTPUT)) :
+                          ((logical_cycle >= 7'd3 && logical_cycle <= last_stream_cycle) && (state == STATE_STREAM)));
+
+    // For bit-serial datapath, accumulation can happen anytime logical_acc_en is high.
+    // The aligner handles product alignment within the physical cycles of each logical cycle.
+    wire s_add_en = logical_acc_en;
+
+    // Control signal to enable the parallel accumulator.
+    wire acc_en    = strobe && logical_acc_en;
 
     // Multiplier results wires.
     wire [15:0] mul_prod_lane0, mul_prod_lane1;
@@ -683,6 +690,70 @@ module tt_um_chatelao_fp8_multiplier #(
     // 2. Shared Scale Calculation: S = XA + XB - 254. UE8M0 has bias 127.
     wire signed [9:0] shared_exp = $signed({2'b0, scale_a_val}) + $signed({2'b0, scale_b_val}) - 10'sd254;
 
+    // --- Bit-Serial Datapath (Phase 2 Integration) ---
+    wire serial_aligned_bit;
+    wire [ACCUMULATOR_WIDTH-1:0] serial_acc_parallel_out;
+    wire mul_prod_bit_val;
+    wire s_strobe;
+
+    generate
+        if (SUPPORT_SERIAL) begin : gen_serial_datapath
+            // 1. Multiplier Output Serializer
+            // Captures parallel multiplier output and shifts it out LSB-first.
+            // Bit 0 is presented during cycle 0 (strobe=1) via combinatorial mux.
+            reg [15:0] prod_shifter;
+            always @(posedge clk or negedge rst_n) begin
+                if (!rst_n) begin
+                    prod_shifter <= 16'd0;
+                end else if (ena) begin
+                    if (strobe) prod_shifter <= {1'b0, mul_prod_lane0[15:1]};
+                    else prod_shifter <= {1'b0, prod_shifter[15:1]};
+                end
+            end
+            assign mul_prod_bit_val = strobe ? mul_prod_lane0[0] : prod_shifter[0];
+            assign s_strobe = strobe;
+
+            // 2. Serial Aligner
+            // Aligns the bit-serial product stream to the fixed-point grid.
+            fp8_aligner_serial #(
+                .WIDTH(ALIGNER_WIDTH),
+                .MAX_DELAY(64)
+            ) aligner_serial_inst (
+                .clk(clk),
+                .rst_n(rst_n),
+                .ena(ena),
+                .strobe(s_strobe),
+                .exp_sum(exp_sum_lane0_adj),
+                .sign(mul_sign_lane0), // Use combinatorial sign for cycle 0 alignment
+                .prod_bit(mul_prod_bit_val),
+                .aligned_bit(serial_aligned_bit)
+            );
+
+            // 3. Serial Accumulator
+            // Stores the running sum in a circulating shift register.
+            accumulator_serial #(
+                .WIDTH(ACCUMULATOR_WIDTH)
+            ) acc_serial_inst (
+                .clk(clk),
+                .rst_n(rst_n),
+                .ena(ena),
+                .clear(acc_clear),
+                .strobe(s_strobe),
+                .add_in_bit(serial_aligned_bit),
+                .add_en(s_add_en),
+                .load_en(ena && s_strobe && logical_cycle == capture_cycle),
+                .load_data(final_scaled_result),
+                .data_out_bit(),
+                .parallel_out(serial_acc_parallel_out)
+            );
+        end else begin : gen_no_serial_datapath
+            assign mul_prod_bit_val = 1'b0;
+            assign s_strobe = 1'b0;
+            assign serial_aligned_bit = 1'b0;
+            assign serial_acc_parallel_out = {ACCUMULATOR_WIDTH{1'b0}};
+        end
+    endgenerate
+
     // 3. Aligner Multiplexing
     // We reuse the 'fp8_aligner' for both per-element scaling and final shared scaling to save area.
     localparam ACTUAL_ACC_WIDTH = (ACCUMULATOR_WIDTH > 32) ? ACCUMULATOR_WIDTH : 32;
@@ -900,6 +971,14 @@ module tt_um_chatelao_fp8_multiplier #(
     wire [31:0] final_scaled_result = float32_mode_reg ? f2f_result :
                                       (ENABLE_SHARED_SCALING ? final_scaled_result_sh : acc_out_ext);
 
+    // Select between parallel and serial accumulator outputs.
+    wire [ACTUAL_ACC_WIDTH-1:0] acc_out_p;
+    assign acc_out = (SUPPORT_SERIAL) ? serial_acc_parallel_out[ACTUAL_ACC_WIDTH-1:0] : acc_out_p;
+
+    // Serial-aware load enable for the output shift register.
+    // In serial mode, we sample at the end of the circulation (k_counter == 0).
+    wire load_en_final = ena && strobe && (logical_cycle == capture_cycle);
+
     // Accumulator instance.
     accumulator #(
         .WIDTH(ACCUMULATOR_WIDTH)
@@ -907,14 +986,14 @@ module tt_um_chatelao_fp8_multiplier #(
         .clk(clk),
         .rst_n(rst_n),
         .clear(acc_clear),
-        .en(acc_en),
+        .en(SUPPORT_SERIAL ? 1'b0 : acc_en),
         .overflow_wrap(overflow_wrap),
         .data_in(aligned_combined),
-        .load_en(ena && strobe && logical_cycle == capture_cycle),
+        .load_en(load_en_final),
         .load_data(final_scaled_result),
         .shift_en(ena && strobe && state == STATE_OUTPUT && logical_cycle > capture_cycle && logical_cycle < last_cycle),
         .shift_out(acc_shift_out),
-        .data_out(acc_out)
+        .data_out(acc_out_p)
     );
 
     // --- Probing and Echo Logic ---

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@
 SIM ?= icarus
 TOPLEVEL_LANG ?= verilog
 SRC_DIR = ../src
-PROJECT_SOURCES = project.v fp8_mul.v fp8_mul_lns.v fp8_mul_serial_lns.v fp8_aligner.v fp8_aligner_serial.v accumulator.v lzc40.v fixed_to_float.v
+PROJECT_SOURCES = project.v fp8_mul.v fp8_mul_lns.v fp8_mul_serial_lns.v fp8_aligner.v fp8_aligner_serial.v accumulator.v accumulator_serial.v lzc40.v fixed_to_float.v
 
 ifeq ($(GATES),yes)
 

--- a/test/tb_accumulator_serial.v
+++ b/test/tb_accumulator_serial.v
@@ -7,7 +7,10 @@ module tb_accumulator_serial (
     input  wire ena,
     input  wire clear,
     input  wire strobe,
-    input  wire data_in_bit,
+    input  wire add_in_bit,
+    input  wire add_en,
+    input  wire load_en,
+    input  wire [31:0] load_data,
     output wire data_out_bit,
     output wire [39:0] parallel_out
 );
@@ -20,7 +23,10 @@ module tb_accumulator_serial (
         .ena(ena),
         .clear(clear),
         .strobe(strobe),
-        .data_in_bit(data_in_bit),
+        .add_in_bit(add_in_bit),
+        .add_en(add_en),
+        .load_en(load_en),
+        .load_data(load_data),
         .data_out_bit(data_out_bit),
         .parallel_out(parallel_out)
     );

--- a/test/test_accumulator_serial.py
+++ b/test/test_accumulator_serial.py
@@ -4,12 +4,14 @@ from cocotb.clock import Clock
 import random
 
 async def drive_serial(dut, val, width=40):
+    dut.add_en.value = 1
     for i in range(width):
         dut.strobe.value = 1 if i == 0 else 0
-        dut.data_in_bit.value = (val >> i) & 1
+        dut.add_in_bit.value = (val >> i) & 1
         await RisingEdge(dut.clk)
     dut.strobe.value = 0
-    dut.data_in_bit.value = 0
+    dut.add_in_bit.value = 0
+    dut.add_en.value = 0
 
 @cocotb.test()
 async def test_accumulator_serial_basic(dut):
@@ -22,7 +24,10 @@ async def test_accumulator_serial_basic(dut):
     dut.rst_n.value = 0
     dut.clear.value = 0
     dut.strobe.value = 0
-    dut.data_in_bit.value = 0
+    dut.add_in_bit.value = 0
+    dut.add_en.value = 0
+    dut.load_en.value = 0
+    dut.load_data.value = 0
 
     await RisingEdge(dut.clk)
     await Timer(1, unit="ns")
@@ -57,7 +62,10 @@ async def test_accumulator_serial_random(dut):
     dut.rst_n.value = 0
     dut.clear.value = 0
     dut.strobe.value = 0
-    dut.data_in_bit.value = 0
+    dut.add_in_bit.value = 0
+    dut.add_en.value = 0
+    dut.load_en.value = 0
+    dut.load_data.value = 0
     await RisingEdge(dut.clk)
     dut.rst_n.value = 1
     await RisingEdge(dut.clk)


### PR DESCRIPTION
The bit-serial datapath (aligner and accumulator) is now integrated into the main MAC unit, enabling the `Tiny-Serial` variant. This implementation uses a circulating shift register for accumulation and a delay-line based aligner, significantly reducing the gate count required for internal arithmetic. The unit maintains compatibility with the existing 8-bit streaming protocol by using the parallel accumulator as an output capture buffer. Verified with unit and regression tests.

Fixes #882

---
*PR created automatically by Jules for task [17131815128163507716](https://jules.google.com/task/17131815128163507716) started by @chatelao*