### PR TITLE
Step 4.4: [Integration] Multiplier Swap

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
           elif [ "${{ matrix.config }}" == "Ultra-Tiny" ]; then
             export COMPILE_ARGS="-P tb.ALIGNER_WIDTH=40 -P tb.ACCUMULATOR_WIDTH=40 -P tb.SUPPORT_E5M2=0 -P tb.SUPPORT_MXFP6=0 -P tb.SUPPORT_MXFP4=1 -P tb.SUPPORT_INT8=0 -P tb.SUPPORT_PIPELINING=0 -P tb.SUPPORT_ADV_ROUNDING=0 -P tb.SUPPORT_MIXED_PRECISION=0 -P tb.ENABLE_SHARED_SCALING=0 -P tb.SUPPORT_SERIAL=0 -P tb.SERIAL_K_FACTOR=1"
           elif [ "${{ matrix.config }}" == "Tiny-Serial" ]; then
-            export COMPILE_ARGS="-P tb.SUPPORT_SERIAL=1 -P tb.SERIAL_K_FACTOR=16"
+            export COMPILE_ARGS="-P tb.SUPPORT_SERIAL=1 -P tb.SERIAL_K_FACTOR=8"
             echo "Running Serial Aligner Unit Test..."
             # Use a subshell to run the unit test without overriding top-level parameters
             (unset COMPILE_ARGS && make -f Makefile_aligner_serial)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
           elif [ "${{ matrix.config }}" == "Ultra-Tiny" ]; then
             export COMPILE_ARGS="-P tb.ALIGNER_WIDTH=40 -P tb.ACCUMULATOR_WIDTH=40 -P tb.SUPPORT_E5M2=0 -P tb.SUPPORT_MXFP6=0 -P tb.SUPPORT_MXFP4=1 -P tb.SUPPORT_INT8=0 -P tb.SUPPORT_PIPELINING=0 -P tb.SUPPORT_ADV_ROUNDING=0 -P tb.SUPPORT_MIXED_PRECISION=0 -P tb.ENABLE_SHARED_SCALING=0 -P tb.SUPPORT_SERIAL=0 -P tb.SERIAL_K_FACTOR=1"
           elif [ "${{ matrix.config }}" == "Tiny-Serial" ]; then
-            export COMPILE_ARGS="-P tb.SUPPORT_SERIAL=1 -P tb.SERIAL_K_FACTOR=8"
+            export COMPILE_ARGS="-P tb.SUPPORT_SERIAL=1 -P tb.SERIAL_K_FACTOR=16"
             echo "Running Serial Aligner Unit Test..."
             # Use a subshell to run the unit test without overriding top-level parameters
             (unset COMPILE_ARGS && make -f Makefile_aligner_serial)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ The goal is to achieve an ultra-minimal footprint (< 500 gates) by processing da
 
 - [x] **Step 4.1: [Datapath] Serial Aligner & Accumulator**: Implement individual modules (`fp8_aligner_serial`, `accumulator_serial`).
 - [x] **Step 4.2: [Datapath] Serial LNS Multiplier**: Implement `fp8_mul_serial_lns`.
-- [ ] **Step 4.3: [Integration] Serial Input Buffering**: Implement 8-bit shift registers to feed the serial datapath.
+- [x] **Step 4.3: [Integration] Serial Input Buffering**: Implement 8-bit shift registers to feed the serial datapath.
 - [ ] **Step 4.4: [Integration] Multiplier Swap**: Connect `fp8_mul_serial_lns` in the top-level serial path.
 - [ ] **Step 4.5: [Integration] Aligner Swap**: Connect `fp8_aligner_serial` and align timing.
 - [ ] **Step 4.6: [Integration] Accumulator Swap**: Replace the parallel accumulator in the serial path.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,8 +7,8 @@ The goal is to achieve an ultra-minimal footprint (< 500 gates) by processing da
 
 - [x] **Step 4.1: [Datapath] Serial Aligner & Accumulator**: Implement individual modules (`fp8_aligner_serial`, `accumulator_serial`).
 - [x] **Step 4.2: [Datapath] Serial LNS Multiplier**: Implement `fp8_mul_serial_lns`.
-- [ ] **Step 4.3: [Integration] Serial Input Buffering**: Implement 8-bit shift registers to feed the serial datapath.
-- [ ] **Step 4.4: [Integration] Multiplier Swap**: Connect `fp8_mul_serial_lns` in the top-level serial path.
+- [x] **Step 4.3: [Integration] Serial Input Buffering**: Implement 8-bit shift registers to feed the serial datapath.
+- [x] **Step 4.4: [Integration] Multiplier Swap**: Connect `fp8_mul_serial_lns` in the top-level serial path.
 - [ ] **Step 4.5: [Integration] Aligner Swap**: Connect `fp8_aligner_serial` and align timing.
 - [ ] **Step 4.6: [Integration] Accumulator Swap**: Replace the parallel accumulator in the serial path.
 - [ ] **Step 4.7: [Integration] Serial-to-Parallel Handoff**: Connect the serial accumulator's parallel output to the top-level result capture.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,8 +7,8 @@ The goal is to achieve an ultra-minimal footprint (< 500 gates) by processing da
 
 - [x] **Step 4.1: [Datapath] Serial Aligner & Accumulator**: Implement individual modules (`fp8_aligner_serial`, `accumulator_serial`).
 - [x] **Step 4.2: [Datapath] Serial LNS Multiplier**: Implement `fp8_mul_serial_lns`.
-- [x] **Step 4.3: [Integration] Serial Input Buffering**: Implement 8-bit shift registers to feed the serial datapath.
-- [/] **Step 4.4: [Integration] Multiplier Swap**: Connect `fp8_mul_serial_lns` in the top-level serial path.
+- [ ] **Step 4.3: [Integration] Serial Input Buffering**: Implement 8-bit shift registers to feed the serial datapath.
+- [ ] **Step 4.4: [Integration] Multiplier Swap**: Connect `fp8_mul_serial_lns` in the top-level serial path.
 - [ ] **Step 4.5: [Integration] Aligner Swap**: Connect `fp8_aligner_serial` and align timing.
 - [ ] **Step 4.6: [Integration] Accumulator Swap**: Replace the parallel accumulator in the serial path.
 - [ ] **Step 4.7: [Integration] Serial-to-Parallel Handoff**: Connect the serial accumulator's parallel output to the top-level result capture.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ The goal is to achieve an ultra-minimal footprint (< 500 gates) by processing da
 - [x] **Step 4.1: [Datapath] Serial Aligner & Accumulator**: Implement individual modules (`fp8_aligner_serial`, `accumulator_serial`).
 - [x] **Step 4.2: [Datapath] Serial LNS Multiplier**: Implement `fp8_mul_serial_lns`.
 - [x] **Step 4.3: [Integration] Serial Input Buffering**: Implement 8-bit shift registers to feed the serial datapath.
-- [ ] **Step 4.4: [Integration] Multiplier Swap**: Connect `fp8_mul_serial_lns` in the top-level serial path.
+- [/] **Step 4.4: [Integration] Multiplier Swap**: Connect `fp8_mul_serial_lns` in the top-level serial path.
 - [ ] **Step 4.5: [Integration] Aligner Swap**: Connect `fp8_aligner_serial` and align timing.
 - [ ] **Step 4.6: [Integration] Accumulator Swap**: Replace the parallel accumulator in the serial path.
 - [ ] **Step 4.7: [Integration] Serial-to-Parallel Handoff**: Connect the serial accumulator's parallel output to the top-level result capture.

--- a/src/fp8_mul_serial_lns.v
+++ b/src/fp8_mul_serial_lns.v
@@ -37,12 +37,15 @@ module fp8_mul_serial_lns #(
      */
     reg [3:0] cnt;
     always @(posedge clk or negedge rst_n) begin
-        if (!rst_n) cnt <= 4'd15;
+        if (!rst_n) cnt <= 4'd0;
         else if (ena) begin
-            if (strobe) cnt <= 4'd0; // Reset counter on strobe.
+            if (strobe) cnt <= 4'd0;
             else if (cnt < 4'd15) cnt <= cnt + 4'd1;
         end
     end
+
+    // Use a wire for the current cycle to process strobe-cycle bits immediately.
+    wire [3:0] bit_cnt = cnt;
 
     // --- Helper functions to retrieve format-specific properties ---
     function automatic [3:0] get_m_width(input [2:0] fmt);
@@ -113,7 +116,7 @@ module fp8_mul_serial_lns #(
                      (m_w_b == 4'd1) ? b_m_delay[1] : b_bit;
 
     // bit_bias: The specific bit of the 'bias_offset' we are subtracting in this cycle.
-    wire bit_bias = (cnt >= 4'd3 && cnt < 4'd11) ? bias_offset[cnt - 4'd3] : 1'b0;
+    wire bit_bias = (bit_cnt >= 4'd3 && bit_cnt < 4'd11) ? bias_offset[bit_cnt - 4'd3] : 1'b0;
 
     /**
      * --- Bit-Serial Arithmetic ---
@@ -124,15 +127,19 @@ module fp8_mul_serial_lns #(
     reg carry_adder;
     reg carry_sub;
 
+    // Carries must be bypassed on strobe cycle to process bit 0 immediately.
+    wire c_add_in = strobe ? 1'b0 : carry_adder;
+    wire c_sub_in = strobe ? 1'b1 : carry_sub;
+
     // Stage 1: Add LogA and LogB bits.
-    wire s1_a = (cnt < 4'd12) ? a_aligned : 1'b0;
-    wire s1_b = (cnt < 4'd12) ? b_aligned : 1'b0;
-    wire sum_s1 = s1_a ^ s1_b ^ carry_adder;
-    wire carry_s1_next = (s1_a & s1_b) | (carry_adder & (s1_a ^ s1_b));
+    wire s1_a = (bit_cnt < 4'd12) ? a_aligned : 1'b0;
+    wire s1_b = (bit_cnt < 4'd12) ? b_aligned : 1'b0;
+    wire sum_s1 = s1_a ^ s1_b ^ c_add_in;
+    wire carry_s1_next = (s1_a & s1_b) | (c_add_in & (s1_a ^ s1_b));
 
     // Stage 2: Subtract the bias bit.
-    wire res_s2 = sum_s1 ^ (~bit_bias) ^ carry_sub;
-    wire carry_s2_next = (sum_s1 & (~bit_bias)) | (carry_sub & (sum_s1 ^ (~bit_bias)));
+    wire res_s2 = sum_s1 ^ (~bit_bias) ^ c_sub_in;
+    wire carry_s2_next = (sum_s1 & (~bit_bias)) | (c_sub_in & (sum_s1 ^ (~bit_bias)));
 
     // Sequential update of carry bits.
     always @(posedge clk or negedge rst_n) begin
@@ -170,30 +177,30 @@ module fp8_mul_serial_lns #(
             a_m_any_nonzero <= 1'b0; b_m_any_nonzero <= 1'b0;
         end else if (ena) begin
             if (strobe) begin
+                // Initial bit processing on strobe (bit 0)
                 sign_a <= 1'b0; sign_b <= 1'b0;
-                a_any_nonzero <= 1'b0; b_any_nonzero <= 1'b0;
+                a_any_nonzero <= a_bit; b_any_nonzero <= b_bit;
                 a_e_all_ones <= 1'b1; b_e_all_ones <= 1'b1;
-                a_m_any_nonzero <= 1'b0; b_m_any_nonzero <= 1'b0;
+                a_m_any_nonzero <= (m_w_a > 0) ? a_bit : 1'b0;
+                b_m_any_nonzero <= (m_w_b > 0) ? b_bit : 1'b0;
             end else if (cnt < 4'd15) begin
-                // Capture sign bits at their format-specific positions.
-                if (cnt == s_p_a) sign_a <= a_bit;
-                if (cnt == s_p_b) sign_b <= b_bit;
+                // Sequential bit processing (bits 1-14)
+                // Use cnt + 1 because this posedge samples the bit corresponding to cnt+1
+                if (cnt + 4'd1 == s_p_a) sign_a <= a_bit;
+                if (cnt + 4'd1 == s_p_b) sign_b <= b_bit;
 
-                // Track if any bit is non-zero (to detect actual zero values).
-                if (cnt < s_p_a) a_any_nonzero <= a_any_nonzero | a_bit;
-                if (cnt < s_p_b) b_any_nonzero <= b_any_nonzero | b_bit;
+                if (cnt + 4'd1 < s_p_a) a_any_nonzero <= a_any_nonzero | a_bit;
+                if (cnt + 4'd1 < s_p_b) b_any_nonzero <= b_any_nonzero | b_bit;
 
-                // Monitor exponent bits for NaN/Inf detection.
-                if (cnt >= m_w_a && cnt < s_p_a) begin
+                if (cnt + 4'd1 >= m_w_a && cnt + 4'd1 < s_p_a) begin
                     if (!a_bit) a_e_all_ones <= 1'b0;
                 end
-                if (cnt >= m_w_b && cnt < s_p_b) begin
+                if (cnt + 4'd1 >= m_w_b && cnt + 4'd1 < s_p_b) begin
                     if (!b_bit) b_e_all_ones <= 1'b0;
                 end
 
-                // Monitor mantissa bits for NaN/Inf detection.
-                if (cnt < m_w_a) a_m_any_nonzero <= a_m_any_nonzero | a_bit;
-                if (cnt < m_w_b) b_m_any_nonzero <= b_m_any_nonzero | b_bit;
+                if (cnt + 4'd1 < m_w_a) a_m_any_nonzero <= a_m_any_nonzero | a_bit;
+                if (cnt + 4'd1 < m_w_b) b_m_any_nonzero <= b_m_any_nonzero | b_bit;
             end
         end
     end
@@ -208,6 +215,8 @@ module fp8_mul_serial_lns #(
     wire a_is_nan_inf = ( (format_a == 3'b001 && a_e_all_ones) || (format_a == 3'b000 && a_e_all_ones && a_m_any_nonzero) );
     wire b_is_nan_inf = ( (format_b == 3'b001 && b_e_all_ones) || (format_b == 3'b000 && b_e_all_ones && b_m_any_nonzero) );
 
+    // Robust special value logic: Only valid during stream.
+    // Note: E4M3 (fmt 0) NaN is exactly 0x7F or 0xFF. For simplicity we check exp=15 and m != 0.
     assign special_nan = (a_is_nan_inf && (format_a != 3'b001 || a_m_any_nonzero)) ||
                          (b_is_nan_inf && (format_b != 3'b001 || b_m_any_nonzero));
     assign special_inf = (a_is_nan_inf && format_a == 3'b001 && !a_m_any_nonzero) ||

--- a/src/fp8_mul_serial_lns.v
+++ b/src/fp8_mul_serial_lns.v
@@ -99,11 +99,22 @@ module fp8_mul_serial_lns #(
     // --- Operand Alignment ---
     // Since different formats have different mantissa widths, we delay bits
     // to align their binary points before serial addition.
+    // MW=3 (E4M3) -> No delay. MW=2 (E5M2) -> 1 cycle delay. MW=1 (E2M1) -> 2 cycles delay.
     reg [1:0] a_m_delay, b_m_delay;
-    always @(posedge clk) begin
-        if (ena) begin
-            a_m_delay <= {a_m_delay[0], a_bit};
-            b_m_delay <= {b_m_delay[0], b_bit};
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            a_m_delay <= 2'b00;
+            b_m_delay <= 2'b00;
+        end else if (ena) begin
+            if (strobe) begin
+                // On strobe, capture the first bit but clear higher delay stages
+                // to ensure previous element bits don't leak into current calculation.
+                a_m_delay <= {1'b0, a_bit};
+                b_m_delay <= {1'b0, b_bit};
+            end else begin
+                a_m_delay <= {a_m_delay[0], a_bit};
+                b_m_delay <= {b_m_delay[0], b_bit};
+            end
         end
     end
 
@@ -144,6 +155,8 @@ module fp8_mul_serial_lns #(
             carry_adder <= 1'b0;
             carry_sub <= 1'b1;
         end else if (ena) begin
+            // Carry is updated every cycle, including strobe.
+            // On strobe, it captures the carry from bit 0 to be used for bit 1.
             if (bit_cnt < 4'd15) begin
                 carry_adder <= carry_s1_next;
                 carry_sub <= carry_s2_next;

--- a/src/fp8_mul_serial_lns.v
+++ b/src/fp8_mul_serial_lns.v
@@ -37,15 +37,15 @@ module fp8_mul_serial_lns #(
      */
     reg [3:0] cnt;
     always @(posedge clk or negedge rst_n) begin
-        if (!rst_n) cnt <= 4'd0;
+        if (!rst_n) cnt <= 4'd15;
         else if (ena) begin
-            if (strobe) cnt <= 4'd0;
+            if (strobe) cnt <= 4'd0; // Reset counter on strobe.
             else if (cnt < 4'd15) cnt <= cnt + 4'd1;
         end
     end
 
-    // Use a wire for the current cycle to process strobe-cycle bits immediately.
-    wire [3:0] bit_cnt = cnt;
+    // bit_cnt: 0 on strobe cycle, 1..15 on subsequent cycles.
+    wire [3:0] bit_cnt = strobe ? 4'd0 : (cnt < 4'd15 ? cnt + 4'd1 : 4'd15);
 
     // --- Helper functions to retrieve format-specific properties ---
     function automatic [3:0] get_m_width(input [2:0] fmt);
@@ -120,9 +120,6 @@ module fp8_mul_serial_lns #(
 
     /**
      * --- Bit-Serial Arithmetic ---
-     * This section implements the serial equivalent of (LogA + LogB - Bias).
-     * Stage 1: Serial Adder for (LogA + LogB).
-     * Stage 2: Serial Subtractor for the Bias offset.
      */
     reg carry_adder;
     reg carry_sub;
@@ -145,12 +142,9 @@ module fp8_mul_serial_lns #(
     always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin
             carry_adder <= 1'b0;
-            carry_sub <= 1'b1; // Initial carry for subtraction (2's complement style).
+            carry_sub <= 1'b1;
         end else if (ena) begin
-            if (strobe) begin
-                carry_adder <= 1'b0;
-                carry_sub <= 1'b1;
-            end else if (cnt < 4'd15) begin
+            if (bit_cnt < 4'd15) begin
                 carry_adder <= carry_s1_next;
                 carry_sub <= carry_s2_next;
             end
@@ -177,30 +171,27 @@ module fp8_mul_serial_lns #(
             a_m_any_nonzero <= 1'b0; b_m_any_nonzero <= 1'b0;
         end else if (ena) begin
             if (strobe) begin
-                // Initial bit processing on strobe (bit 0)
                 sign_a <= 1'b0; sign_b <= 1'b0;
                 a_any_nonzero <= a_bit; b_any_nonzero <= b_bit;
                 a_e_all_ones <= 1'b1; b_e_all_ones <= 1'b1;
                 a_m_any_nonzero <= (m_w_a > 0) ? a_bit : 1'b0;
                 b_m_any_nonzero <= (m_w_b > 0) ? b_bit : 1'b0;
-            end else if (cnt < 4'd15) begin
-                // Sequential bit processing (bits 1-14)
-                // Use cnt + 1 because this posedge samples the bit corresponding to cnt+1
-                if (cnt + 4'd1 == s_p_a) sign_a <= a_bit;
-                if (cnt + 4'd1 == s_p_b) sign_b <= b_bit;
+            end else if (bit_cnt < 4'd15) begin
+                if (bit_cnt == s_p_a) sign_a <= a_bit;
+                if (bit_cnt == s_p_b) sign_b <= b_bit;
 
-                if (cnt + 4'd1 < s_p_a) a_any_nonzero <= a_any_nonzero | a_bit;
-                if (cnt + 4'd1 < s_p_b) b_any_nonzero <= b_any_nonzero | b_bit;
+                if (bit_cnt < s_p_a) a_any_nonzero <= a_any_nonzero | a_bit;
+                if (bit_cnt < s_p_b) b_any_nonzero <= b_any_nonzero | b_bit;
 
-                if (cnt + 4'd1 >= m_w_a && cnt + 4'd1 < s_p_a) begin
+                if (bit_cnt >= m_w_a && bit_cnt < s_p_a) begin
                     if (!a_bit) a_e_all_ones <= 1'b0;
                 end
-                if (cnt + 4'd1 >= m_w_b && cnt + 4'd1 < s_p_b) begin
+                if (bit_cnt >= m_w_b && bit_cnt < s_p_b) begin
                     if (!b_bit) b_e_all_ones <= 1'b0;
                 end
 
-                if (cnt + 4'd1 < m_w_a) a_m_any_nonzero <= a_m_any_nonzero | a_bit;
-                if (cnt + 4'd1 < m_w_b) b_m_any_nonzero <= b_m_any_nonzero | b_bit;
+                if (bit_cnt < m_w_a) a_m_any_nonzero <= a_m_any_nonzero | a_bit;
+                if (bit_cnt < m_w_b) b_m_any_nonzero <= b_m_any_nonzero | b_bit;
             end
         end
     end
@@ -215,8 +206,6 @@ module fp8_mul_serial_lns #(
     wire a_is_nan_inf = ( (format_a == 3'b001 && a_e_all_ones) || (format_a == 3'b000 && a_e_all_ones && a_m_any_nonzero) );
     wire b_is_nan_inf = ( (format_b == 3'b001 && b_e_all_ones) || (format_b == 3'b000 && b_e_all_ones && b_m_any_nonzero) );
 
-    // Robust special value logic: Only valid during stream.
-    // Note: E4M3 (fmt 0) NaN is exactly 0x7F or 0xFF. For simplicity we check exp=15 and m != 0.
     assign special_nan = (a_is_nan_inf && (format_a != 3'b001 || a_m_any_nonzero)) ||
                          (b_is_nan_inf && (format_b != 3'b001 || b_m_any_nonzero));
     assign special_inf = (a_is_nan_inf && format_a == 3'b001 && !a_m_any_nonzero) ||

--- a/src/project.v
+++ b/src/project.v
@@ -425,9 +425,8 @@ module tt_um_chatelao_fp8_multiplier #(
     wire actual_input_buffering = (SUPPORT_INPUT_BUFFERING && !SUPPORT_VECTOR_PACKING && packed_mode && (format_a == 3'b100) && (format_b_val == 3'b100));
     wire actual_packed_serial = (SUPPORT_PACKED_SERIAL && !SUPPORT_VECTOR_PACKING && !actual_input_buffering && packed_mode && (format_a == 3'b100) && (format_b_val == 3'b100));
     wire [COUNTER_WIDTH-1:0] last_stream_cycle = actual_packed_mode ? 6'd18 : 6'd34;
-    // capture_cycle and last_cycle are shifted based on the total datapath delay to ensure all elements are accumulated.
-    wire [COUNTER_WIDTH-1:0] capture_cycle     = (actual_packed_mode ? 6'd20 : 6'd36) + (SUPPORT_SERIAL ? 6'd1 : 6'd0);
-    wire [COUNTER_WIDTH-1:0] last_cycle        = (actual_packed_mode ? 6'd24 : 6'd40) + (SUPPORT_SERIAL ? 6'd1 : 6'd0);
+    wire [COUNTER_WIDTH-1:0] capture_cycle     = actual_packed_mode ? 6'd20 : 6'd36;
+    wire [COUNTER_WIDTH-1:0] last_cycle        = actual_packed_mode ? 6'd24 : 6'd40;
 
     // FSM State derivation based on the current logical cycle.
     wire [1:0] state = (logical_cycle == 6'd0) ? STATE_IDLE :
@@ -829,9 +828,8 @@ module tt_um_chatelao_fp8_multiplier #(
     // These capture any NaNs or Infinities that occur anywhere in the block.
     reg nan_sticky, inf_pos_sticky, inf_neg_sticky;
     // Optimization: Use a constant cycle window for element sticky latching to fix timing and avoid metadata latching.
-    // Standard elements at 3..last_stream_cycle. Pipelined products at 4..last_stream_cycle+1.
-    // This avoids Cycle 1/2 (Scales) and Cycle 3 (Pipelined garbage).
-    wire sticky_latch_en = (logical_cycle >= (SUPPORT_PIPELINING ? 6'd4 : 6'd3)) && (logical_cycle <= last_stream_cycle + (SUPPORT_PIPELINING ? 6'd1 : 6'd0));
+    // Window is shifted by the total datapath delay.
+    wire sticky_latch_en = (logical_cycle >= (6'd3 + DATAPATH_DELAY)) && (logical_cycle <= (last_stream_cycle + DATAPATH_DELAY));
 
     always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin

--- a/src/project.v
+++ b/src/project.v
@@ -32,7 +32,7 @@ module tt_um_chatelao_fp8_multiplier #(
     parameter SUPPORT_INPUT_BUFFERING = 1,
     parameter SUPPORT_MX_PLUS = 1,
     parameter SUPPORT_SERIAL = 0,
-    parameter SERIAL_K_FACTOR = 16,
+    parameter SERIAL_K_FACTOR = 8,
     parameter ENABLE_SHARED_SCALING = 1,
     parameter USE_LNS_MUL = 0,
     parameter USE_LNS_MUL_PRECISE = 1,
@@ -64,6 +64,15 @@ module tt_um_chatelao_fp8_multiplier #(
     wire strobe; // Used to handle bit-serial timing if enabled.
     wire [COUNTER_WIDTH-1:0] logical_cycle;
 
+    // --- Bit-Serial Control and Status Wires (for Hierarchical Access) ---
+    wire [COUNTER_WIDTH-1:0] serial_k_counter;
+    wire serial_mul_nan_lane0;
+    wire serial_mul_inf_lane0;
+    wire serial_mul_sign_lane0;
+    wire serial_mul_zero_lane0;
+    wire [15:0] serial_mul_res_lane0;
+    wire signed [7:0] serial_mul_exp_lane0;
+
     // Control logic for serial vs parallel operation.
     generate
         if (SUPPORT_SERIAL) begin : gen_serial_ctrl
@@ -74,9 +83,107 @@ module tt_um_chatelao_fp8_multiplier #(
             end
             assign strobe = (k_counter == {COUNTER_WIDTH{1'b0}});
             assign logical_cycle = cycle_count;
+            assign serial_k_counter = k_counter;
         end else begin : gen_no_serial_ctrl
             assign strobe = 1'b1;
             assign logical_cycle = cycle_count;
+            assign serial_k_counter = {COUNTER_WIDTH{1'b0}};
+        end
+    endgenerate
+
+    // --- Bit-Serial Multiplier and Deserializer ---
+    generate
+        if (SUPPORT_SERIAL) begin : serial_mul_gen
+            wire mul_res_bit_lane0_serial;
+            wire mul_nan_lane0_wire;
+            wire mul_inf_lane0_wire;
+            wire mul_sign_lane0_wire;
+            wire mul_zero_lane0_wire;
+
+            fp8_mul_serial_lns #(
+                .EXP_SUM_WIDTH(EXP_SUM_WIDTH)
+            ) multiplier_lane0_serial (
+                .clk(clk),
+                .rst_n(rst_n),
+                .ena(ena),
+                .strobe(strobe),
+                .a_bit(a_bit_serial),
+                .b_bit(b_bit_serial),
+                .format_a(format_a),
+                .format_b(format_b_val),
+                .res_bit(mul_res_bit_lane0_serial),
+                .sign_out(mul_sign_lane0_wire),
+                .special_zero(mul_zero_lane0_wire),
+                .special_nan(mul_nan_lane0_wire),
+                .special_inf(mul_inf_lane0_wire)
+            );
+
+            // Mitchell LNS Serial result is captured bit-by-bit.
+            // Result bits are valid during the serial window (11 bits total).
+            reg [10:0] mul_res_shift_reg;
+            always @(posedge clk or negedge rst_n) begin
+                if (!rst_n) mul_res_shift_reg <= 11'd0;
+                else if (ena) begin
+                    if (strobe) mul_res_shift_reg <= 11'd0;
+                    else if (serial_k_counter >= 1 && serial_k_counter <= 11)
+                        mul_res_shift_reg <= {mul_res_bit_lane0_serial, mul_res_shift_reg[10:1]};
+                end
+            end
+
+            // Reconstruct Mitchell result for the parallel aligner.
+            // Log2(Res) = I.F => Res \approx 2^I * (1 + F).
+            // mul_res_shift_reg[2:0] = F, mul_res_shift_reg[10:3] = I.
+            // Alignment: Shift by 3 to place binary point at bit 6, matching parallel multiplier convention.
+            wire [15:0] mitchell_prod = { 9'd0, 1'b1, mul_res_shift_reg[2:0], 3'd0 };
+            wire signed [7:0] mitchell_exp  = $signed(mul_res_shift_reg[10:3]);
+
+            // Capture stable results into registers to hold them through the 'strobe' cycle.
+            reg [15:0] res_captured;
+            reg signed [7:0] exp_captured;
+            reg nan_captured, inf_captured, sign_captured, zero_captured;
+            always @(posedge clk or negedge rst_n) begin
+                if (!rst_n) begin
+                    res_captured <= 16'd0;
+                    exp_captured <= 8'd0;
+                    nan_captured <= 1'b0;
+                    inf_captured <= 1'b0;
+                    sign_captured <= 1'b0;
+                    zero_captured <= 1'b1;
+                end else if (ena) begin
+                    // Capture after bit-serial processing is finished (Last cycle of the factor)
+                    // Gate with STATE_STREAM to avoid false triggers from metadata/scales.
+                    if (serial_k_counter == (SERIAL_K_FACTOR[COUNTER_WIDTH-1:0] - 1) && state == STATE_STREAM) begin
+                        res_captured <= mitchell_prod;
+                        exp_captured <= mitchell_exp;
+                        nan_captured  <= mul_nan_lane0_wire;
+                        inf_captured  <= mul_inf_lane0_wire;
+                        sign_captured <= mul_sign_lane0_wire;
+                        zero_captured <= mul_zero_lane0_wire;
+                    end else if (strobe && logical_cycle == 6'd0) begin
+                        // Reset captured flags for a new block
+                        res_captured <= 16'd0;
+                        exp_captured <= 8'd0;
+                        nan_captured <= 1'b0;
+                        inf_captured <= 1'b0;
+                        sign_captured <= 1'b0;
+                        zero_captured <= 1'b1;
+                    end
+                end
+            end
+
+            assign serial_mul_res_lane0  = res_captured;
+            assign serial_mul_exp_lane0  = exp_captured;
+            assign serial_mul_nan_lane0   = nan_captured;
+            assign serial_mul_inf_lane0   = inf_captured;
+            assign serial_mul_sign_lane0  = sign_captured;
+            assign serial_mul_zero_lane0  = zero_captured;
+        end else begin : no_serial_mul
+            assign serial_mul_sign_lane0 = 1'b0;
+            assign serial_mul_zero_lane0 = 1'b0;
+            assign serial_mul_nan_lane0  = 1'b0;
+            assign serial_mul_inf_lane0  = 1'b0;
+            assign serial_mul_res_lane0  = 16'd0;
+            assign serial_mul_exp_lane0  = 8'd0;
         end
     endgenerate
 
@@ -386,19 +493,65 @@ module tt_um_chatelao_fp8_multiplier #(
     localparam EXP_SUM_WIDTH = (SUPPORT_E5M2) ? 7 :
                                (SUPPORT_E4M3 || SUPPORT_INT8 || SUPPORT_MX_PLUS) ? 6 : 5;
 
+    // Total datapath delay: 1 cycle for serial deserialization (if enabled) + 1 cycle for optional pipelining.
+    localparam DATAPATH_DELAY = (SUPPORT_SERIAL ? 6'd1 : 6'd0) + (SUPPORT_PIPELINING ? 6'd1 : 6'd0);
+
     // Control signal to enable the accumulator only when valid products are arriving.
-    wire acc_en    = strobe && (SUPPORT_PIPELINING ?
-                     ((logical_cycle >= 6'd4 && logical_cycle <= last_stream_cycle + 6'd1) && (state == STATE_STREAM || state == STATE_OUTPUT)) :
-                     ((logical_cycle >= 6'd3 && logical_cycle <= last_stream_cycle) && (state == STATE_STREAM)));
+    wire acc_en    = strobe && (logical_cycle >= (6'd3 + DATAPATH_DELAY)) && (logical_cycle <= (last_stream_cycle + DATAPATH_DELAY)) && (state != STATE_IDLE && state != STATE_LOAD_SCALE);
 
     // Multiplier results wires.
-    wire [15:0] mul_prod_lane0, mul_prod_lane1;
+    wire [15:0] mul_prod_lane0_par, mul_prod_lane1_par;
+    wire signed [EXP_SUM_WIDTH-1:0] mul_exp_sum_lane0_par, mul_exp_sum_lane1_par;
+    wire mul_sign_lane0_par, mul_sign_lane1_par;
+    wire mul_nan_lane0_par, mul_nan_lane1_par;
+    wire mul_inf_lane0_par, mul_inf_lane1_par;
+
+    wire [15:0] mul_prod_lane0;
+    wire [15:0] mul_prod_lane1;
+    wire signed [EXP_SUM_WIDTH-1:0] mul_exp_sum_lane0;
+    wire signed [EXP_SUM_WIDTH-1:0] mul_exp_sum_lane1;
+    wire mul_sign_lane0;
+    wire mul_sign_lane1;
+    wire mul_nan_lane0;
+    wire mul_nan_lane1;
+    wire mul_inf_lane0;
+    wire mul_inf_lane1;
+
+    generate
+        if (SUPPORT_SERIAL) begin : gen_serial_mux
+            assign mul_prod_lane0 = serial_mul_zero_lane0 ? 16'd0 : serial_mul_res_lane0;
+            assign mul_prod_lane1 = 16'd0;
+            // Robust sign extension for exp_sum:
+            assign mul_exp_sum_lane0 = (EXP_SUM_WIDTH >= 8) ? $signed(serial_mul_exp_lane0) : serial_mul_exp_lane0[EXP_SUM_WIDTH-1:0];
+            assign mul_exp_sum_lane1 = {EXP_SUM_WIDTH{1'b0}};
+            assign mul_sign_lane0 = serial_mul_sign_lane0;
+            assign mul_sign_lane1 = 1'b0;
+            assign mul_nan_lane0  = serial_mul_nan_lane0;
+            assign mul_nan_lane1  = 1'b0;
+            assign mul_inf_lane0  = serial_mul_inf_lane0;
+            assign mul_inf_lane1  = 1'b0;
+        end else begin : gen_par_mux
+            assign mul_prod_lane0 = mul_prod_lane0_par;
+            assign mul_prod_lane1 = mul_prod_lane1_par;
+            assign mul_exp_sum_lane0 = mul_exp_sum_lane0_par;
+            assign mul_exp_sum_lane1 = mul_exp_sum_lane1_par;
+            assign mul_sign_lane0 = mul_sign_lane0_par;
+            assign mul_sign_lane1 = mul_sign_lane1_par;
+            assign mul_nan_lane0  = mul_nan_lane0_par;
+            assign mul_nan_lane1  = mul_nan_lane1_par;
+            assign mul_inf_lane0  = mul_inf_lane0_par;
+            assign mul_inf_lane1  = mul_inf_lane1_par;
+        end
+    endgenerate
+
+    wire [15:0] mul_prod_lane0_val, mul_prod_lane1_val;
+    wire signed [EXP_SUM_WIDTH-1:0] mul_exp_sum_lane0_val, mul_exp_sum_lane1_val;
+    wire mul_sign_lane0_val, mul_sign_lane1_val;
+    wire mul_nan_lane0_val, mul_nan_lane1_val;
+    wire mul_inf_lane0_val, mul_inf_lane1_val;
+
     // Extended product wires for aligner compatibility
     wire [ALIGNER_WIDTH-1:0] mul_prod_lane0_ext = { {(ALIGNER_WIDTH-16){1'b0}}, mul_prod_lane0_val };
-    wire signed [EXP_SUM_WIDTH-1:0] mul_exp_sum_lane0, mul_exp_sum_lane1;
-    wire mul_sign_lane0, mul_sign_lane1;
-    wire mul_nan_lane0, mul_nan_lane1;
-    wire mul_inf_lane0, mul_inf_lane1;
 
     // Buffer for packed elements in bit-serial modes.
     reg [3:0] packed_a_buf, packed_b_buf;
@@ -455,91 +608,9 @@ module tt_um_chatelao_fp8_multiplier #(
     /* verilator lint_on UNUSEDSIGNAL */
 
 
-    // Instantiate Multipliers (either standard, LNS parallel, or LNS serial).
+    // Instantiate Multipliers (either standard or LNS based on parameters).
     generate
-        if (SUPPORT_SERIAL) begin : serial_mul_gen
-            wire mul_res_bit_lane0;
-            wire mul_sign_lane0_serial;
-            wire mul_zero_lane0_serial;
-            wire mul_nan_lane0_serial;
-            wire mul_inf_lane0_serial;
-
-            fp8_mul_serial_lns #(
-                .EXP_SUM_WIDTH(EXP_SUM_WIDTH)
-            ) multiplier_lane0 (
-                .clk(clk),
-                .rst_n(rst_n),
-                .ena(ena),
-                .strobe(strobe),
-                .a_bit(a_bit_serial),
-                .b_bit(b_bit_serial),
-                .format_a(format_a),
-                .format_b(format_b_val),
-                .res_bit(mul_res_bit_lane0),
-                .sign_out(mul_sign_lane0_serial),
-                .special_zero(mul_zero_lane0_serial),
-                .special_nan(mul_nan_lane0_serial),
-                .special_inf(mul_inf_lane0_serial)
-            );
-
-            // Deserializer for Mitchell LNS result (11 bits: 3-bit Mantissa, 8-bit Exponent)
-            reg [10:0] mul_res_shift_reg;
-            always @(posedge clk or negedge rst_n) begin
-                if (!rst_n) mul_res_shift_reg <= 11'd0;
-                else if (ena) begin
-                    if (gen_serial_ctrl.k_counter >= 6'd1 && gen_serial_ctrl.k_counter <= 6'd11)
-                        mul_res_shift_reg <= {mul_res_bit_lane0, mul_res_shift_reg[10:1]};
-                end
-            end
-
-            // Capture product and flags at strobe (end of logical cycle)
-            reg [15:0] mul_prod_lane0_reg_serial;
-            reg signed [EXP_SUM_WIDTH-1:0] mul_exp_sum_lane0_reg_serial;
-            reg mul_sign_lane0_reg_serial;
-            reg mul_nan_lane0_reg_serial;
-            reg mul_inf_lane0_reg_serial;
-            reg mul_zero_lane0_reg_serial;
-
-            always @(posedge clk or negedge rst_n) begin
-                if (!rst_n) begin
-                    mul_prod_lane0_reg_serial <= 16'd0;
-                    mul_exp_sum_lane0_reg_serial <= {EXP_SUM_WIDTH{1'b0}};
-                    mul_sign_lane0_reg_serial <= 1'b0;
-                    mul_nan_lane0_reg_serial <= 1'b0;
-                    mul_inf_lane0_reg_serial <= 1'b0;
-                    mul_zero_lane0_reg_serial <= 1'b1;
-                end else if (ena && strobe) begin
-                    if (logical_cycle == 6'd0) begin
-                        mul_prod_lane0_reg_serial <= 16'd0;
-                        mul_exp_sum_lane0_reg_serial <= {EXP_SUM_WIDTH{1'b0}};
-                        mul_sign_lane0_reg_serial <= 1'b0;
-                        mul_nan_lane0_reg_serial <= 1'b0;
-                        mul_inf_lane0_reg_serial <= 1'b0;
-                        mul_zero_lane0_reg_serial <= 1'b1;
-                    end else if (logical_cycle >= 6'd3 && logical_cycle <= last_stream_cycle) begin
-                        mul_sign_lane0_reg_serial <= mul_sign_lane0_serial;
-                        mul_zero_lane0_reg_serial <= mul_zero_lane0_serial;
-                        mul_nan_lane0_reg_serial <= mul_nan_lane0_serial;
-                        mul_inf_lane0_reg_serial <= mul_inf_lane0_serial;
-                    mul_prod_lane0_reg_serial <= mul_zero_lane0_serial ? 16'd0 : {9'd0, 1'b1, mul_res_shift_reg[10:8], 3'd0};
-                    mul_exp_sum_lane0_reg_serial <= mul_zero_lane0_serial ? {EXP_SUM_WIDTH{1'b0}} : $signed(mul_res_shift_reg[7:0]);
-                    end
-                end
-            end
-
-            assign mul_prod_lane0 = mul_prod_lane0_reg_serial;
-            assign mul_exp_sum_lane0 = mul_exp_sum_lane0_reg_serial;
-            assign mul_sign_lane0 = mul_sign_lane0_reg_serial;
-            assign mul_nan_lane0 = mul_nan_lane0_reg_serial | (mul_inf_lane0_reg_serial && mul_zero_lane0_reg_serial);
-            assign mul_inf_lane0 = mul_inf_lane0_reg_serial && !mul_zero_lane0_reg_serial;
-
-            assign mul_prod_lane1 = 16'd0;
-            assign mul_exp_sum_lane1 = {EXP_SUM_WIDTH{1'b0}};
-            assign mul_sign_lane1 = 1'b0;
-            assign mul_nan_lane1 = 1'b0;
-            assign mul_inf_lane1 = 1'b0;
-
-        end else if (USE_LNS_MUL) begin : lns_gen
+        if (USE_LNS_MUL) begin : lns_gen
             fp8_mul_lns #(
                 .SUPPORT_E4M3(SUPPORT_E4M3),
                 .SUPPORT_E5M2(SUPPORT_E5M2),
@@ -558,11 +629,11 @@ module tt_um_chatelao_fp8_multiplier #(
                 .is_bm_a(is_bm_a_lane0_raw),
                 .is_bm_b(is_bm_b_lane0_raw),
                 .lns_mode(lns_mode_reg),
-                .prod(mul_prod_lane0),
-                .exp_sum(mul_exp_sum_lane0),
-                .sign(mul_sign_lane0),
-                .nan(mul_nan_lane0),
-                .inf(mul_inf_lane0)
+                .prod(mul_prod_lane0_par),
+                .exp_sum(mul_exp_sum_lane0_par),
+                .sign(mul_sign_lane0_par),
+                .nan(mul_nan_lane0_par),
+                .inf(mul_inf_lane0_par)
             );
             if (SUPPORT_VECTOR_PACKING) begin : gen_lane1
                 fp8_mul_lns #(
@@ -583,18 +654,18 @@ module tt_um_chatelao_fp8_multiplier #(
                     .is_bm_a(is_bm_a_lane1_raw),
                     .is_bm_b(is_bm_b_lane1_raw),
                     .lns_mode(lns_mode_reg),
-                    .prod(mul_prod_lane1),
-                    .exp_sum(mul_exp_sum_lane1),
-                    .sign(mul_sign_lane1),
-                    .nan(mul_nan_lane1),
-                    .inf(mul_inf_lane1)
+                .prod(mul_prod_lane1_par),
+                .exp_sum(mul_exp_sum_lane1_par),
+                .sign(mul_sign_lane1_par),
+                .nan(mul_nan_lane1_par),
+                .inf(mul_inf_lane1_par)
                 );
             end else begin : no_lane1
-                assign mul_prod_lane1 = 16'd0;
-                assign mul_exp_sum_lane1 = {EXP_SUM_WIDTH{1'b0}};
-                assign mul_sign_lane1 = 1'b0;
-                assign mul_nan_lane1 = 1'b0;
-                assign mul_inf_lane1 = 1'b0;
+                assign mul_prod_lane1_par = 16'd0;
+                assign mul_exp_sum_lane1_par = {EXP_SUM_WIDTH{1'b0}};
+                assign mul_sign_lane1_par = 1'b0;
+                assign mul_nan_lane1_par = 1'b0;
+                assign mul_inf_lane1_par = 1'b0;
             end
         end else begin : std_gen
             fp8_mul #(
@@ -614,11 +685,11 @@ module tt_um_chatelao_fp8_multiplier #(
                 .is_bm_a(is_bm_a_lane0_raw),
                 .is_bm_b(is_bm_b_lane0_raw),
                 .lns_mode(lns_mode_reg),
-                .prod(mul_prod_lane0),
-                .exp_sum(mul_exp_sum_lane0),
-                .sign(mul_sign_lane0),
-                .nan(mul_nan_lane0),
-                .inf(mul_inf_lane0)
+                .prod(mul_prod_lane0_par),
+                .exp_sum(mul_exp_sum_lane0_par),
+                .sign(mul_sign_lane0_par),
+                .nan(mul_nan_lane0_par),
+                .inf(mul_inf_lane0_par)
             );
             if (SUPPORT_VECTOR_PACKING) begin : gen_lane1
                 fp8_mul #(
@@ -638,31 +709,23 @@ module tt_um_chatelao_fp8_multiplier #(
                     .is_bm_a(is_bm_a_lane1_raw),
                     .is_bm_b(is_bm_b_lane1_raw),
                     .lns_mode(lns_mode_reg),
-                    .prod(mul_prod_lane1),
-                    .exp_sum(mul_exp_sum_lane1),
-                    .sign(mul_sign_lane1),
-                    .nan(mul_nan_lane1),
-                    .inf(mul_inf_lane1)
+                .prod(mul_prod_lane1_par),
+                .exp_sum(mul_exp_sum_lane1_par),
+                .sign(mul_sign_lane1_par),
+                .nan(mul_nan_lane1_par),
+                .inf(mul_inf_lane1_par)
                 );
             end else begin : no_lane1
-                assign mul_prod_lane1 = 16'd0;
-                assign mul_exp_sum_lane1 = {EXP_SUM_WIDTH{1'b0}};
-                assign mul_sign_lane1 = 1'b0;
-                assign mul_nan_lane1 = 1'b0;
-                assign mul_inf_lane1 = 1'b0;
+                assign mul_prod_lane1_par = 16'd0;
+                assign mul_exp_sum_lane1_par = {EXP_SUM_WIDTH{1'b0}};
+                assign mul_sign_lane1_par = 1'b0;
+                assign mul_nan_lane1_par = 1'b0;
+                assign mul_inf_lane1_par = 1'b0;
             end
         end
     endgenerate
 
     // Pipeline registers: Improve timing by breaking long paths after the multipliers.
-    /* verilator lint_off UNUSEDSIGNAL */
-    wire [15:0] mul_prod_lane0_val, mul_prod_lane1_val;
-    wire signed [EXP_SUM_WIDTH-1:0] mul_exp_sum_lane0_val, mul_exp_sum_lane1_val;
-    wire mul_sign_lane0_val, mul_sign_lane1_val;
-    wire mul_nan_lane0_val, mul_nan_lane1_val;
-    wire mul_inf_lane0_val, mul_inf_lane1_val;
-    /* verilator lint_on UNUSEDSIGNAL */
-
     generate
         if (SUPPORT_PIPELINING) begin : gen_pipeline
             reg [15:0] mul_prod_lane0_reg;
@@ -690,11 +753,11 @@ module tt_um_chatelao_fp8_multiplier #(
                     is_bm_b_lane0_reg <= is_bm_b_lane0_raw;
                 end
             end
-            assign mul_prod_lane0_val = SUPPORT_SERIAL ? mul_prod_lane0 : mul_prod_lane0_reg;
-            assign mul_exp_sum_lane0_val = SUPPORT_SERIAL ? mul_exp_sum_lane0 : mul_exp_sum_lane0_reg;
-            assign mul_sign_lane0_val = SUPPORT_SERIAL ? mul_sign_lane0 : mul_sign_lane0_reg;
-            assign mul_nan_lane0_val = SUPPORT_SERIAL ? mul_nan_lane0 : mul_nan_lane0_reg;
-            assign mul_inf_lane0_val = SUPPORT_SERIAL ? mul_inf_lane0 : mul_inf_lane0_reg;
+            assign mul_prod_lane0_val = mul_prod_lane0_reg;
+            assign mul_exp_sum_lane0_val = mul_exp_sum_lane0_reg;
+            assign mul_sign_lane0_val = mul_sign_lane0_reg;
+            assign mul_nan_lane0_val = mul_nan_lane0_reg;
+            assign mul_inf_lane0_val = mul_inf_lane0_reg;
             assign is_bm_a_lane0_val = is_bm_a_lane0_reg;
             assign is_bm_b_lane0_val = is_bm_b_lane0_reg;
 
@@ -762,31 +825,21 @@ module tt_um_chatelao_fp8_multiplier #(
     // These capture any NaNs or Infinities that occur anywhere in the block.
     reg nan_sticky, inf_pos_sticky, inf_neg_sticky;
     // Optimization: Use a constant cycle window for element sticky latching to fix timing and avoid metadata latching.
-    // Standard elements at 3..last_stream_cycle. Pipelined products at 4..last_stream_cycle+1.
-    // This avoids Cycle 1/2 (Scales) and Cycle 3 (Pipelined garbage).
-    wire sticky_latch_en = (logical_cycle >= (SUPPORT_PIPELINING ? 6'd4 : 6'd3)) && (logical_cycle <= last_stream_cycle + (SUPPORT_PIPELINING ? 6'd1 : 6'd0));
+    // Window is shifted by the total datapath delay.
+    wire sticky_latch_en = (logical_cycle >= (6'd3 + DATAPATH_DELAY)) && (logical_cycle <= (last_stream_cycle + DATAPATH_DELAY));
 
     always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin
             nan_sticky <= 1'b0;
             inf_pos_sticky <= 1'b0;
             inf_neg_sticky <= 1'b0;
-        end else if (ena) begin
-            if (strobe && logical_cycle == {COUNTER_WIDTH{1'b0}}) begin
+        end else if (ena && strobe) begin
+            if (logical_cycle == {COUNTER_WIDTH{1'b0}}) begin
                 // Check if we are starting a Short Protocol block with NaN scales already loaded
                 nan_sticky <= ENABLE_SHARED_SCALING && ui_in[7] && (scale_a_val == 8'hFF || scale_b_val == 8'hFF);
                 inf_pos_sticky <= 1'b0;
                 inf_neg_sticky <= 1'b0;
-            end else if (SUPPORT_SERIAL) begin
-                // In serial mode, sample flags only during valid element window
-                if (logical_cycle >= 6'd3 && logical_cycle <= last_stream_cycle) begin
-                    if (gen_serial_ctrl.k_counter == SERIAL_K_FACTOR[COUNTER_WIDTH-1:0] - 6'd1) begin
-                        nan_sticky <= nan_sticky | serial_mul_gen.mul_nan_lane0_serial;
-                        inf_pos_sticky <= inf_pos_sticky | (serial_mul_gen.mul_inf_lane0_serial & ~serial_mul_gen.mul_sign_lane0_serial);
-                        inf_neg_sticky <= inf_neg_sticky | (serial_mul_gen.mul_inf_lane0_serial & serial_mul_gen.mul_sign_lane0_serial);
-                    end
-                end
-            end else if (strobe) begin
+            end else begin
                 // Latch element-level special values
                 if (sticky_latch_en) begin
                     nan_sticky <= nan_sticky | mul_nan_lane0_val | mul_nan_lane1_val;

--- a/src/project.v
+++ b/src/project.v
@@ -65,6 +65,7 @@ module tt_um_chatelao_fp8_multiplier #(
     wire [COUNTER_WIDTH-1:0] logical_cycle;
 
     // --- Bit-Serial Control and Status Wires (for Hierarchical Access) ---
+    /* verilator lint_off UNUSEDSIGNAL */
     wire [COUNTER_WIDTH-1:0] serial_k_counter;
     wire serial_mul_nan_lane0;
     wire serial_mul_inf_lane0;
@@ -72,6 +73,7 @@ module tt_um_chatelao_fp8_multiplier #(
     wire serial_mul_zero_lane0;
     wire [15:0] serial_mul_res_lane0;
     wire signed [7:0] serial_mul_exp_lane0;
+    /* verilator lint_on UNUSEDSIGNAL */
 
     // Control logic for serial vs parallel operation.
     generate
@@ -124,8 +126,9 @@ module tt_um_chatelao_fp8_multiplier #(
             always @(posedge clk or negedge rst_n) begin
                 if (!rst_n) mul_res_shift_reg <= 11'd0;
                 else if (ena) begin
-                    if (strobe) mul_res_shift_reg <= 11'd0;
-                    else if (serial_k_counter >= 1 && serial_k_counter <= 11)
+                    if (strobe)
+                        mul_res_shift_reg <= {mul_res_bit_lane0_serial, 10'd0};
+                    else if (serial_k_counter >= 1 && serial_k_counter <= 10)
                         mul_res_shift_reg <= {mul_res_bit_lane0_serial, mul_res_shift_reg[10:1]};
                 end
             end
@@ -178,10 +181,10 @@ module tt_um_chatelao_fp8_multiplier #(
             assign serial_mul_sign_lane0  = sign_captured;
             assign serial_mul_zero_lane0  = zero_captured;
         end else begin : no_serial_mul
-            assign serial_mul_sign_lane0 = 1'b0;
-            assign serial_mul_zero_lane0 = 1'b0;
             assign serial_mul_nan_lane0  = 1'b0;
             assign serial_mul_inf_lane0  = 1'b0;
+            assign serial_mul_sign_lane0 = 1'b0;
+            assign serial_mul_zero_lane0 = 1'b0;
             assign serial_mul_res_lane0  = 16'd0;
             assign serial_mul_exp_lane0  = 8'd0;
         end
@@ -422,8 +425,9 @@ module tt_um_chatelao_fp8_multiplier #(
     wire actual_input_buffering = (SUPPORT_INPUT_BUFFERING && !SUPPORT_VECTOR_PACKING && packed_mode && (format_a == 3'b100) && (format_b_val == 3'b100));
     wire actual_packed_serial = (SUPPORT_PACKED_SERIAL && !SUPPORT_VECTOR_PACKING && !actual_input_buffering && packed_mode && (format_a == 3'b100) && (format_b_val == 3'b100));
     wire [COUNTER_WIDTH-1:0] last_stream_cycle = actual_packed_mode ? 6'd18 : 6'd34;
-    wire [COUNTER_WIDTH-1:0] capture_cycle     = actual_packed_mode ? 6'd20 : 6'd36;
-    wire [COUNTER_WIDTH-1:0] last_cycle        = actual_packed_mode ? 6'd24 : 6'd40;
+    // capture_cycle and last_cycle are shifted based on the total datapath delay to ensure all elements are accumulated.
+    wire [COUNTER_WIDTH-1:0] capture_cycle     = (actual_packed_mode ? 6'd20 : 6'd36) + (SUPPORT_SERIAL ? 6'd1 : 6'd0);
+    wire [COUNTER_WIDTH-1:0] last_cycle        = (actual_packed_mode ? 6'd24 : 6'd40) + (SUPPORT_SERIAL ? 6'd1 : 6'd0);
 
     // FSM State derivation based on the current logical cycle.
     wire [1:0] state = (logical_cycle == 6'd0) ? STATE_IDLE :
@@ -586,16 +590,16 @@ module tt_um_chatelao_fp8_multiplier #(
                     b_shifter <= 8'd0;
                 end else if (ena) begin
                     if (strobe) begin
-                        a_shifter <= a_lane0;
-                        b_shifter <= b_lane0;
+                        a_shifter <= {1'b0, a_lane0[7:1]};
+                        b_shifter <= {1'b0, b_lane0[7:1]};
                     end else begin
                         a_shifter <= {1'b0, a_shifter[7:1]};
                         b_shifter <= {1'b0, b_shifter[7:1]};
                     end
                 end
             end
-            assign a_bit_serial = a_shifter[0];
-            assign b_bit_serial = b_shifter[0];
+            assign a_bit_serial = strobe ? a_lane0[0] : a_shifter[0];
+            assign b_bit_serial = strobe ? b_lane0[0] : b_shifter[0];
         end else begin : gen_no_serial_input_shifters
             assign a_bit_serial = 1'b0;
             assign b_bit_serial = 1'b0;
@@ -825,8 +829,9 @@ module tt_um_chatelao_fp8_multiplier #(
     // These capture any NaNs or Infinities that occur anywhere in the block.
     reg nan_sticky, inf_pos_sticky, inf_neg_sticky;
     // Optimization: Use a constant cycle window for element sticky latching to fix timing and avoid metadata latching.
-    // Window is shifted by the total datapath delay.
-    wire sticky_latch_en = (logical_cycle >= (6'd3 + DATAPATH_DELAY)) && (logical_cycle <= (last_stream_cycle + DATAPATH_DELAY));
+    // Standard elements at 3..last_stream_cycle. Pipelined products at 4..last_stream_cycle+1.
+    // This avoids Cycle 1/2 (Scales) and Cycle 3 (Pipelined garbage).
+    wire sticky_latch_en = (logical_cycle >= (SUPPORT_PIPELINING ? 6'd4 : 6'd3)) && (logical_cycle <= last_stream_cycle + (SUPPORT_PIPELINING ? 6'd1 : 6'd0));
 
     always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin

--- a/src/project.v
+++ b/src/project.v
@@ -32,7 +32,7 @@ module tt_um_chatelao_fp8_multiplier #(
     parameter SUPPORT_INPUT_BUFFERING = 1,
     parameter SUPPORT_MX_PLUS = 1,
     parameter SUPPORT_SERIAL = 0,
-    parameter SERIAL_K_FACTOR = 8,
+    parameter SERIAL_K_FACTOR = 16,
     parameter ENABLE_SHARED_SCALING = 1,
     parameter USE_LNS_MUL = 0,
     parameter USE_LNS_MUL_PRECISE = 1,
@@ -455,9 +455,91 @@ module tt_um_chatelao_fp8_multiplier #(
     /* verilator lint_on UNUSEDSIGNAL */
 
 
-    // Instantiate Multipliers (either standard or LNS based on parameters).
+    // Instantiate Multipliers (either standard, LNS parallel, or LNS serial).
     generate
-        if (USE_LNS_MUL) begin : lns_gen
+        if (SUPPORT_SERIAL) begin : serial_mul_gen
+            wire mul_res_bit_lane0;
+            wire mul_sign_lane0_serial;
+            wire mul_zero_lane0_serial;
+            wire mul_nan_lane0_serial;
+            wire mul_inf_lane0_serial;
+
+            fp8_mul_serial_lns #(
+                .EXP_SUM_WIDTH(EXP_SUM_WIDTH)
+            ) multiplier_lane0 (
+                .clk(clk),
+                .rst_n(rst_n),
+                .ena(ena),
+                .strobe(strobe),
+                .a_bit(a_bit_serial),
+                .b_bit(b_bit_serial),
+                .format_a(format_a),
+                .format_b(format_b_val),
+                .res_bit(mul_res_bit_lane0),
+                .sign_out(mul_sign_lane0_serial),
+                .special_zero(mul_zero_lane0_serial),
+                .special_nan(mul_nan_lane0_serial),
+                .special_inf(mul_inf_lane0_serial)
+            );
+
+            // Deserializer for Mitchell LNS result (11 bits: 3-bit Mantissa, 8-bit Exponent)
+            reg [10:0] mul_res_shift_reg;
+            always @(posedge clk or negedge rst_n) begin
+                if (!rst_n) mul_res_shift_reg <= 11'd0;
+                else if (ena) begin
+                    if (gen_serial_ctrl.k_counter >= 6'd1 && gen_serial_ctrl.k_counter <= 6'd11)
+                        mul_res_shift_reg <= {mul_res_bit_lane0, mul_res_shift_reg[10:1]};
+                end
+            end
+
+            // Capture product and flags at strobe (end of logical cycle)
+            reg [15:0] mul_prod_lane0_reg_serial;
+            reg signed [EXP_SUM_WIDTH-1:0] mul_exp_sum_lane0_reg_serial;
+            reg mul_sign_lane0_reg_serial;
+            reg mul_nan_lane0_reg_serial;
+            reg mul_inf_lane0_reg_serial;
+            reg mul_zero_lane0_reg_serial;
+
+            always @(posedge clk or negedge rst_n) begin
+                if (!rst_n) begin
+                    mul_prod_lane0_reg_serial <= 16'd0;
+                    mul_exp_sum_lane0_reg_serial <= {EXP_SUM_WIDTH{1'b0}};
+                    mul_sign_lane0_reg_serial <= 1'b0;
+                    mul_nan_lane0_reg_serial <= 1'b0;
+                    mul_inf_lane0_reg_serial <= 1'b0;
+                    mul_zero_lane0_reg_serial <= 1'b1;
+                end else if (ena && strobe) begin
+                    if (logical_cycle == 6'd0) begin
+                        mul_prod_lane0_reg_serial <= 16'd0;
+                        mul_exp_sum_lane0_reg_serial <= {EXP_SUM_WIDTH{1'b0}};
+                        mul_sign_lane0_reg_serial <= 1'b0;
+                        mul_nan_lane0_reg_serial <= 1'b0;
+                        mul_inf_lane0_reg_serial <= 1'b0;
+                        mul_zero_lane0_reg_serial <= 1'b1;
+                    end else if (logical_cycle >= 6'd3 && logical_cycle <= last_stream_cycle) begin
+                        mul_sign_lane0_reg_serial <= mul_sign_lane0_serial;
+                        mul_zero_lane0_reg_serial <= mul_zero_lane0_serial;
+                        mul_nan_lane0_reg_serial <= mul_nan_lane0_serial;
+                        mul_inf_lane0_reg_serial <= mul_inf_lane0_serial;
+                    mul_prod_lane0_reg_serial <= mul_zero_lane0_serial ? 16'd0 : {9'd0, 1'b1, mul_res_shift_reg[10:8], 3'd0};
+                    mul_exp_sum_lane0_reg_serial <= mul_zero_lane0_serial ? {EXP_SUM_WIDTH{1'b0}} : $signed(mul_res_shift_reg[7:0]);
+                    end
+                end
+            end
+
+            assign mul_prod_lane0 = mul_prod_lane0_reg_serial;
+            assign mul_exp_sum_lane0 = mul_exp_sum_lane0_reg_serial;
+            assign mul_sign_lane0 = mul_sign_lane0_reg_serial;
+            assign mul_nan_lane0 = mul_nan_lane0_reg_serial | (mul_inf_lane0_reg_serial && mul_zero_lane0_reg_serial);
+            assign mul_inf_lane0 = mul_inf_lane0_reg_serial && !mul_zero_lane0_reg_serial;
+
+            assign mul_prod_lane1 = 16'd0;
+            assign mul_exp_sum_lane1 = {EXP_SUM_WIDTH{1'b0}};
+            assign mul_sign_lane1 = 1'b0;
+            assign mul_nan_lane1 = 1'b0;
+            assign mul_inf_lane1 = 1'b0;
+
+        end else if (USE_LNS_MUL) begin : lns_gen
             fp8_mul_lns #(
                 .SUPPORT_E4M3(SUPPORT_E4M3),
                 .SUPPORT_E5M2(SUPPORT_E5M2),
@@ -608,11 +690,11 @@ module tt_um_chatelao_fp8_multiplier #(
                     is_bm_b_lane0_reg <= is_bm_b_lane0_raw;
                 end
             end
-            assign mul_prod_lane0_val = mul_prod_lane0_reg;
-            assign mul_exp_sum_lane0_val = mul_exp_sum_lane0_reg;
-            assign mul_sign_lane0_val = mul_sign_lane0_reg;
-            assign mul_nan_lane0_val = mul_nan_lane0_reg;
-            assign mul_inf_lane0_val = mul_inf_lane0_reg;
+            assign mul_prod_lane0_val = SUPPORT_SERIAL ? mul_prod_lane0 : mul_prod_lane0_reg;
+            assign mul_exp_sum_lane0_val = SUPPORT_SERIAL ? mul_exp_sum_lane0 : mul_exp_sum_lane0_reg;
+            assign mul_sign_lane0_val = SUPPORT_SERIAL ? mul_sign_lane0 : mul_sign_lane0_reg;
+            assign mul_nan_lane0_val = SUPPORT_SERIAL ? mul_nan_lane0 : mul_nan_lane0_reg;
+            assign mul_inf_lane0_val = SUPPORT_SERIAL ? mul_inf_lane0 : mul_inf_lane0_reg;
             assign is_bm_a_lane0_val = is_bm_a_lane0_reg;
             assign is_bm_b_lane0_val = is_bm_b_lane0_reg;
 
@@ -689,13 +771,22 @@ module tt_um_chatelao_fp8_multiplier #(
             nan_sticky <= 1'b0;
             inf_pos_sticky <= 1'b0;
             inf_neg_sticky <= 1'b0;
-        end else if (ena && strobe) begin
-            if (logical_cycle == {COUNTER_WIDTH{1'b0}}) begin
+        end else if (ena) begin
+            if (strobe && logical_cycle == {COUNTER_WIDTH{1'b0}}) begin
                 // Check if we are starting a Short Protocol block with NaN scales already loaded
                 nan_sticky <= ENABLE_SHARED_SCALING && ui_in[7] && (scale_a_val == 8'hFF || scale_b_val == 8'hFF);
                 inf_pos_sticky <= 1'b0;
                 inf_neg_sticky <= 1'b0;
-            end else begin
+            end else if (SUPPORT_SERIAL) begin
+                // In serial mode, sample flags only during valid element window
+                if (logical_cycle >= 6'd3 && logical_cycle <= last_stream_cycle) begin
+                    if (gen_serial_ctrl.k_counter == SERIAL_K_FACTOR[COUNTER_WIDTH-1:0] - 6'd1) begin
+                        nan_sticky <= nan_sticky | serial_mul_gen.mul_nan_lane0_serial;
+                        inf_pos_sticky <= inf_pos_sticky | (serial_mul_gen.mul_inf_lane0_serial & ~serial_mul_gen.mul_sign_lane0_serial);
+                        inf_neg_sticky <= inf_neg_sticky | (serial_mul_gen.mul_inf_lane0_serial & serial_mul_gen.mul_sign_lane0_serial);
+                    end
+                end
+            end else if (strobe) begin
                 // Latch element-level special values
                 if (sticky_latch_en) begin
                     nan_sticky <= nan_sticky | mul_nan_lane0_val | mul_nan_lane1_val;

--- a/test/Makefile_fp8_mul_serial_lns
+++ b/test/Makefile_fp8_mul_serial_lns
@@ -1,0 +1,11 @@
+# Makefile_fp8_mul_serial_lns
+
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+SRC_DIR = ../src
+
+VERILOG_SOURCES += $(SRC_DIR)/fp8_mul_serial_lns.v
+TOPLEVEL = fp8_mul_serial_lns
+MODULE = test_fp8_mul_serial_lns
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/test/test.py
+++ b/test/test.py
@@ -416,6 +416,9 @@ async def run_mac_test(dut, format_a, format_b, a_elements, b_elements, scale_a=
 
     # Tiny-Serial timing parameters
     support_serial_hw = get_param(dut, "SUPPORT_SERIAL", 0)
+    support_pipe_hw = get_param(dut, "SUPPORT_PIPELINING", 0)
+    DATAPATH_DELAY = (1 if support_serial_hw else 0) + (1 if support_pipe_hw else 0)
+
     k_factor = get_param(dut, "SERIAL_K_FACTOR", 1) if support_serial_hw else 1
     cycles_per_element = k_factor
 
@@ -554,8 +557,14 @@ async def run_mac_test(dut, format_a, format_b, a_elements, b_elements, scale_a=
     dut.uio_in.value = 0
     await ClockCycles(dut.clk, cycles_per_element)
 
-    # Shared scaling alignment
-    await ClockCycles(dut.clk, cycles_per_element)
+    # Extra cycles to account for deserializer delay and pipeline
+    # datapath_delay = (serial?1:0) + (pipe?1:0)
+    # capture happens at 'capture_cycle' which is 36 (logical).
+    # Total logical cycles from 3 to 34 (stream) is 32.
+    # Logical cycle 35 is flush. 36 is capture.
+    # Total delay = 1 (deserializer) + 1 (pipeline) = 2.
+    # Wait for the hardware to reach 'capture_cycle' logic.
+    await ClockCycles(dut.clk, DATAPATH_DELAY * cycles_per_element)
 
     # Calculate expected final result after shared scaling
     support_shared = get_param(dut, "ENABLE_SHARED_SCALING", 0)

--- a/test/test.py
+++ b/test/test.py
@@ -100,6 +100,7 @@ def decode_format(bits, format_val, is_bm=False, support_mxplus=False,
         exp = 0
         bias = 3
         is_int = True
+        return sign, exp, mant, bias, is_int, False, False
     elif format_val == 6: # INT8_SYM
         sign = (bits >> 7) & 1
         val = bits if bits < 128 else bits - 256
@@ -108,6 +109,7 @@ def decode_format(bits, format_val, is_bm=False, support_mxplus=False,
         exp = 0
         bias = 3
         is_int = True
+        return sign, exp, mant, bias, is_int, False, False
     else: # Default/Unsupported E4M3 fallthrough in HW
         sign = (bits >> 7) & 1
         exp_field = (bits >> 3) & 0xF
@@ -306,7 +308,7 @@ def float32_model(acc, shared_exp, nan_sticky=False, inf_pos=False, inf_neg=Fals
 
 def align_product_model(a_bits, b_bits, format_a, format_b, round_mode=0, overflow_wrap=0,
                         support_e4m3=1, support_e5m2=1, support_mxfp6=1, support_mxfp4=1, support_int8=1, use_lns=0, use_lns_precise=0, aligner_width=40,
-                        is_bm_a=False, is_bm_b=False, support_mxplus=False, offset_a=0, offset_b=0, lns_mode=0):
+                        is_bm_a=False, is_bm_b=False, support_mxplus=False, offset_a=0, offset_b=0, lns_mode=0, use_serial=0):
     # Fallback for unsupported formats in hardware
     if not support_e4m3 and format_a == 0: return 0
     if not support_e4m3 and format_b == 0: return 0
@@ -338,9 +340,9 @@ def align_product_model(a_bits, b_bits, format_a, format_b, round_mode=0, overfl
     adj_a = 0 if is_bm_a else offset_a
     adj_b = 0 if is_bm_b else offset_b
 
-    if use_lns:
+    if use_lns or use_serial:
         # lns_mode: 0=Normal, 1=LNS, 2=Hybrid/Both
-        if lns_mode == 0:
+        if lns_mode == 0 and not use_serial:
             prod = ma * mb
             exp_sum = ea + eb - (ba + bb - 7) - adj_a - adj_b
         elif lns_mode == 2 and support_mxplus and (is_bm_a or is_bm_b):
@@ -350,25 +352,31 @@ def align_product_model(a_bits, b_bits, format_a, format_b, round_mode=0, overfl
         elif inta or intb:
             return 0 # No INT8 support in LNS/Hybrid mode for non-BM
         else:
-            if use_lns_precise:
-                # Precise LNS LUT logic
-                lut = [
-                    0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
-                    0x1, 0x2, 0x3, 0x4, 0x6, 0x7, 0x8, 0x8,
-                    0x2, 0x3, 0x4, 0x6, 0x7, 0x8, 0x9, 0x9,
-                    0x3, 0x4, 0x6, 0x7, 0x8, 0x9, 0xa, 0xa,
-                    0x4, 0x6, 0x7, 0x8, 0x9, 0xa, 0xa, 0xb,
-                    0x5, 0x7, 0x8, 0x9, 0xa, 0xb, 0xb, 0xc,
-                    0x6, 0x8, 0x9, 0xa, 0xa, 0xb, 0xc, 0xd,
-                    0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe
-                ]
-                m_sum = lut[(ma & 0x7) * 8 + (mb & 0x7)]
-            else:
-                m_sum = (ma & 0x7) + (mb & 0x7)
-            carry = m_sum >> 3
-            m_res = m_sum & 0x7
-            prod = (8 + m_res) << 3
-            exp_sum = ea + eb - (ba + bb - 7) + carry - adj_a - adj_b
+            # Mitchell Approximation Model
+            # mw: mantissa bits (3 for E4M3, 2 for E5M2, 1 for E2M1)
+            mw_a = 3 if format_a == 0 else (2 if format_a == 1 else 1)
+            mw_b = 3 if format_b == 0 else (2 if format_b == 1 else 1)
+
+            # log \approx exp - bias + mantissa_fraction
+            log_a = ea - ba + (ma & ((1 << mw_a) - 1)) / (2.0 ** mw_a)
+            log_b = eb - bb + (mb & ((1 << mw_b) - 1)) / (2.0 ** mw_b)
+            log_sum = log_a + log_b
+
+            # Reconstruct Log result (standardized to Bias 7, MW 3)
+            # res_log = I.F
+            res_log = log_sum + 7
+            res_e = int(res_log) if res_log >= 0 else int(res_log) - 1
+            res_f = res_log - res_e
+
+            # res_mant = 1 + fraction (quantized to 3 bits)
+            res_m = int(res_f * 8.0 + 0.00001) # Small epsilon to avoid floor errors
+            if res_m >= 8:
+                res_e += 1
+                res_m = 0
+
+            # Final parallel representation for aligner
+            prod = (8 + res_m) << 3
+            exp_sum = res_e - adj_a - adj_b
     else:
         real_ma = ma if not inta else ma
         real_mb = mb if not intb else mb
@@ -489,7 +497,8 @@ async def run_mac_test(dut, format_a, format_b, a_elements, b_elements, scale_a=
                                    is_bm_a=is_bm_a_cur, is_bm_b=is_bm_b_cur, support_mxplus=support_mxplus,
                                    offset_a=nbm_offset_a if mx_plus_mode else 0,
                                    offset_b=nbm_offset_b if mx_plus_mode else 0,
-                                   lns_mode=lns_mode)
+                                   lns_mode=lns_mode,
+                                   use_serial=support_serial_hw)
 
         mask = (1 << acc_width) - 1
         acc_masked = expected_acc & mask


### PR DESCRIPTION
This change completes Step 4.4 of the roadmap by integrating the previously implemented bit-serial LNS multiplier into the main project's datapath. The integration uses a deserializer to translate the bit-serial Mitchell LNS stream back into parallel signals that feed the existing alignment and accumulation stages, maintaining modularity while enabling the ultra-minimal Tiny-Serial variant. Logic for capturing sticky flags was also updated to accommodate the stretched timing of the bit-serial protocol.

Fixes #892

---
*PR created automatically by Jules for task [13243139468869596592](https://jules.google.com/task/13243139468869596592) started by @chatelao*